### PR TITLE
hotfix: Place suggestion searchBar

### DIFF
--- a/src/components/ui/modernSearchBar.tsx
+++ b/src/components/ui/modernSearchBar.tsx
@@ -107,9 +107,14 @@ export default function ModernSearchBar({
     }
   }
 
-  // Gérer la sélection d'une ville depuis les suggestions
+  // Gérer la sélection d'une ville depuis les suggestions (optionnel)
   const handleCitySelect = (city: GooglePlacePrediction) => {
     setLocation(city.description);
+  }
+
+  // Gérer la saisie libre de localisation
+  const handleLocationChange = (value: string) => {
+    setLocation(value);
   }
 
   return (
@@ -128,10 +133,12 @@ export default function ModernSearchBar({
               </div>
               <CityAutocomplete
                 onCitySelect={handleCitySelect}
+                onInputChange={handleLocationChange}
                 placeholder='Où souhaitez-vous aller ?'
                 defaultValue={location}
                 className='w-full'
-                countryFilter='MG' // Filtrer par défaut sur Madagascar
+                allowFreeInput={true} // Permet la saisie libre
+                // Pas de countryFilter pour permettre toutes les suggestions
               />
             </div>
           </div>


### PR DESCRIPTION
This pull request enhances the `CityAutocomplete` component to support free-form city input in addition to suggestion-based selection. It also improves the user experience by expanding the search scope if too few results are found for a given country filter. The `ModernSearchBar` component is updated to use these new capabilities.

**Enhancements to city input and autocomplete:**

* Added `allowFreeInput` and `onInputChange` props to `CityAutocomplete`, enabling users to enter cities not present in the suggestions and notifying the parent component of free-form input. [[1]](diffhunk://#diff-2e737e919c2a4af18ebcd232e07a23066284191329d3e7d8726c152a7dca55ceR12-R29) [[2]](diffhunk://#diff-2e737e919c2a4af18ebcd232e07a23066284191329d3e7d8726c152a7dca55ceR99-R112) [[3]](diffhunk://#diff-2e737e919c2a4af18ebcd232e07a23066284191329d3e7d8726c152a7dca55ceR123-R129)
* Modified the city search logic to perform a global search if a country filter yields fewer than three results, and merged results to prioritize the filtered country.

**Integration with search bar:**

* Updated `ModernSearchBar` to handle both suggestion selection and free-form location input, passing the appropriate handlers and enabling free input in `CityAutocomplete`. [[1]](diffhunk://#diff-0fc48d6a201cd63f204df04c26ad6c5a8c1e854495736faf2dda51789e6382c0L110-R119) [[2]](diffhunk://#diff-0fc48d6a201cd63f204df04c26ad6c5a8c1e854495736faf2dda51789e6382c0R136-R141)