### PR TITLE
fix(product): persist images end-to-end and survive redeploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,17 @@ jobs:
             echo "=== 0. Check system resources ==="
             free -h
 
+            echo "=== 0b. Rescue any runtime uploads before pnpm build wipes standalone ==="
+            # Previous deploys had a broken symlink step, so runtime writes may
+            # have landed in standalone/public/uploads (a real directory) instead
+            # of the canonical public/uploads/. Rsync them back before pnpm build
+            # destroys the standalone tree. Safe no-op once standalone/public/uploads
+            # is a proper symlink.
+            if [ -d .next/standalone/public/uploads ] && [ ! -L .next/standalone/public/uploads ]; then
+              echo "Preserving runtime-written uploads back to canonical public/uploads/"
+              rsync -a .next/standalone/public/uploads/ public/uploads/ || true
+            fi
+
             echo "=== 1. Pull latest changes ==="
             git fetch origin main
             git reset --hard origin/main
@@ -45,11 +56,19 @@ jobs:
             echo "=== 6. Copy static files (without overwriting) ==="
             cp -rn .next/static/* .next/standalone/.next/static/ 2>/dev/null || cp -r .next/static .next/standalone/.next/
 
-            echo "=== 7. Sync public files (new files only) ==="
-            rsync -a --ignore-existing public/ .next/standalone/public/
+            echo "=== 7. Sync public files (excluding uploads, which is symlinked) ==="
+            rsync -a --ignore-existing --exclude='uploads' public/ .next/standalone/public/
 
-            echo "=== 8. Ensure uploads symlink ==="
-            ln -sfn /var/www/hosteedv2.com/public/uploads .next/standalone/public/uploads
+            echo "=== 8. Ensure uploads is a real symlink (force-replace any directory) ==="
+            # ln -sfn cannot replace an existing directory; remove it first then
+            # create the symlink pointing to the persistent canonical path.
+            rm -rf .next/standalone/public/uploads
+            ln -s /var/www/hosteedv2.com/public/uploads .next/standalone/public/uploads
+            # Sanity-check: abort the deploy if the symlink is not what we expect
+            if [ "$(readlink .next/standalone/public/uploads)" != "/var/www/hosteedv2.com/public/uploads" ]; then
+              echo "ERROR: uploads symlink creation failed"
+              exit 1
+            fi
 
             echo "=== 9. Link .env file to standalone ==="
             ln -sfn /var/www/hosteedv2.com/.env .next/standalone/.env

--- a/src/app/admin/validation/[id]/components/ProductEditForm/index.tsx
+++ b/src/app/admin/validation/[id]/components/ProductEditForm/index.tsx
@@ -231,13 +231,22 @@ export function ProductEditForm({ product, onSave, onCancel }: ProductEditFormPr
 
       // Update images separately if needed
       if (finalImages.length > 0) {
-        await fetch(`/api/products/${product.id}/images`, {
+        const imagesResponse = await fetch(`/api/products/${product.id}/images`, {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
           },
+          credentials: 'include',
           body: JSON.stringify({ imageUrls: finalImages }),
         })
+
+        if (!imagesResponse.ok) {
+          const errorBody = await imagesResponse.json().catch(() => ({}))
+          throw new Error(
+            errorBody.error ||
+              `Échec de l'enregistrement des images (HTTP ${imagesResponse.status})`
+          )
+        }
       }
 
       onSave(updatedProduct as unknown as Product)

--- a/src/app/admin/validation/[id]/components/ProductEditWizard.tsx
+++ b/src/app/admin/validation/[id]/components/ProductEditWizard.tsx
@@ -289,11 +289,20 @@ export function ProductEditWizard({ product, onSave, onCancel }: ProductEditForm
 
       // Update images
       if (allImageUrls.length > 0) {
-        await fetch(`/api/products/${product.id}/images`, {
+        const imagesResponse = await fetch(`/api/products/${product.id}/images`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
           body: JSON.stringify({ imageUrls: allImageUrls }),
         })
+
+        if (!imagesResponse.ok) {
+          const errorBody = await imagesResponse.json().catch(() => ({}))
+          throw new Error(
+            errorBody.error ||
+              `Échec de l'enregistrement des images (HTTP ${imagesResponse.status})`
+          )
+        }
       }
 
       toast.success('Annonce mise à jour avec succes!')

--- a/src/app/api/products/[id]/images/route.ts
+++ b/src/app/api/products/[id]/images/route.ts
@@ -63,17 +63,22 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   try {
     const session = await auth()
     if (!session?.user?.id) {
+      console.warn('[PUT /api/products/[id]/images] unauthenticated request rejected')
       return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
     }
 
     const { id: productId } = await params
     const { imageUrls } = await request.json()
 
+    console.log(
+      `[PUT /api/products/${productId}/images] user=${session.user.id} role=${session.user.roles} count=${Array.isArray(imageUrls) ? imageUrls.length : 'invalid'}`
+    )
+
     if (!imageUrls || !Array.isArray(imageUrls)) {
       return NextResponse.json({ error: 'imageUrls doit être un tableau' }, { status: 400 })
     }
 
-    // Vérifier que l'utilisateur est propriétaire du produit
+    // Vérifier que l'utilisateur est propriétaire du produit OU admin/host_manager
     const product = await prisma.product.findUnique({
       where: { id: productId },
       include: {
@@ -87,7 +92,11 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     const isOwner = product.owner.id === session.user.id
-    if (!isOwner) {
+    const canManageAny = ['ADMIN', 'HOST_MANAGER'].includes(session.user.roles as string)
+    if (!isOwner && !canManageAny) {
+      console.warn(
+        `[PUT /api/products/${productId}/images] forbidden: user=${session.user.id} role=${session.user.roles} owner=${product.owner.id}`
+      )
       return NextResponse.json({ error: 'Non autorisé' }, { status: 403 })
     }
 

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 import { findProductById, updateProduct } from '@/lib/services/product.service'
+import { auth } from '@/lib/auth'
+import prisma from '@/lib/prisma'
 
 /**
  * Convert BigInt values to numbers for JSON serialization
@@ -60,16 +62,41 @@ export async function GET(request: Request, context: { params: Promise<{ id: str
 
 /**
  * PUT /api/products/[id]
- * Update an existing product
+ * Update an existing product. Only the product owner, ADMIN or HOST_MANAGER can update.
  */
 export async function PUT(request: Request, context: { params: Promise<{ id: string }> }) {
   try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+    }
+
     const { id } = await context.params
-    const data = await request.json()
 
     if (!id) {
       return NextResponse.json({ error: 'Product ID is required' }, { status: 400 })
     }
+
+    // Verify ownership or elevated role before mutating
+    const existing = await prisma.product.findUnique({
+      where: { id },
+      select: { ownerId: true },
+    })
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Product not found' }, { status: 404 })
+    }
+
+    const isOwner = existing.ownerId === session.user.id
+    const canManageAny = ['ADMIN', 'HOST_MANAGER'].includes(session.user.roles as string)
+    if (!isOwner && !canManageAny) {
+      console.warn(
+        `[PUT /api/products/${id}] forbidden: user=${session.user.id} role=${session.user.roles} owner=${existing.ownerId}`
+      )
+      return NextResponse.json({ error: 'Non autorisé' }, { status: 403 })
+    }
+
+    const data = await request.json()
 
     const updatedProduct = await updateProduct(id, data)
 

--- a/src/app/createProduct/page.tsx
+++ b/src/app/createProduct/page.tsx
@@ -197,7 +197,11 @@ export default function CreateProductPage() {
       })
 
       if (!updateResponse.ok) {
-        console.error('Erreur lors de la mise à jour des images')
+        const errorBody = await updateResponse.json().catch(() => ({}))
+        throw new Error(
+          errorBody.error ||
+            `Échec de l'enregistrement des images (HTTP ${updateResponse.status})`
+        )
       }
 
       await queryClient.invalidateQueries({ queryKey: ['host-products'] })

--- a/src/app/dashboard/host/edit/[id]/page.tsx
+++ b/src/app/dashboard/host/edit/[id]/page.tsx
@@ -258,11 +258,20 @@ export default function EditProductPage() {
         ...newImageUrls,
       ]
 
-      await fetch(`/api/products/${productId}/images`, {
+      const imagesResponse = await fetch(`/api/products/${productId}/images`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({ imageUrls: allImageUrls }),
       })
+
+      if (!imagesResponse.ok) {
+        const errorBody = await imagesResponse.json().catch(() => ({}))
+        throw new Error(
+          errorBody.error ||
+            `Échec de l'enregistrement des images (HTTP ${imagesResponse.status})`
+        )
+      }
 
       toast.success('Annonce modifiée avec succès!')
       setTimeout(() => router.push('/dashboard/host'), 1500)


### PR DESCRIPTION
## Summary
Promotes to production the 4-part fix for the image persistence bug, bundled with a rescue and symlink repair in the deploy workflow.

Includes:
- TristanHourtoulle/hosteed#61 — fix(product): persist images end-to-end and survive redeploys

## Root cause recap
Product image uploads appeared to succeed but never displayed. Four layered issues:
1. `PUT /api/products/[id]/images` rejected ADMIN / HOST_MANAGER with silent 403
2. Client callers ignored `response.ok` and showed success toasts on failure
3. `PUT /api/products/[id]` had no authentication at all
4. `deploy.yml` uploads symlink was dead (nested `uploads/uploads`) so runtime writes were destroyed on each `pnpm build`

See TristanHourtoulle/hosteed#61 for the full investigation and diagnostic traces.

## Post-deploy verification checklist
- [ ] `readlink /var/www/hosteedv2.com/.next/standalone/public/uploads` returns `/var/www/hosteedv2.com/public/uploads`
- [ ] ADMIN edits a non-owned product → image persists in DB and displays
- [ ] Host edits own product → still works
- [ ] Unauthenticated `curl -X PUT /api/products/<id>` → now 401 (was: 200)
- [ ] After a subsequent deploy, newly uploaded images still exist on disk