### PR TITLE
fix(dashboard): keep host products visible on first mount

### DIFF
--- a/src/app/dashboard/host/page.tsx
+++ b/src/app/dashboard/host/page.tsx
@@ -191,8 +191,15 @@ export default function HostDashboard() {
             </Card>
           </motion.div>
         ) : (
+          // Re-key the grid on products.length so framer-motion remounts it when data
+          // arrives after the outer container's initial animation has already completed.
+          // Without this, item motion children stay stuck at the `hidden` variant
+          // because the stagger orchestration already ran before they were mounted.
           <motion.div
+            key={`grid-${products.length}`}
             className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'
+            initial='hidden'
+            animate='visible'
             variants={containerVariants}
           >
             {products.map(product => {


### PR DESCRIPTION
## Summary

Fixes a visual bug where `/dashboard/host` rendered an **empty page** after a hard reload or after the `createProduct` redirect, even though the API response contained the 4 products and they were in the DOM.

Confirmed end-to-end via Chrome DevTools MCP on local staging. The bug was **not** a cache problem — it was framer-motion stagger orchestration running too early.

## Root cause

`src/app/dashboard/host/page.tsx` wraps the whole page in a `<motion.div initial='hidden' animate='visible' variants={containerVariants}>` that runs its stagger orchestration **immediately on mount**. While React Query is loading:

1. `products = []` → the empty-state branch renders. The grid subtree does **not** exist in the tree.
2. The outer motion container's `animate='visible'` transition **completes** before data arrives.
3. React Query resolves → re-render → grid + card `<motion.div variants={itemVariants}>` children now mount.
4. Framer-motion sees the new item children but the parent's orchestration has already finished, so the children never receive the `visible` named variant — they stay at the default initial state (`hidden`: `{ opacity: 0, y: 20 }`).

Observed DOM state before the fix (walking up from a card `<h2>`):
```
level 4  <motion.div card wrapper>  opacity: 0   transform: matrix(1, 0, 0, 1, 0, 20)
```

Switching to another tab and coming back "fixed" it because the second mount had the data already in the React Query cache, so the grid children existed from the first render of that subtree and were correctly orchestrated.

## Fix

Give the inner grid its own animation lifecycle:
- `key={`grid-${products.length}`}` — re-key on products count so the subtree fully remounts when data arrives
- explicit `initial='hidden' animate='visible'` — the grid runs its own stagger with its cards present from its first render, independent of the outer container's already-finished animation

## Changes

- `src/app/dashboard/host/page.tsx` — only the inner grid `motion.div` on the non-empty branch (7 insertions, 0 deletions)

## Test plan

Verified locally on staging via Chrome DevTools MCP, logged in as Cathy (ADMIN, owns 4 products in local):

**Before the fix:**
- Hard reload of `/dashboard/host`: cards wrapper has `opacity: 0, transform: matrix(1,0,0,1,0,20)`, page visually empty
- `/createProduct` → link to `/dashboard/host`: same bug
- Switch `Mes annonces` → `Calendrier` → `Mes annonces`: cards become visible (confirms the mount-timing theory)

**After the fix:**
- Hard reload of `/dashboard/host`: cards wrapper `opacity: 1, transform: none`, all 4 visible ✅
- `/createProduct` → `/dashboard/host`: ✅
- Fresh URL navigation: ✅
- Tab switch and back: still works ✅
- Empty state (no products): branch unchanged, still renders the "Vous n'avez pas encore d'annonces" card

Screenshot of the fixed hard-reload confirms the 4 cards visible at their expected positions.

## CI checklist

- [ ] `Build & Lint` passes (local: 0 errors, 0 TS issues)