### PR TITLE
fix(dashboard): keep host products visible on first mount

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "ioredis": "^5.8.2",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.513.0",
+    "marked": "^18.0.0",
     "nanoid": "^5.1.6",
     "next": "16.1.1",
     "next-auth": "5.0.0-beta.29",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       lucide-react:
         specifier: ^0.513.0
         version: 0.513.0(react@19.2.3)
+      marked:
+        specifier: ^18.0.0
+        version: 18.0.0
       nanoid:
         specifier: ^5.1.6
         version: 5.1.6
@@ -766,89 +769,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -924,24 +943,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.1':
     resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.1':
     resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.1':
     resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.1':
     resolution: {integrity: sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==}
@@ -1777,24 +1800,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
     resolution: {integrity: sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
     resolution: {integrity: sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
     resolution: {integrity: sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     resolution: {integrity: sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==}
@@ -2217,41 +2244,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3650,24 +3685,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3762,6 +3801,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@18.0.0:
+    resolution: {integrity: sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -9131,6 +9175,8 @@ snapshots:
       uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
+
+  marked@18.0.0: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model HomepageSettings {
   id                  String   @id @default(cuid())
   heroBackgroundImage String? // Image de fond de la Hero Section
   howItWorksImage     String? // Image de la section "Comment ça marche"
+  authBackgroundImage String? // Image de fond du panneau gauche de la page d'authentification (desktop)
   updatedAt           DateTime @updatedAt
   createdAt           DateTime @default(now())
 

--- a/src/app/admin/blog/edit/[id]/page.tsx
+++ b/src/app/admin/blog/edit/[id]/page.tsx
@@ -1,27 +1,18 @@
 'use client'
 
-import { useState, useEffect, use, useCallback } from 'react'
-import { motion } from 'framer-motion'
+import { useCallback, useEffect, useState, use } from 'react'
 import { useRouter } from 'next/navigation'
-import { useBlogAuth } from '@/hooks/useMultiRoleAuth'
-import { LazyMarkdownEditor, LazyMarkdownViewer } from '@/components/dynamic/LazyComponents'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/shadcnui/card'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/shadcnui/input'
-import { Label } from '@/components/ui/shadcnui/label'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/shadcnui/tabs'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import { ArrowLeft, Save, Eye, Edit3, ImagePlus, X, Sparkles } from 'lucide-react'
 import Link from 'next/link'
 import { toast } from 'sonner'
-import Image from 'next/image'
-import SEOFieldsCard, { type SEOData } from '@/components/ui/SEOFieldsCard'
+import { BookOpen, Eye, Calendar, UserCircle2, Link as LinkIcon } from 'lucide-react'
+
+import { useBlogAuth } from '@/hooks/useMultiRoleAuth'
+import { Button } from '@/components/ui/shadcnui/button'
+import {
+  BlogPostForm,
+  type BlogPostFormData,
+} from '@/components/admin/blog/BlogPostForm'
+import { type SEOData } from '@/components/ui/SEOFieldsCard'
 
 interface Post {
   id: string
@@ -42,17 +33,13 @@ interface Post {
   }
 }
 
-const containerVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: { duration: 0.3, staggerChildren: 0.1 },
-  },
-}
-
-const itemVariants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: { opacity: 1, y: 0 },
+async function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(file)
+  })
 }
 
 interface PageProps {
@@ -65,18 +52,7 @@ export default function EditPostPage({ params }: PageProps) {
   const router = useRouter()
 
   const [post, setPost] = useState<Post | null>(null)
-  const [title, setTitle] = useState('')
-  const [content, setContent] = useState('')
-  const [images, setImages] = useState<File[]>([])
-  const [currentImage, setCurrentImage] = useState<string>('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const [isLoadingPost, setIsLoadingPost] = useState(true)
-  const [seoData, setSeoData] = useState<SEOData>({
-    metaTitle: '',
-    metaDescription: '',
-    keywords: '',
-    slug: '',
-  })
 
   const fetchPost = useCallback(async () => {
     try {
@@ -92,25 +68,15 @@ export default function EditPostPage({ params }: PageProps) {
         throw new Error("Erreur lors du chargement de l'article")
       }
 
-      const postData = await response.json()
+      const data = (await response.json()) as Post
 
-      // Check if user can edit this post
-      if (session?.user?.roles !== 'ADMIN' && postData.author.id !== session?.user?.id) {
+      if (session?.user?.roles !== 'ADMIN' && data.author.id !== session?.user?.id) {
         toast.error('Vous ne pouvez modifier que vos propres articles')
         router.push('/admin/blog')
         return
       }
 
-      setPost(postData)
-      setTitle(postData.title)
-      setContent(postData.content)
-      setCurrentImage(postData.image || '')
-      setSeoData({
-        metaTitle: postData.metaTitle || postData.title,
-        metaDescription: postData.metaDescription || '',
-        keywords: postData.keywords || '',
-        slug: postData.slug || '',
-      })
+      setPost(data)
     } catch (error) {
       console.error('Error fetching post:', error)
       toast.error("Erreur lors du chargement de l'article")
@@ -126,308 +92,151 @@ export default function EditPostPage({ params }: PageProps) {
     }
   }, [isAuthorized, session, fetchPost])
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files) {
-      const newImages = Array.from(e.target.files)
-      setImages([newImages[0]]) // Limit to 1 image
-    }
+  if (isLoading || isLoadingPost || !isAuthorized) {
+    return (
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-6xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-6 lg:grid-cols-3'>
+            <div className='space-y-6 lg:col-span-2'>
+              <div className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
+              <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
+            </div>
+            <div className='space-y-6'>
+              <div className='h-72 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
+              <div className='h-60 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
+            </div>
+          </div>
+        </div>
+      </div>
+    )
   }
 
-  const removeImage = () => {
-    setImages([])
-    setCurrentImage('')
+  if (!post) return null
+
+  const initialSeoData: SEOData = {
+    metaTitle: post.metaTitle || post.title,
+    metaDescription: post.metaDescription || '',
+    keywords: post.keywords || '',
+    slug: post.slug || '',
   }
 
-  const handleSubmit = async () => {
-    if (!title.trim() || !content.trim()) {
-      toast.error('Le titre et le contenu sont requis')
-      return
-    }
-
-    if (!session?.user?.id) {
-      toast.error('Vous devez être connecté pour modifier un article')
-      return
-    }
-
-    setIsSubmitting(true)
-
+  const handleSubmit = async (data: BlogPostFormData) => {
     try {
-      let imageToUse = currentImage
-
-      if (images.length > 0) {
-        // Convert new image to base64
-        const reader = new FileReader()
-        reader.readAsDataURL(images[0])
-        await new Promise(resolve => {
-          reader.onload = () => {
-            imageToUse = reader.result as string
-            resolve(null)
-          }
-        })
+      let imageToUse = data.imageUrl
+      if (data.newImageFile) {
+        imageToUse = await fileToBase64(data.newImageFile)
       }
 
       const response = await fetch(`/api/posts/${resolvedParams.id}`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          title,
-          content,
+          title: data.title,
+          content: data.content,
           image: imageToUse,
-          seoData,
+          seoData: data.seoData,
         }),
       })
 
       if (!response.ok) {
-        const errorData = await response.json()
+        const errorData = await response.json().catch(() => ({}))
         throw new Error(errorData.error || 'Erreur lors de la mise à jour')
       }
 
-      await response.json()
-      toast.success('Article mis à jour avec succès !', {
-        description: 'Vos modifications ont été sauvegardées',
+      toast.success('Article mis à jour', {
+        description: 'Vos modifications ont été sauvegardées.',
       })
-
       router.push('/admin/blog')
     } catch (error) {
       console.error('Error updating post:', error)
-      const errorMessage =
+      const message =
         error instanceof Error ? error.message : "Erreur lors de la mise à jour de l'article"
-      toast.error(errorMessage)
-    } finally {
-      setIsSubmitting(false)
+      toast.error(message)
     }
   }
 
-  if (isLoading || isLoadingPost || !isAuthorized) {
-    return (
-      <div className='flex items-center justify-center min-h-screen'>
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className='text-center'>
-          <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4'></div>
-          <p className='text-gray-600'>Chargement...</p>
-        </motion.div>
-      </div>
-    )
-  }
+  const formattedCreatedAt = new Date(post.createdAt).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  })
 
-  if (!post) {
-    return (
-      <div className='flex items-center justify-center min-h-screen'>
-        <div className='text-center'>
-          <h2 className='text-xl font-semibold text-gray-900'>Article non trouvé</h2>
-          <p className='text-gray-600 mt-2'>L&apos;article que vous cherchez n&apos;existe pas.</p>
-          <Button asChild className='mt-4'>
-            <Link href='/admin/blog'>
-              <ArrowLeft className='h-4 w-4 mr-2' />
-              Retour aux articles
-            </Link>
-          </Button>
+  const sidebarExtra = (
+    <div className='rounded-2xl border border-slate-200/80 bg-white shadow-sm'>
+      <div className='flex items-center gap-3 border-b border-slate-100 px-6 py-4'>
+        <div className='flex h-9 w-9 items-center justify-center rounded-lg bg-slate-100 text-slate-600'>
+          <UserCircle2 className='h-4 w-4' />
         </div>
+        <h2 className='text-sm font-semibold uppercase tracking-wide text-slate-500'>
+          Informations
+        </h2>
       </div>
-    )
-  }
+      <dl className='space-y-3 p-6 text-sm'>
+        <div className='flex items-start justify-between gap-4'>
+          <dt className='flex items-center gap-1.5 text-slate-500'>
+            <UserCircle2 className='h-3.5 w-3.5' />
+            Auteur
+          </dt>
+          <dd className='truncate text-right font-medium text-slate-900'>
+            {post.author.name || post.author.email}
+          </dd>
+        </div>
+        <div className='flex items-start justify-between gap-4'>
+          <dt className='flex items-center gap-1.5 text-slate-500'>
+            <Calendar className='h-3.5 w-3.5' />
+            Créé le
+          </dt>
+          <dd className='text-right font-medium text-slate-900'>
+            {formattedCreatedAt}
+          </dd>
+        </div>
+        {post.slug && (
+          <div className='flex items-start justify-between gap-4'>
+            <dt className='flex items-center gap-1.5 text-slate-500'>
+              <LinkIcon className='h-3.5 w-3.5' />
+              Slug
+            </dt>
+            <dd className='truncate rounded bg-slate-100 px-2 py-0.5 text-right font-mono text-xs text-slate-900'>
+              /{post.slug}
+            </dd>
+          </div>
+        )}
+      </dl>
+    </div>
+  )
+
+  const headerActions = (
+    <Button variant='outline' asChild className='gap-2'>
+      <Link href={`/posts/article/${post.slug || post.id}`} target='_blank'>
+        <Eye className='h-4 w-4' />
+        Aperçu
+      </Link>
+    </Button>
+  )
 
   return (
-    <motion.div
-      variants={containerVariants}
-      initial='hidden'
-      animate='visible'
-      className='min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50 p-4 sm:p-6'
-    >
-      <div className='max-w-6xl mx-auto space-y-6'>
-        {/* Header */}
-        <motion.div variants={itemVariants} className='flex items-center justify-between'>
-          <div>
-            <div className='flex items-center gap-3 mb-2'>
-              <Button variant='ghost' asChild>
-                <Link href='/admin/blog'>
-                  <ArrowLeft className='h-4 w-4 mr-2' />
-                  Retour
-                </Link>
-              </Button>
-              <Badge variant='secondary' className='bg-purple-50 text-purple-700 px-3 py-1'>
-                <Edit3 className='w-3 h-3 mr-1' />
-                Modification
-              </Badge>
-            </div>
-            <h1 className='text-3xl font-bold text-gray-900'>Modifier l&apos;article</h1>
-            <p className='text-gray-600 mt-1'>
-              Éditez votre article et optimisez son référencement
-            </p>
-          </div>
-
-          <div className='flex items-center gap-3'>
-            <Button variant='outline' asChild className='hidden sm:flex'>
-              <Link href={`/posts/article/${post.slug || post.id}`} target='_blank'>
-                <Eye className='h-4 w-4 mr-2' />
-                Aperçu
-              </Link>
-            </Button>
-            <Button
-              onClick={handleSubmit}
-              disabled={isSubmitting}
-              className='bg-green-600 hover:bg-green-700 min-w-[120px]'
-            >
-              {isSubmitting ? (
-                <div className='flex items-center'>
-                  <div className='animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2'></div>
-                  Mise à jour...
-                </div>
-              ) : (
-                <>
-                  <Save className='h-4 w-4 mr-2' />
-                  Sauvegarder
-                </>
-              )}
-            </Button>
-          </div>
-        </motion.div>
-
-        {/* Main Content */}
-        <div className='grid grid-cols-1 lg:grid-cols-3 gap-6'>
-          {/* Editor Section */}
-          <motion.div variants={itemVariants} className='lg:col-span-2 space-y-6'>
-            {/* Title Input */}
-            <Card>
-              <CardHeader>
-                <CardTitle className='flex items-center gap-2'>
-                  <Sparkles className='h-5 w-5 text-yellow-600' />
-                  Titre de l&apos;article
-                </CardTitle>
-                <CardDescription>
-                  Un titre accrocheur est essentiel pour attirer l&apos;attention
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <Input
-                  placeholder='Entrez le titre de votre article...'
-                  value={title}
-                  onChange={e => setTitle(e.target.value)}
-                  className='text-lg font-medium'
-                />
-              </CardContent>
-            </Card>
-
-            {/* Content Editor */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Contenu de l&apos;article</CardTitle>
-                <CardDescription>Utilisez Markdown pour formater votre contenu</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <Tabs defaultValue='edit' className='w-full'>
-                  <TabsList className='grid w-full grid-cols-2'>
-                    <TabsTrigger value='edit'>Éditer</TabsTrigger>
-                    <TabsTrigger value='preview'>Aperçu</TabsTrigger>
-                  </TabsList>
-                  <TabsContent value='edit' className='mt-4'>
-                    <LazyMarkdownEditor
-                      value={content}
-                      onChange={val => setContent(val || '')}
-                      preview='edit'
-                      height={400}
-                      data-color-mode='light'
-                    />
-                  </TabsContent>
-                  <TabsContent value='preview' className='mt-4'>
-                    <div className='border rounded-lg p-4 min-h-[400px] bg-white'>
-                      <LazyMarkdownViewer source={content} />
-                    </div>
-                  </TabsContent>
-                </Tabs>
-              </CardContent>
-            </Card>
-          </motion.div>
-
-          {/* Sidebar */}
-          <motion.div variants={itemVariants} className='space-y-6'>
-            {/* Image Upload */}
-            <Card>
-              <CardHeader>
-                <CardTitle className='flex items-center gap-2'>
-                  <ImagePlus className='h-5 w-5 text-green-600' />
-                  Image de couverture
-                </CardTitle>
-                <CardDescription>Une image attrayante améliore l&apos;engagement</CardDescription>
-              </CardHeader>
-              <CardContent className='space-y-4'>
-                {(currentImage || images.length > 0) && (
-                  <div className='relative'>
-                    <div className='aspect-video relative rounded-lg overflow-hidden bg-gray-100'>
-                      {images.length > 0 ? (
-                        <Image
-                          src={URL.createObjectURL(images[0])}
-                          alt='Nouvelle image'
-                          fill
-                          className='object-cover'
-                        />
-                      ) : (
-                        <Image
-                          src={currentImage}
-                          alt='Image actuelle'
-                          fill
-                          className='object-cover'
-                        />
-                      )}
-                    </div>
-                    <Button
-                      type='button'
-                      variant='destructive'
-                      size='sm'
-                      className='absolute top-2 right-2'
-                      onClick={removeImage}
-                    >
-                      <X className='h-4 w-4' />
-                    </Button>
-                  </div>
-                )}
-
-                <div className='space-y-2'>
-                  <Label htmlFor='image' className='text-sm font-medium'>
-                    {currentImage || images.length > 0 ? "Changer l'image" : 'Ajouter une image'}
-                  </Label>
-                  <Input
-                    id='image'
-                    type='file'
-                    accept='image/*'
-                    onChange={handleImageChange}
-                    className='file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100'
-                  />
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* SEO Fields */}
-            <SEOFieldsCard seoData={seoData} onSeoChange={setSeoData} articleTitle={title} />
-
-            {/* Post Info */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Informations</CardTitle>
-              </CardHeader>
-              <CardContent className='space-y-3'>
-                <div className='flex justify-between text-sm'>
-                  <span className='text-gray-500'>Auteur:</span>
-                  <span className='font-medium'>{post.author.name || post.author.email}</span>
-                </div>
-                <div className='flex justify-between text-sm'>
-                  <span className='text-gray-500'>Créé le:</span>
-                  <span className='font-medium'>
-                    {new Date(post.createdAt || '').toLocaleDateString('fr-FR')}
-                  </span>
-                </div>
-                <div className='flex justify-between text-sm'>
-                  <span className='text-gray-500'>Slug:</span>
-                  <span className='font-mono text-xs bg-gray-100 px-2 py-1 rounded'>
-                    /{post.slug}
-                  </span>
-                </div>
-              </CardContent>
-            </Card>
-          </motion.div>
-        </div>
-      </div>
-    </motion.div>
+    <BlogPostForm
+      mode='edit'
+      backHref='/admin/blog'
+      backLabel='Retour au blog'
+      eyebrow='Espace rédaction'
+      eyebrowIcon={BookOpen}
+      pageTitle="Modifier l'article"
+      pageSubtitle='Ajustez le contenu, mettez à jour l’image ou affinez le référencement SEO.'
+      initialTitle={post.title}
+      initialContent={post.content}
+      initialImageUrl={post.image || ''}
+      initialSeoData={initialSeoData}
+      submitLabel='Sauvegarder'
+      submittingLabel='Sauvegarde…'
+      sidebarExtra={sidebarExtra}
+      headerActions={headerActions}
+      onSubmit={handleSubmit}
+    />
   )
 }

--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -1,56 +1,45 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { motion } from 'framer-motion'
-import { useBlogAuth } from '@/hooks/useMultiRoleAuth'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/shadcnui/card'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/shadcnui/input'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/shadcnui/table'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/shadcnui/alert-dialog'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/shadcnui/dropdown-menu'
+import Link from 'next/link'
+import { toast } from 'sonner'
 import {
   BookOpen,
   Plus,
-  Edit3,
+  Edit,
   Trash2,
   Eye,
-  MoreHorizontal,
-  Search,
   Calendar,
-  User,
+  Clock,
+  Shield,
+  CalendarDays,
+  UserCircle2,
+  AlertTriangle,
+  Loader2,
+  Crown,
+  PenLine,
 } from 'lucide-react'
-import Link from 'next/link'
-import { toast } from 'sonner'
+
+import { useBlogAuth } from '@/hooks/useMultiRoleAuth'
+import { Button } from '@/components/ui/shadcnui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/shadcnui/dialog'
+import type { LucideIcon } from 'lucide-react'
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard } from '@/components/admin/ui/KpiCard'
+import { FilterBar } from '@/components/admin/ui/FilterBar'
+import {
+  DataTable,
+  type DataTableColumn,
+  type DataTableSort,
+} from '@/components/admin/ui/DataTable'
 
 interface Post {
   id: string
@@ -66,53 +55,121 @@ interface Post {
   }
 }
 
-const containerVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: { duration: 0.3, staggerChildren: 0.1 },
-  },
+const INFO_TILE_TONE: Record<
+  'blue' | 'indigo' | 'emerald' | 'amber' | 'purple' | 'slate',
+  { bg: string; text: string }
+> = {
+  blue: { bg: 'bg-blue-50', text: 'text-blue-600' },
+  indigo: { bg: 'bg-indigo-50', text: 'text-indigo-600' },
+  emerald: { bg: 'bg-emerald-50', text: 'text-emerald-600' },
+  amber: { bg: 'bg-amber-50', text: 'text-amber-600' },
+  purple: { bg: 'bg-purple-50', text: 'text-purple-600' },
+  slate: { bg: 'bg-slate-100', text: 'text-slate-600' },
 }
 
-const itemVariants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: { opacity: 1, y: 0 },
+function InfoTile({
+  label,
+  value,
+  hint,
+  icon: Icon,
+  tone = 'slate',
+  loading = false,
+}: {
+  label: string
+  value: string
+  hint?: string
+  icon: LucideIcon
+  tone?: keyof typeof INFO_TILE_TONE
+  loading?: boolean
+}) {
+  const toneClass = INFO_TILE_TONE[tone]
+  if (loading) {
+    return (
+      <div className='relative overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm'>
+        <div className='flex items-start justify-between gap-4'>
+          <div className='flex-1 space-y-2'>
+            <div className='h-4 w-24 animate-pulse rounded bg-slate-200' />
+            <div className='h-6 w-32 animate-pulse rounded bg-slate-200' />
+            <div className='h-3 w-32 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='h-10 w-10 animate-pulse rounded-xl bg-slate-200' />
+        </div>
+      </div>
+    )
+  }
+  return (
+    <div className='rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm'>
+      <div className='flex items-start justify-between gap-4'>
+        <div className='min-w-0 space-y-1'>
+          <p className='text-sm font-medium text-slate-500'>{label}</p>
+          <p
+            className={`text-lg font-semibold leading-tight ${toneClass.text}`}
+          >
+            {value}
+          </p>
+          {hint && <p className='text-xs text-slate-500'>{hint}</p>}
+        </div>
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${toneClass.bg} ${toneClass.text}`}
+        >
+          <Icon className='h-5 w-5' />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function formatDate(dateString: string) {
+  return new Date(dateString).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+function formatDateTime(dateString: string) {
+  return new Date(dateString).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
 }
 
 export default function BlogManagementPage() {
   const { isAuthorized, isLoading, session } = useBlogAuth()
+
   const [posts, setPosts] = useState<Post[]>([])
-  const [filteredPosts, setFilteredPosts] = useState<Post[]>([])
-  const [searchTerm, setSearchTerm] = useState('')
   const [isLoadingPosts, setIsLoadingPosts] = useState(true)
-  const [deletingPostId, setDeletingPostId] = useState<string | null>(null)
+  const [searchValue, setSearchValue] = useState('')
+  const [sort, setSort] = useState<DataTableSort | null>({
+    key: 'createdAt',
+    direction: 'desc',
+  })
+
+  const [deleteTarget, setDeleteTarget] = useState<Post | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  const isAdmin = session?.user?.roles === 'ADMIN'
 
   const fetchPosts = useCallback(async () => {
     if (!session?.user?.id) return
-
     try {
       setIsLoadingPosts(true)
-      // For BLOGWRITER: fetch only their posts, for ADMIN: fetch all posts
-      const authorParam = session.user.roles === 'ADMIN' ? '' : `?authorId=${session.user.id}`
+      const authorParam = isAdmin ? '' : `?authorId=${session.user.id}`
       const response = await fetch(`/api/posts${authorParam}`, {
         cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
+        headers: { 'Cache-Control': 'no-cache' },
       })
-
       if (!response.ok) {
         throw new Error('Erreur lors du chargement des articles')
       }
-
       const data = await response.json()
-      // Defensive: the /api/posts contract is an array, but guard against a
-      // wrapped shape (e.g. `{ posts, pagination }`) in case an upstream
-      // change accidentally leaks the paginated object through.
       const normalized = Array.isArray(data)
         ? data
         : Array.isArray((data as { posts?: unknown }).posts)
-          ? ((data as { posts: Post[] }).posts)
+          ? (data as { posts: Post[] }).posts
           : []
       setPosts(normalized)
     } catch (error) {
@@ -121,7 +178,7 @@ export default function BlogManagementPage() {
     } finally {
       setIsLoadingPosts(false)
     }
-  }, [session])
+  }, [session, isAdmin])
 
   useEffect(() => {
     if (isAuthorized && session?.user?.id) {
@@ -129,276 +186,383 @@ export default function BlogManagementPage() {
     }
   }, [isAuthorized, session, fetchPosts])
 
-  useEffect(() => {
-    if (searchTerm) {
-      const filtered = posts.filter(post =>
-        post.title.toLowerCase().includes(searchTerm.toLowerCase())
-      )
-      setFilteredPosts(filtered)
-    } else {
-      setFilteredPosts(posts)
-    }
-  }, [searchTerm, posts])
+  const filteredPosts = useMemo(() => {
+    const q = searchValue.trim().toLowerCase()
+    if (!q) return posts
+    return posts.filter(
+      post =>
+        post.title.toLowerCase().includes(q) ||
+        (post.author.name ?? '').toLowerCase().includes(q) ||
+        post.author.email.toLowerCase().includes(q) ||
+        (post.slug ?? '').toLowerCase().includes(q)
+    )
+  }, [posts, searchValue])
 
-  const handleDeletePost = async (postId: string) => {
+  const stats = useMemo(() => {
+    const total = posts.length
+    const now = new Date()
+    const thisMonth = posts.filter(post => {
+      const date = new Date(post.createdAt)
+      return (
+        date.getMonth() === now.getMonth() &&
+        date.getFullYear() === now.getFullYear()
+      )
+    }).length
+    const authors = new Set(posts.map(p => p.author.id)).size
+    const lastPublished = posts.length > 0
+      ? posts.reduce((latest, p) =>
+          new Date(p.createdAt) > new Date(latest.createdAt) ? p : latest
+        ).createdAt
+      : null
+    return { total, thisMonth, authors, lastPublished }
+  }, [posts])
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return
     try {
-      setDeletingPostId(postId)
-      const response = await fetch(`/api/posts/${postId}`, {
+      setDeleting(true)
+      const response = await fetch(`/api/posts/${deleteTarget.id}`, {
         method: 'DELETE',
       })
-
       if (!response.ok) {
         throw new Error('Erreur lors de la suppression')
       }
-
       const result = await response.json()
-      toast.success(result.message || 'Article supprimé avec succès')
-
-      // Remove from local state
-      setPosts(posts.filter(post => post.id !== postId))
+      toast.success(result.message || 'Article supprimé')
+      setPosts(prev => prev.filter(p => p.id !== deleteTarget.id))
+      setDeleteTarget(null)
     } catch (error) {
       console.error('Error deleting post:', error)
       toast.error("Erreur lors de la suppression de l'article")
     } finally {
-      setDeletingPostId(null)
+      setDeleting(false)
     }
   }
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('fr-FR', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-  }
+  const columns: Array<DataTableColumn<Post>> = [
+    {
+      key: 'title',
+      header: 'Article',
+      sortable: true,
+      sortAccessor: post => post.title.toLowerCase(),
+      render: post => (
+        <div className='flex items-center gap-3'>
+          <div className='flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600'>
+            <BookOpen className='h-4 w-4' />
+          </div>
+          <div className='min-w-0 max-w-[420px]'>
+            <p
+              className='truncate text-sm font-semibold text-slate-900'
+              title={post.title}
+            >
+              {post.title}
+            </p>
+            {post.slug && (
+              <p
+                className='truncate font-mono text-xs text-slate-500'
+                title={`/${post.slug}`}
+              >
+                /{post.slug}
+              </p>
+            )}
+          </div>
+        </div>
+      ),
+      cellClassName: 'max-w-[460px]',
+    },
+    ...(isAdmin
+      ? [
+          {
+            key: 'author',
+            header: 'Auteur',
+            sortable: true,
+            sortAccessor: (post: Post) =>
+              (post.author.name || post.author.email).toLowerCase(),
+            render: (post: Post) => {
+              const isAuthorAdmin = post.author.roles === 'ADMIN'
+              const AuthorIcon = isAuthorAdmin ? Crown : PenLine
+              return (
+                <div className='flex items-center gap-2 min-w-0'>
+                  <span
+                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold ring-1 ${
+                      isAuthorAdmin
+                        ? 'bg-purple-50 text-purple-700 ring-purple-200'
+                        : 'bg-blue-50 text-blue-700 ring-blue-200'
+                    }`}
+                  >
+                    <AuthorIcon className='h-3 w-3' />
+                    {isAuthorAdmin ? 'Admin' : 'Rédacteur'}
+                  </span>
+                  <span className='truncate text-sm text-slate-600'>
+                    {post.author.name || post.author.email}
+                  </span>
+                </div>
+              )
+            },
+          } as DataTableColumn<Post>,
+        ]
+      : []),
+    {
+      key: 'createdAt',
+      header: 'Créé',
+      sortable: true,
+      sortAccessor: post => new Date(post.createdAt),
+      render: post => (
+        <p className='whitespace-nowrap text-sm text-slate-600'>
+          {formatDate(post.createdAt)}
+        </p>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'updatedAt',
+      header: 'Modifié',
+      sortable: true,
+      sortAccessor: post => new Date(post.updatedAt),
+      render: post => (
+        <p className='whitespace-nowrap text-sm text-slate-600'>
+          {formatDate(post.updatedAt)}
+        </p>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+  ]
 
   if (isLoading || !isAuthorized) {
     return (
-      <div className='flex items-center justify-center min-h-screen'>
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className='text-center'>
-          <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4'></div>
-          <p className='text-gray-600'>Chargement...</p>
-        </motion.div>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+        </div>
       </div>
     )
   }
 
   return (
-    <motion.div
-      variants={containerVariants}
-      initial='hidden'
-      animate='visible'
-      className='space-y-6 p-6'
-    >
-      {/* Header */}
-      <motion.div variants={itemVariants} className='flex items-center justify-between'>
-        <div>
-          <h1 className='text-3xl font-bold text-gray-900 flex items-center gap-3'>
-            <BookOpen className='h-8 w-8 text-blue-600' />
-            Gestion des articles
-          </h1>
-          <p className='text-gray-600 mt-2'>
-            {session?.user?.roles === 'ADMIN'
-              ? 'Gérer tous les articles du blog'
-              : 'Gérer vos articles de blog'}
-          </p>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <PageHeader
+          backHref='/admin'
+          backLabel='Retour au panel admin'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title='Gestion du blog'
+          subtitle={
+            isAdmin
+              ? 'Consultez, modifiez et supprimez tous les articles publiés sur le blog.'
+              : 'Consultez, modifiez et supprimez vos propres articles.'
+          }
+          actions={
+            <Button asChild className='gap-2'>
+              <Link href='/createPost'>
+                <Plus className='h-4 w-4' />
+                Créer un article
+              </Link>
+            </Button>
+          }
+        />
+
+        {/* KPI row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Total articles'
+            value={stats.total}
+            hint={isAdmin ? 'tous auteurs confondus' : 'de votre publication'}
+            icon={BookOpen}
+            tone='blue'
+            loading={isLoadingPosts}
+          />
+          <KpiCard
+            label='Publiés ce mois'
+            value={stats.thisMonth}
+            hint='nouveaux articles'
+            icon={CalendarDays}
+            tone='emerald'
+            loading={isLoadingPosts}
+          />
+          <KpiCard
+            label={isAdmin ? 'Auteurs actifs' : 'Votre activité'}
+            value={isAdmin ? stats.authors : stats.total}
+            hint={isAdmin ? 'ont publié au moins 1 article' : 'articles rédigés'}
+            icon={UserCircle2}
+            tone='purple'
+            loading={isLoadingPosts}
+          />
+          <InfoTile
+            label='Dernière publication'
+            value={stats.lastPublished ? formatDate(stats.lastPublished) : '—'}
+            hint='article le plus récent'
+            icon={Clock}
+            tone='indigo'
+            loading={isLoadingPosts}
+          />
         </div>
-        <Button asChild className='bg-blue-600 hover:bg-blue-700'>
-          <Link href='/createPost'>
-            <Plus className='h-4 w-4 mr-2' />
-            Créer un article
-          </Link>
-        </Button>
+
+        {/* Search */}
+        <FilterBar
+          searchValue={searchValue}
+          onSearchChange={setSearchValue}
+          searchPlaceholder='Rechercher un article par titre, auteur ou slug…'
+        />
+
+        {/* Data table */}
+        <DataTable<Post>
+          columns={columns}
+          rows={filteredPosts}
+          getRowId={post => post.id}
+          loading={isLoadingPosts}
+          sort={sort}
+          onSortChange={setSort}
+          rowActions={post => (
+            <div className='flex items-center justify-end gap-1'>
+              <Button
+                variant='ghost'
+                size='sm'
+                asChild
+                className='text-slate-600 hover:text-slate-900'
+              >
+                <Link
+                  href={`/posts/article/${post.slug || post.id}`}
+                  target='_blank'
+                  title='Voir en ligne'
+                >
+                  <Eye className='h-4 w-4' />
+                </Link>
+              </Button>
+              <Button
+                variant='ghost'
+                size='sm'
+                asChild
+                className='text-slate-600 hover:text-slate-900'
+              >
+                <Link href={`/admin/blog/edit/${post.id}`} title='Modifier'>
+                  <Edit className='h-4 w-4' />
+                </Link>
+              </Button>
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={() => setDeleteTarget(post)}
+                className='text-red-600 hover:bg-red-50 hover:text-red-700'
+                title='Supprimer'
+              >
+                <Trash2 className='h-4 w-4' />
+              </Button>
+            </div>
+          )}
+          emptyState={{
+            icon: BookOpen,
+            title: searchValue
+              ? 'Aucun article trouvé'
+              : 'Aucun article pour l’instant',
+            subtitle: searchValue
+              ? 'Essayez d’ajuster votre recherche.'
+              : 'Commencez par rédiger votre premier article.',
+          }}
+        />
       </motion.div>
 
-      {/* Stats Cards */}
-      <motion.div variants={itemVariants} className='grid grid-cols-1 md:grid-cols-3 gap-6'>
-        <Card>
-          <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-            <CardTitle className='text-sm font-medium'>Total Articles</CardTitle>
-            <BookOpen className='h-4 w-4 text-muted-foreground' />
-          </CardHeader>
-          <CardContent>
-            <div className='text-2xl font-bold'>{posts.length}</div>
-            <p className='text-xs text-muted-foreground'>
-              {session?.user?.roles === 'ADMIN' ? 'Tous les articles' : 'Vos articles'}
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-            <CardTitle className='text-sm font-medium'>Publiés ce mois</CardTitle>
-            <Calendar className='h-4 w-4 text-muted-foreground' />
-          </CardHeader>
-          <CardContent>
-            <div className='text-2xl font-bold'>
-              {
-                posts.filter(post => {
-                  const postDate = new Date(post.createdAt)
-                  const now = new Date()
-                  return (
-                    postDate.getMonth() === now.getMonth() &&
-                    postDate.getFullYear() === now.getFullYear()
-                  )
-                }).length
-              }
-            </div>
-            <p className='text-xs text-muted-foreground'>Ce mois-ci</p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-            <CardTitle className='text-sm font-medium'>Dernière publication</CardTitle>
-            <User className='h-4 w-4 text-muted-foreground' />
-          </CardHeader>
-          <CardContent>
-            <div className='text-2xl font-bold'>
-              {posts.length > 0 ? formatDate(posts[0]?.createdAt).split(' ')[0] : 'Aucun'}
-            </div>
-            <p className='text-xs text-muted-foreground'>Dernier article</p>
-          </CardContent>
-        </Card>
-      </motion.div>
-
-      {/* Search and Filters */}
-      <motion.div variants={itemVariants}>
-        <Card>
-          <CardHeader>
-            <CardTitle>Articles</CardTitle>
-            <CardDescription>Gérez vos articles de blog</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className='flex items-center space-x-2 mb-6'>
-              <div className='relative flex-1'>
-                <Search className='absolute left-2 top-2.5 h-4 w-4 text-muted-foreground' />
-                <Input
-                  placeholder='Rechercher un article...'
-                  value={searchTerm}
-                  onChange={e => setSearchTerm(e.target.value)}
-                  className='pl-8'
-                />
+      {/* Delete confirmation */}
+      <Dialog
+        open={Boolean(deleteTarget)}
+        onOpenChange={open => !open && !deleting && setDeleteTarget(null)}
+      >
+        <DialogContent className='sm:max-w-[480px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-red-50 text-red-600 ring-1 ring-red-100'>
+                <AlertTriangle className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>
+                  Supprimer l&apos;article
+                </DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  {deleteTarget ? (
+                    <>
+                      Cette action supprimera définitivement{' '}
+                      <span className='font-semibold text-slate-900'>
+                        {deleteTarget.title}
+                      </span>
+                      . Elle est <strong>irréversible</strong>.
+                    </>
+                  ) : null}
+                </DialogDescription>
               </div>
             </div>
+          </DialogHeader>
 
-            {isLoadingPosts ? (
-              <div className='flex items-center justify-center py-8'>
-                <div className='animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600'></div>
-                <span className='ml-2'>Chargement des articles...</span>
+          {deleteTarget && (
+            <div className='space-y-2 rounded-xl border border-slate-200 bg-slate-50/60 p-4 text-sm'>
+              <div className='flex items-center justify-between gap-4'>
+                <span className='text-slate-500'>Auteur</span>
+                <span className='truncate font-medium text-slate-900'>
+                  {deleteTarget.author.name || deleteTarget.author.email}
+                </span>
               </div>
-            ) : filteredPosts.length === 0 ? (
-              <div className='text-center py-8'>
-                <BookOpen className='mx-auto h-12 w-12 text-gray-400' />
-                <h3 className='mt-2 text-sm font-medium text-gray-900'>Aucun article</h3>
-                <p className='mt-1 text-sm text-gray-500'>
-                  {searchTerm
-                    ? 'Aucun article trouvé pour cette recherche.'
-                    : 'Commencez par créer votre premier article.'}
-                </p>
-                <div className='mt-6'>
-                  <Button asChild>
-                    <Link href='/createPost'>
-                      <Plus className='h-4 w-4 mr-2' />
-                      Créer un article
-                    </Link>
-                  </Button>
+              <div className='flex items-center justify-between gap-4'>
+                <span className='text-slate-500'>Créé le</span>
+                <span className='font-medium text-slate-900'>
+                  {formatDateTime(deleteTarget.createdAt)}
+                </span>
+              </div>
+              {deleteTarget.slug && (
+                <div className='flex items-center justify-between gap-4'>
+                  <span className='text-slate-500'>Slug</span>
+                  <span className='truncate font-mono text-xs text-slate-900'>
+                    /{deleteTarget.slug}
+                  </span>
                 </div>
-              </div>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Titre</TableHead>
-                    {session?.user?.roles === 'ADMIN' && <TableHead>Auteur</TableHead>}
-                    <TableHead>Créé le</TableHead>
-                    <TableHead>Modifié le</TableHead>
-                    <TableHead className='text-right'>Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredPosts.map(post => (
-                    <TableRow key={post.id}>
-                      <TableCell className='font-medium'>
-                        <div className='flex flex-col'>
-                          <span className='truncate max-w-xs'>{post.title}</span>
-                          {post.slug && <span className='text-xs text-gray-500'>/{post.slug}</span>}
-                        </div>
-                      </TableCell>
-                      {session?.user?.roles === 'ADMIN' && (
-                        <TableCell>
-                          <div className='flex items-center gap-2'>
-                            <Badge variant='secondary'>
-                              {post.author.roles === 'ADMIN' ? '👑 Admin' : '✍️ Rédacteur'}
-                            </Badge>
-                            <span className='text-sm text-gray-600'>
-                              {post.author.name || post.author.email}
-                            </span>
-                          </div>
-                        </TableCell>
-                      )}
-                      <TableCell>{formatDate(post.createdAt)}</TableCell>
-                      <TableCell>{formatDate(post.updatedAt)}</TableCell>
-                      <TableCell className='text-right'>
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button variant='ghost' className='h-8 w-8 p-0'>
-                              <MoreHorizontal className='h-4 w-4' />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align='end'>
-                            <DropdownMenuItem asChild>
-                              <Link href={`/posts/article/${post.slug || post.id}`}>
-                                <Eye className='mr-2 h-4 w-4' />
-                                Voir
-                              </Link>
-                            </DropdownMenuItem>
-                            <DropdownMenuItem asChild>
-                              <Link href={`/admin/blog/edit/${post.id}`}>
-                                <Edit3 className='mr-2 h-4 w-4' />
-                                Modifier
-                              </Link>
-                            </DropdownMenuItem>
-                            <AlertDialog>
-                              <AlertDialogTrigger asChild>
-                                <DropdownMenuItem onSelect={e => e.preventDefault()}>
-                                  <Trash2 className='mr-2 h-4 w-4' />
-                                  Supprimer
-                                </DropdownMenuItem>
-                              </AlertDialogTrigger>
-                              <AlertDialogContent>
-                                <AlertDialogHeader>
-                                  <AlertDialogTitle>Confirmer la suppression</AlertDialogTitle>
-                                  <AlertDialogDescription>
-                                    Êtes-vous sûr de vouloir supprimer l&apos;article &quot;
-                                    {post.title}&quot; ? Cette action est irréversible.
-                                  </AlertDialogDescription>
-                                </AlertDialogHeader>
-                                <AlertDialogFooter>
-                                  <AlertDialogCancel>Annuler</AlertDialogCancel>
-                                  <AlertDialogAction
-                                    onClick={() => handleDeletePost(post.id)}
-                                    disabled={deletingPostId === post.id}
-                                    className='bg-red-600 hover:bg-red-700'
-                                  >
-                                    {deletingPostId === post.id ? 'Suppression...' : 'Supprimer'}
-                                  </AlertDialogAction>
-                                </AlertDialogFooter>
-                              </AlertDialogContent>
-                            </AlertDialog>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            )}
-          </CardContent>
-        </Card>
-      </motion.div>
-    </motion.div>
+              )}
+            </div>
+          )}
+
+          <DialogFooter className='gap-2'>
+            <Button
+              variant='outline'
+              onClick={() => setDeleteTarget(null)}
+              disabled={deleting}
+            >
+              Annuler
+            </Button>
+            <Button
+              variant='destructive'
+              onClick={handleDelete}
+              disabled={deleting}
+              className='gap-2'
+            >
+              {deleting ? (
+                <>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Suppression…
+                </>
+              ) : (
+                <>
+                  <Trash2 className='h-4 w-4' />
+                  Supprimer définitivement
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
   )
 }

--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -106,7 +106,15 @@ export default function BlogManagementPage() {
       }
 
       const data = await response.json()
-      setPosts(data)
+      // Defensive: the /api/posts contract is an array, but guard against a
+      // wrapped shape (e.g. `{ posts, pagination }`) in case an upstream
+      // change accidentally leaks the paginated object through.
+      const normalized = Array.isArray(data)
+        ? data
+        : Array.isArray((data as { posts?: unknown }).posts)
+          ? ((data as { posts: Post[] }).posts)
+          : []
+      setPosts(normalized)
     } catch (error) {
       console.error('Error fetching posts:', error)
       toast.error('Erreur lors du chargement des articles')

--- a/src/app/admin/components/ActionCardGroup.tsx
+++ b/src/app/admin/components/ActionCardGroup.tsx
@@ -2,10 +2,77 @@
 
 import React from 'react'
 import Link from 'next/link'
-import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/shadcnui/card'
-import { Badge } from '@/components/ui/shadcnui/badge'
 import { motion } from 'framer-motion'
-import { ArrowRight, LucideIcon } from 'lucide-react'
+import { ArrowUpRight, LucideIcon } from 'lucide-react'
+
+export type ActionCardTone =
+  | 'slate'
+  | 'blue'
+  | 'indigo'
+  | 'emerald'
+  | 'amber'
+  | 'orange'
+  | 'red'
+  | 'purple'
+
+const TONE_CLASSES: Record<
+  ActionCardTone,
+  {
+    iconBg: string
+    iconText: string
+    hoverBorder: string
+    accent: string
+  }
+> = {
+  slate: {
+    iconBg: 'bg-slate-100',
+    iconText: 'text-slate-600',
+    hoverBorder: 'hover:border-slate-300',
+    accent: 'group-hover:text-slate-700',
+  },
+  blue: {
+    iconBg: 'bg-blue-50',
+    iconText: 'text-blue-600',
+    hoverBorder: 'hover:border-blue-300',
+    accent: 'group-hover:text-blue-700',
+  },
+  indigo: {
+    iconBg: 'bg-indigo-50',
+    iconText: 'text-indigo-600',
+    hoverBorder: 'hover:border-indigo-300',
+    accent: 'group-hover:text-indigo-700',
+  },
+  emerald: {
+    iconBg: 'bg-emerald-50',
+    iconText: 'text-emerald-600',
+    hoverBorder: 'hover:border-emerald-300',
+    accent: 'group-hover:text-emerald-700',
+  },
+  amber: {
+    iconBg: 'bg-amber-50',
+    iconText: 'text-amber-600',
+    hoverBorder: 'hover:border-amber-300',
+    accent: 'group-hover:text-amber-700',
+  },
+  orange: {
+    iconBg: 'bg-orange-50',
+    iconText: 'text-orange-600',
+    hoverBorder: 'hover:border-orange-300',
+    accent: 'group-hover:text-orange-700',
+  },
+  red: {
+    iconBg: 'bg-red-50',
+    iconText: 'text-red-600',
+    hoverBorder: 'hover:border-red-300',
+    accent: 'group-hover:text-red-700',
+  },
+  purple: {
+    iconBg: 'bg-purple-50',
+    iconText: 'text-purple-600',
+    hoverBorder: 'hover:border-purple-300',
+    accent: 'group-hover:text-purple-700',
+  },
+}
 
 interface ActionCardProps {
   title: string
@@ -14,63 +81,60 @@ interface ActionCardProps {
   href: string
   badge?: string | null
   badgeVariant?: 'destructive' | 'secondary'
-  priority?: 'high' | 'medium' | 'low'
+  tone?: ActionCardTone
 }
 
 export function ActionCard({
   title,
   description,
   href,
-  icon,
+  icon: Icon,
   badge,
   badgeVariant = 'secondary',
-  priority = 'medium',
+  tone = 'slate',
 }: ActionCardProps) {
-  const priorityStyles = {
-    high: 'ring-2 ring-red-200 hover:ring-red-300',
-    medium: 'hover:ring-2 hover:ring-blue-200',
-    low: 'hover:ring-2 hover:ring-slate-200',
-  }
+  const toneClass = TONE_CLASSES[tone]
+  const badgeClass =
+    badgeVariant === 'destructive'
+      ? 'bg-red-100 text-red-800 ring-1 ring-red-200'
+      : 'bg-slate-100 text-slate-700 ring-1 ring-slate-200'
 
   return (
-    <motion.div whileHover={{ scale: 1.02, y: -2 }} whileTap={{ scale: 0.98 }} className='h-full'>
-      <Link href={href} className='block h-full'>
-        <Card
-          className={`
-          h-full border-0 shadow-sm hover:shadow-lg transition-all duration-300 
-          bg-white/70 backdrop-blur-sm hover:bg-white/90 group
-          ${priorityStyles[priority]}
-        `}
-        >
-          <CardHeader className='pb-3'>
-            <div className='flex items-start justify-between'>
-              <div className='flex items-center gap-3 flex-1'>
-                <div className='p-2 bg-slate-50 rounded-lg group-hover:bg-blue-50 transition-colors shrink-0'>
-                  {React.createElement(icon, { className: 'h-6 w-6 text-slate-700' })}
-                </div>
-                <div className='min-w-0 flex-1'>
-                  <CardTitle className='text-lg font-semibold text-slate-800 group-hover:text-blue-700 transition-colors line-clamp-2'>
-                    {title}
-                  </CardTitle>
-                  <CardDescription className='text-slate-600 text-sm mt-1 line-clamp-2'>
-                    {description}
-                  </CardDescription>
-                </div>
-              </div>
-              <ArrowRight className='h-4 w-4 text-slate-400 group-hover:text-blue-600 group-hover:translate-x-1 transition-all shrink-0 ml-2' />
-            </div>
+    <Link href={href} className='block h-full'>
+      <motion.div
+        whileHover={{ y: -2 }}
+        transition={{ type: 'tween', duration: 0.2 }}
+        className={`group relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm transition hover:shadow-md ${toneClass.hoverBorder}`}
+      >
+        <div className='flex items-start justify-between gap-3'>
+          <div
+            className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl ${toneClass.iconBg} ${toneClass.iconText}`}
+          >
+            <Icon className='h-5 w-5' />
+          </div>
+          <ArrowUpRight className='h-4 w-4 text-slate-300 transition group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-slate-600' />
+        </div>
 
-            {badge && (
-              <div className='mt-3'>
-                <Badge variant={badgeVariant} className='text-xs'>
-                  {badge}
-                </Badge>
-              </div>
-            )}
-          </CardHeader>
-        </Card>
-      </Link>
-    </motion.div>
+        <div className='mt-4 space-y-1'>
+          <h3
+            className={`text-base font-semibold leading-tight text-slate-900 transition ${toneClass.accent}`}
+          >
+            {title}
+          </h3>
+          <p className='line-clamp-2 text-sm text-slate-500'>{description}</p>
+        </div>
+
+        {badge && (
+          <div className='mt-4'>
+            <span
+              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${badgeClass}`}
+            >
+              {badge}
+            </span>
+          </div>
+        )}
+      </motion.div>
+    </Link>
   )
 }
 
@@ -78,7 +142,9 @@ interface ActionCardGroupProps {
   title: string
   description: string
   icon: LucideIcon
-  cards: ActionCardProps[]
+  /** Color tone for the group header icon chip. Defaults to slate. */
+  tone?: ActionCardTone
+  cards: (ActionCardProps & { tone?: ActionCardTone })[]
   className?: string
 }
 
@@ -86,38 +152,54 @@ export function ActionCardGroup({
   title,
   description,
   icon: Icon,
+  tone = 'slate',
   cards,
   className = '',
 }: ActionCardGroupProps) {
+  const headerTone = TONE_CLASSES[tone]
+
   return (
-    <div className={`space-y-6 ${className}`}>
+    <div className={`space-y-5 ${className}`}>
       <div className='flex items-center gap-3'>
-        <div className='p-2 bg-slate-100 rounded-lg'>
-          <Icon className='h-6 w-6 text-slate-700' />
+        <div
+          className={`flex h-10 w-10 items-center justify-center rounded-xl ${headerTone.iconBg} ${headerTone.iconText}`}
+        >
+          <Icon className='h-5 w-5' />
         </div>
         <div>
-          <h2 className='text-2xl font-bold text-slate-800'>{title}</h2>
-          <p className='text-slate-600'>{description}</p>
+          <h2 className='text-xl font-semibold text-slate-900'>{title}</h2>
+          <p className='text-sm text-slate-500'>{description}</p>
         </div>
       </div>
 
-      <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
-        {cards.map((card, index) => (
+      <motion.div
+        className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'
+        initial='hidden'
+        animate='visible'
+        variants={{
+          hidden: { opacity: 0 },
+          visible: {
+            opacity: 1,
+            transition: { staggerChildren: 0.04 },
+          },
+        }}
+      >
+        {cards.map(card => (
           <motion.div
             key={card.title}
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{
-              delay: index * 0.05,
-              type: 'spring',
-              stiffness: 100,
-              damping: 15,
+            variants={{
+              hidden: { opacity: 0, y: 12 },
+              visible: {
+                opacity: 1,
+                y: 0,
+                transition: { type: 'tween', duration: 0.3, ease: 'easeOut' },
+              },
             }}
           >
             <ActionCard {...card} />
           </motion.div>
         ))}
-      </div>
+      </motion.div>
     </div>
   )
 }

--- a/src/app/admin/components/AdminNav.tsx
+++ b/src/app/admin/components/AdminNav.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import { useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { UserRole } from '@prisma/client'
@@ -31,8 +31,8 @@ import {
   Wallet,
   Tag,
   Image as ImageIcon,
+  ShieldCheck,
 } from 'lucide-react'
-import { Button } from '@/components/ui/shadcnui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -61,47 +61,19 @@ const navGroups: NavGroup[] = [
     title: "Vue d'ensemble",
     icon: TrendingUp,
     items: [
-      {
-        title: 'Dashboard',
-        href: '/admin',
-        icon: BarChart2,
-      },
-      {
-        title: 'Aperçu Rapide',
-        href: '/admin/overview',
-        icon: TrendingUp,
-      },
+      { title: 'Dashboard', href: '/admin', icon: BarChart2 },
+      { title: 'Aperçu Rapide', href: '/admin/overview', icon: TrendingUp },
     ],
   },
   {
     title: 'Contenus',
     icon: Shield,
     items: [
-      {
-        title: 'Validation',
-        href: '/admin/validation',
-        icon: ClipboardCheck,
-      },
-      {
-        title: 'Hébergements',
-        href: '/admin/products',
-        icon: Home,
-      },
-      {
-        title: 'Avis',
-        href: '/admin/reviews',
-        icon: MessageSquare,
-      },
-      {
-        title: 'Évaluations utilisateurs',
-        href: '/admin/user-ratings',
-        icon: Star,
-      },
-      {
-        title: 'Refus',
-        href: '/admin/rejections',
-        icon: XCircle,
-      },
+      { title: 'Validation', href: '/admin/validation', icon: ClipboardCheck },
+      { title: 'Hébergements', href: '/admin/products', icon: Home },
+      { title: 'Avis', href: '/admin/reviews', icon: MessageSquare },
+      { title: 'Évaluations utilisateurs', href: '/admin/user-ratings', icon: Star },
+      { title: 'Refus', href: '/admin/rejections', icon: XCircle },
     ],
   },
   {
@@ -128,12 +100,7 @@ const navGroups: NavGroup[] = [
     icon: Users,
     requiredRoles: ['ADMIN'],
     items: [
-      {
-        title: 'Comptes',
-        href: '/admin/users',
-        icon: Users,
-        requiredRoles: ['ADMIN'],
-      },
+      { title: 'Comptes', href: '/admin/users', icon: Users, requiredRoles: ['ADMIN'] },
     ],
   },
   {
@@ -154,7 +121,7 @@ const navGroups: NavGroup[] = [
         requiredRoles: ['ADMIN'],
       },
       {
-        title: 'Reservations',
+        title: 'Réservations',
         href: '/admin/reservations',
         icon: CalendarDays,
         requiredRoles: ['ADMIN'],
@@ -177,58 +144,26 @@ const navGroups: NavGroup[] = [
         icon: Settings,
         requiredRoles: ['ADMIN'],
       },
-    ],
-  },
-  {
-    title: 'Configuration',
-    icon: Settings,
-    items: [
-      {
-        title: 'Services inclus',
-        href: '/admin/included-services',
-        icon: Package,
-      },
-      {
-        title: 'Extras',
-        href: '/admin/extras',
-        icon: Plus,
-      },
-      {
-        title: 'Points forts',
-        href: '/admin/highlights',
-        icon: Highlighter,
-      },
-      {
-        title: 'Équipements',
-        href: '/admin/equipments',
-        icon: Settings,
-      },
-      {
-        title: 'Repas',
-        href: '/admin/meals',
-        icon: Settings,
-      },
-      {
-        title: 'Sécurité',
-        href: '/admin/security',
-        icon: Shield,
-      },
-      {
-        title: 'Types de location',
-        href: '/admin/typeRent',
-        icon: Home,
-      },
-      {
-        title: 'Images Homepage',
-        href: '/admin/homepage',
-        icon: ImageIcon,
-      },
       {
         title: 'Retraits',
         href: '/admin/withdrawals',
         icon: Wallet,
         requiredRoles: ['ADMIN', 'HOST_MANAGER'],
       },
+    ],
+  },
+  {
+    title: 'Configuration',
+    icon: Settings,
+    items: [
+      { title: 'Services inclus', href: '/admin/included-services', icon: Package },
+      { title: 'Extras', href: '/admin/extras', icon: Plus },
+      { title: 'Points forts', href: '/admin/highlights', icon: Highlighter },
+      { title: 'Équipements', href: '/admin/equipments', icon: Settings },
+      { title: 'Repas', href: '/admin/meals', icon: Settings },
+      { title: 'Sécurité', href: '/admin/security', icon: Shield },
+      { title: 'Types de location', href: '/admin/typeRent', icon: Home },
+      { title: 'Images Homepage', href: '/admin/homepage', icon: ImageIcon },
     ],
   },
 ]
@@ -240,140 +175,191 @@ export function AdminNav() {
 
   const userRole = session?.user?.roles
 
-  // Filter function to check if user has required role
   const hasRequiredRole = (requiredRoles?: UserRole[]): boolean => {
     if (!requiredRoles || requiredRoles.length === 0) {
-      // No specific roles required, allow ADMIN and HOST_MANAGER
       return userRole === 'ADMIN' || userRole === 'HOST_MANAGER'
     }
     return userRole ? requiredRoles.includes(userRole) : false
   }
 
-  // Filter nav groups and items based on user role
   const filteredNavGroups = navGroups
     .filter(group => hasRequiredRole(group.requiredRoles))
     .map(group => ({
       ...group,
       items: group.items.filter(item => hasRequiredRole(item.requiredRoles)),
     }))
-    .filter(group => group.items.length > 0) // Remove groups with no visible items
+    .filter(group => group.items.length > 0)
 
   const isActiveGroup = (group: NavGroup) => {
-    return group.items.some(item => pathname === item.href)
+    if (group.items.some(item => item.href === '/admin' && pathname === '/admin')) {
+      return true
+    }
+    return group.items.some(item => item.href !== '/admin' && pathname.startsWith(item.href))
   }
 
   const isActiveItem = (href: string) => {
-    return pathname === href
+    if (href === '/admin') return pathname === '/admin'
+    return pathname === href || pathname.startsWith(href + '/')
   }
 
   return (
-    <nav className='sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur-md shadow-sm'>
-      <div className='flex h-16 items-center justify-between px-4 md:px-6'>
-        {/* Logo/Home Link */}
-        <Link
-          href='/admin'
-          className='flex items-center gap-2 font-semibold text-slate-800 hover:text-blue-600 transition-colors'
-        >
-          <Shield className='h-6 w-6' />
-          <span className='hidden md:inline'>Admin Panel</span>
+    <nav className='sticky top-0 z-50 w-full border-b border-slate-200/80 bg-white/80 backdrop-blur-md'>
+      <div className='mx-auto flex h-16 max-w-7xl items-center justify-between px-4 md:px-6'>
+        {/* Logo */}
+        <Link href='/admin' className='group flex items-center gap-3'>
+          <div className='flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600 to-indigo-600 shadow-sm transition group-hover:shadow-md'>
+            <ShieldCheck className='h-5 w-5 text-white' />
+          </div>
+          <div className='hidden md:flex md:flex-col md:leading-tight'>
+            <span className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+              Hosteed
+            </span>
+            <span className='text-sm font-bold text-slate-900'>Admin Panel</span>
+          </div>
         </Link>
 
         {/* Desktop Navigation */}
-        <div className='hidden lg:flex items-center space-x-1'>
+        <div className='hidden items-center gap-1 lg:flex'>
           {filteredNavGroups.map(group => {
             const isGroupActive = isActiveGroup(group)
+            const GroupIcon = group.icon
 
             return (
               <DropdownMenu key={group.title}>
                 <DropdownMenuTrigger asChild>
-                  <Button
-                    variant='ghost'
+                  <button
                     className={cn(
-                      'flex items-center gap-2 px-3 py-2 text-sm font-medium transition-colors hover:text-blue-600 hover:bg-blue-50',
-                      isGroupActive ? 'text-blue-600 bg-blue-50' : 'text-slate-600'
+                      'relative inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition',
+                      isGroupActive
+                        ? 'text-blue-700'
+                        : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
                     )}
                   >
-                    <group.icon className='h-4 w-4' />
+                    <GroupIcon className='h-4 w-4' />
                     <span>{group.title}</span>
-                    <ChevronDown className='h-3 w-3 opacity-50' />
-                  </Button>
+                    <ChevronDown className='h-3 w-3 opacity-60' />
+                    {isGroupActive && (
+                      <motion.span
+                        layoutId='admin-nav-active'
+                        className='absolute inset-x-2 -bottom-[1px] h-0.5 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600'
+                        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                      />
+                    )}
+                  </button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align='start' className='w-48'>
-                  <DropdownMenuLabel className='text-xs text-slate-500 uppercase tracking-wide'>
+                <DropdownMenuContent
+                  align='start'
+                  className='w-56 rounded-xl border border-slate-200 p-1.5 shadow-lg'
+                >
+                  <DropdownMenuLabel className='px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400'>
                     {group.title}
                   </DropdownMenuLabel>
-                  <DropdownMenuSeparator />
-                  {group.items.map(item => (
-                    <DropdownMenuItem key={item.href} asChild>
-                      <Link
-                        href={item.href}
-                        className={cn(
-                          'flex items-center gap-2 w-full cursor-pointer',
-                          isActiveItem(item.href)
-                            ? 'text-blue-600 bg-blue-50'
-                            : 'text-slate-700 hover:text-blue-600'
-                        )}
+                  <DropdownMenuSeparator className='bg-slate-100' />
+                  {group.items.map(item => {
+                    const ItemIcon = item.icon
+                    const active = isActiveItem(item.href)
+                    return (
+                      <DropdownMenuItem
+                        key={item.href}
+                        asChild
+                        className='rounded-lg px-2 py-1.5 focus:bg-blue-50 focus:text-blue-700'
                       >
-                        <item.icon className='h-4 w-4' />
-                        {item.title}
-                      </Link>
-                    </DropdownMenuItem>
-                  ))}
+                        <Link
+                          href={item.href}
+                          className={cn(
+                            'flex w-full cursor-pointer items-center gap-2.5 text-sm',
+                            active
+                              ? 'font-semibold text-blue-700'
+                              : 'text-slate-700 hover:text-slate-900'
+                          )}
+                        >
+                          <span
+                            className={cn(
+                              'flex h-7 w-7 items-center justify-center rounded-md',
+                              active ? 'bg-blue-100 text-blue-700' : 'bg-slate-100 text-slate-600'
+                            )}
+                          >
+                            <ItemIcon className='h-3.5 w-3.5' />
+                          </span>
+                          <span className='flex-1'>{item.title}</span>
+                        </Link>
+                      </DropdownMenuItem>
+                    )
+                  })}
                 </DropdownMenuContent>
               </DropdownMenu>
             )
           })}
         </div>
 
-        {/* Mobile Navigation Toggle */}
-        <Button
-          variant='ghost'
-          size='sm'
-          className='lg:hidden'
+        {/* Mobile toggle */}
+        <button
+          className='inline-flex h-9 w-9 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 hover:text-slate-900 lg:hidden'
           onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+          aria-label='Toggle navigation menu'
         >
           {mobileMenuOpen ? <X className='h-5 w-5' /> : <Menu className='h-5 w-5' />}
-        </Button>
+        </button>
       </div>
 
-      {/* Mobile Navigation Menu */}
-      {mobileMenuOpen && (
-        <motion.div
-          initial={{ opacity: 0, height: 0 }}
-          animate={{ opacity: 1, height: 'auto' }}
-          exit={{ opacity: 0, height: 0 }}
-          className='lg:hidden border-t bg-white'
-        >
-          <div className='px-4 py-4 space-y-4'>
-            {filteredNavGroups.map(group => (
-              <div key={group.title} className='space-y-2'>
-                <div className='flex items-center gap-2 text-sm font-medium text-slate-800 px-2 py-1'>
-                  <group.icon className='h-4 w-4' />
-                  {group.title}
-                </div>
-                <div className='pl-6 space-y-1'>
-                  {group.items.map(item => (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      className={cn(
-                        'flex items-center gap-2 px-2 py-2 text-sm rounded-md transition-colors',
-                        isActiveItem(item.href)
-                          ? 'text-blue-600 bg-blue-50'
-                          : 'text-slate-600 hover:text-blue-600 hover:bg-slate-50'
-                      )}
-                      onClick={() => setMobileMenuOpen(false)}
-                    >
-                      <item.icon className='h-4 w-4' />
-                      {item.title}
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </motion.div>
-      )}
+      {/* Mobile menu */}
+      <AnimatePresence initial={false}>
+        {mobileMenuOpen && (
+          <motion.div
+            key='mobile-menu'
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+            className='border-t border-slate-200/80 bg-white/95 backdrop-blur-md lg:hidden'
+          >
+            <div className='mx-auto max-w-7xl space-y-6 px-4 py-5'>
+              {filteredNavGroups.map(group => {
+                const GroupIcon = group.icon
+                return (
+                  <div key={group.title} className='space-y-2'>
+                    <div className='flex items-center gap-2 px-2 text-xs font-semibold uppercase tracking-wide text-slate-400'>
+                      <GroupIcon className='h-3.5 w-3.5' />
+                      {group.title}
+                    </div>
+                    <div className='space-y-1'>
+                      {group.items.map(item => {
+                        const ItemIcon = item.icon
+                        const active = isActiveItem(item.href)
+                        return (
+                          <Link
+                            key={item.href}
+                            href={item.href}
+                            onClick={() => setMobileMenuOpen(false)}
+                            className={cn(
+                              'flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition',
+                              active
+                                ? 'bg-blue-50 font-semibold text-blue-700'
+                                : 'text-slate-700 hover:bg-slate-50 hover:text-slate-900'
+                            )}
+                          >
+                            <span
+                              className={cn(
+                                'flex h-8 w-8 items-center justify-center rounded-md',
+                                active
+                                  ? 'bg-blue-100 text-blue-700'
+                                  : 'bg-slate-100 text-slate-600'
+                              )}
+                            >
+                              <ItemIcon className='h-4 w-4' />
+                            </span>
+                            {item.title}
+                          </Link>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </nav>
   )
 }

--- a/src/app/admin/equipments/page.tsx
+++ b/src/app/admin/equipments/page.tsx
@@ -1,530 +1,96 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
-import { useAuth } from '@/hooks/useAuth'
-import { isAdmin } from '@/hooks/useAdminAuth'
-import Link from 'next/link'
-import { motion, Variants } from 'framer-motion'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/shadcnui/input'
-import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
+import { Sofa, Shield } from 'lucide-react'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/shadcnui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import {
-  Loader2,
-  Search,
-  Eye,
-  BrushCleaning,
-  Plus,
-  ArrowLeft,
-  CheckCircle,
-  Edit3,
-  Trash2,
-} from 'lucide-react'
-
-import {
-  findAllEquipments,
   createEquipment,
-  updateEquipment,
   deleteEquipement,
+  findAllEquipments,
+  updateEquipment,
 } from '@/lib/services/equipments.service'
 import { EquipmentInterface } from '@/lib/interface/equipmentInterface'
-import { IconPicker } from '@/components/ui/IconPicker'
-import { DynamicIcon } from '@/lib/utils/iconMapping'
+import { TaxonomyManager, type TaxonomyAdapter } from '@/components/admin/ui/TaxonomyManager'
+import type { DataTableColumn } from '@/components/admin/ui/DataTable'
 
-const containerVariants: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
+interface EquipmentFormData {
+  name: string
+  icon: string
+}
+
+const adapter: TaxonomyAdapter<EquipmentInterface, EquipmentFormData> = {
+  fetchAll: async () => {
+    const result = await findAllEquipments()
+    return result ?? []
+  },
+  create: async data => {
+    const created = await createEquipment(data.name, data.icon)
+    return created ?? null
+  },
+  update: async (id, data) => {
+    const updated = await updateEquipment(id, data.name, data.icon)
+    return updated ?? null
+  },
+  delete: async id => {
+    const success = await deleteEquipement(id)
+    return Boolean(success)
   },
 }
 
-const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: 'tween' as const,
-      duration: 0.5,
-      ease: 'easeOut',
-    },
+const extraColumns: Array<DataTableColumn<EquipmentInterface>> = [
+  {
+    key: 'icon',
+    header: 'Icône',
+    render: item =>
+      item.icon ? (
+        <span className='inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 font-mono text-xs text-slate-600'>
+          {item.icon}
+        </span>
+      ) : (
+        <span className='text-xs text-slate-400'>—</span>
+      ),
+    cellClassName: 'whitespace-nowrap',
   },
-}
+]
 
 export default function EquipmentsPage() {
-  const {
-    session,
-    isLoading: isAuthLoading,
-    isAuthenticated,
-  } = useAuth({ required: true, redirectTo: '/auth' })
-  const router = useRouter()
-  const [equipments, setEquipments] = useState<EquipmentInterface[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState('')
-  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
-  const [newOptionName, setNewOptionName] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [selectedIcon, setSelectedIcon] = useState('CheckCircle')
-
-  // États pour l'édition
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
-  const [editingOption, setEditingOption] = useState<EquipmentInterface | null>(null)
-  const [editOptionName, setEditOptionName] = useState('')
-  const [editIcon, setEditIcon] = useState('CheckCircle')
-
-  // États pour la suppression
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
-  const [deletingOption, setDeletingOption] = useState<EquipmentInterface | null>(null)
-
-  useEffect(() => {
-    if (isAuthenticated && (!session?.user?.roles || !isAdmin(session.user.roles))) {
-      router.push('/')
-    }
-  }, [isAuthenticated, session, router])
-
-  useEffect(() => {
-    const fetchEquipments = async () => {
-      try {
-        const equipmentsData = await findAllEquipments()
-        if (equipmentsData) {
-          setEquipments(equipmentsData)
-        }
-      } catch (err) {
-        setError("Erreur lors du chargement des options d'équipements")
-        console.error(err)
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchEquipments()
-  }, [])
-
-  const filteredEquipments = equipments.filter((option: EquipmentInterface) =>
-    option.name?.toLowerCase().includes(searchTerm.toLowerCase())
-  )
-
-  const handleAddOption = async () => {
-    if (!newOptionName.trim()) return
-
-    setIsSubmitting(true)
-    try {
-      const newOption = await createEquipment(newOptionName, selectedIcon)
-
-      if (newOption) {
-        setEquipments([...equipments, newOption])
-        setNewOptionName('')
-        setSelectedIcon('CheckCircle')
-        setIsAddDialogOpen(false)
-      } else {
-        setError("Erreur lors de la création de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la création:', err)
-      setError("Erreur lors de la création de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleEditOption = (option: EquipmentInterface) => {
-    setEditingOption(option)
-    setEditOptionName(option.name || '')
-    setEditIcon(option.icon || 'CheckCircle')
-    setIsEditDialogOpen(true)
-  }
-
-  const handleUpdateOption = async () => {
-    if (!editingOption || !editOptionName.trim()) return
-
-    setIsSubmitting(true)
-    try {
-      const updatedOption = await updateEquipment(
-        editingOption.id,
-        editOptionName,
-        editIcon
-      )
-
-      if (updatedOption) {
-        setEquipments(equipments.map(opt => (opt.id === editingOption.id ? updatedOption : opt)))
-        setEditOptionName('')
-        setEditingOption(null)
-        setIsEditDialogOpen(false)
-      } else {
-        setError("Erreur lors de la modification de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la modification:', err)
-      setError("Erreur lors de la modification de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleDeleteOption = (option: EquipmentInterface) => {
-    setDeletingOption(option)
-    setIsDeleteDialogOpen(true)
-  }
-
-  const handleConfirmDelete = async () => {
-    if (!deletingOption) return
-
-    setIsSubmitting(true)
-    try {
-      const success = await deleteEquipement(deletingOption.id)
-
-      if (success) {
-        setEquipments(equipments.filter(opt => opt.id !== deletingOption.id))
-        setDeletingOption(null)
-        setIsDeleteDialogOpen(false)
-      } else {
-        setError("Erreur lors de la suppression de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la suppression:', err)
-      setError("Erreur lors de la suppression de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  if (isAuthLoading || loading) {
-    return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
-        </div>
-      </div>
-    )
-  }
-
-  if (!session) {
-    return null
-  }
-
-  if (error) {
-    return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive'>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        </div>
-      </div>
-    )
-  }
-
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
-      <motion.div
-        className='max-w-7xl mx-auto p-6 space-y-8'
-        variants={containerVariants}
-        initial='hidden'
-        animate='visible'
-      >
-        {/* Header with breadcrumb */}
-        <motion.div variants={itemVariants} className='space-y-4'>
-          <Button variant='ghost' size='sm' asChild className='text-slate-600 hover:text-slate-800'>
-            <Link href='/admin' className='flex items-center gap-2'>
-              <ArrowLeft className='h-4 w-4' />
-              Retour au dashboard
-            </Link>
-          </Button>
-
-          <div className='flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4'>
-            <div>
-              <div className='flex items-center gap-2 mb-2'>
-                <BrushCleaning className='h-8 w-8 text-green-600' />
-                <h1 className='text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-800 via-green-700 to-emerald-700'>
-                  Gestion des options d&apos;équipements
-                </h1>
-              </div>
-              <p className='text-slate-600 text-lg'>
-                {equipments.length} option{equipments.length > 1 ? 's' : ''} enregistrée
-                {equipments.length > 1 ? 's' : ''}
-              </p>
-            </div>
-
-            <div className='flex items-center gap-3'>
-              <div className='relative'>
-                <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4' />
-                <Input
-                  type='text'
-                  placeholder='Rechercher un équipement...'
-                  value={searchTerm}
-                  onChange={e => setSearchTerm(e.target.value)}
-                  className='pl-10 w-full sm:w-64'
-                />
-              </div>
-
-              <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-                <DialogTrigger asChild>
-                  <Button className='bg-green-600 hover:bg-green-700 text-white shadow-lg'>
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter un équipement
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className='sm:max-w-lg'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <BrushCleaning className='h-5 w-5 text-green-600' />
-                      Nouvel équipement
-                    </DialogTitle>
-                    <DialogDescription>
-                      Ajoutez un nouvel équipement à la liste disponible.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='optionName'>Nom de l&apos;équipement</Label>
-                      <Input
-                        id='optionName'
-                        placeholder='Ex: Lave-linge, Lave-vaisselle, Micro-ondes...'
-                        value={newOptionName}
-                        onChange={e => setNewOptionName(e.target.value)}
-                        onKeyDown={e => e.key === 'Enter' && !isSubmitting && handleAddOption()}
-                      />
-                    </div>
-                    <IconPicker value={selectedIcon} onChange={setSelectedIcon} />
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => {
-                        setIsAddDialogOpen(false)
-                        setSelectedIcon('CheckCircle')
-                      }}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleAddOption}
-                      disabled={!newOptionName.trim() || isSubmitting}
-                      className='bg-green-600 hover:bg-green-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Création...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Créer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Dialog d'édition */}
-              <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-                <DialogContent className='sm:max-w-lg'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Edit3 className='h-5 w-5 text-green-600' />
-                      Modifier l&apos;équipement
-                    </DialogTitle>
-                    <DialogDescription>Modifiez le nom de cet équipement.</DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='editOptionName'>Nom de l&apos;équipement</Label>
-                      <Input
-                        id='editOptionName'
-                        placeholder='Ex: Aspirateur, Fer à repasser...'
-                        value={editOptionName}
-                        onChange={e => setEditOptionName(e.target.value)}
-                        onKeyDown={e => e.key === 'Enter' && !isSubmitting && handleUpdateOption()}
-                      />
-                    </div>
-                    <IconPicker value={editIcon} onChange={setEditIcon} />
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsEditDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleUpdateOption}
-                      disabled={!editOptionName.trim() || isSubmitting}
-                      className='bg-green-600 hover:bg-green-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Modification...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Modifier
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Dialog de suppression */}
-              <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Trash2 className='h-5 w-5 text-red-600' />
-                      Supprimer l&apos;équipement
-                    </DialogTitle>
-                    <DialogDescription>
-                      Êtes-vous sûr de vouloir supprimer l&apos;équipement &quot;
-                      {deletingOption?.name}&quot; ? Cette action est irréversible.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsDeleteDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleConfirmDelete}
-                      disabled={isSubmitting}
-                      variant='destructive'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Suppression...
-                        </>
-                      ) : (
-                        <>
-                          <Trash2 className='h-4 w-4 mr-2' />
-                          Supprimer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-            </div>
-          </div>
-        </motion.div>
-
-        {/* Content */}
-        <motion.div variants={itemVariants}>
-          {filteredEquipments.length === 0 ? (
-            <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm'>
-              <CardContent className='text-center py-12'>
-                <BrushCleaning className='h-16 w-16 text-slate-300 mx-auto mb-4' />
-                <h3 className='text-xl font-semibold text-slate-600 mb-2'>
-                  {searchTerm ? 'Aucun résultat' : 'Aucun équipement'}
-                </h3>
-                <p className='text-slate-500 mb-6'>
-                  {searchTerm
-                    ? 'Aucun équipement ne correspond à votre recherche.'
-                    : 'Commencez par ajouter votre premier équipement.'}
-                </p>
-                {!searchTerm && (
-                  <Button
-                    onClick={() => setIsAddDialogOpen(true)}
-                    className='bg-green-600 hover:bg-green-700'
-                  >
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter un équipement
-                  </Button>
-                )}
-              </CardContent>
-            </Card>
-          ) : (
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 items-stretch'>
-              {filteredEquipments.map((option, index) => (
-                <motion.div
-                  key={option.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.05 }}
-                >
-                  <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm hover:shadow-xl transition-all duration-300 group h-full'>
-                    <CardHeader className='pb-3'>
-                      <div className='flex items-start justify-between'>
-                        <div className='flex items-center gap-3'>
-                          <div className='p-2 bg-green-50 rounded-lg group-hover:bg-green-100 transition-colors'>
-                            <DynamicIcon name={option.icon} className='h-5 w-5 text-green-600' />
-                          </div>
-                          <div>
-                            <CardTitle className='text-lg font-semibold text-slate-800'>
-                              {option.name || 'Équipement sans nom'}
-                            </CardTitle>
-                          </div>
-                        </div>
-                        <Badge
-                          variant='secondary'
-                          className='bg-green-50 text-green-700 border-green-200'
-                        >
-                          Actif
-                        </Badge>
-                      </div>
-                    </CardHeader>
-                    <CardContent className='pt-0'>
-                      <div className='flex items-center gap-2'>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          asChild
-                          className='flex-1 hover:bg-green-50 hover:text-green-600'
-                        >
-                          <Link href={`/admin/equipments/${option.id}`}>
-                            <Eye className='h-4 w-4 mr-2' />
-                            Voir détails
-                          </Link>
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-green-50 hover:text-green-600'
-                          onClick={() => handleEditOption(option)}
-                        >
-                          <Edit3 className='h-4 w-4' />
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-red-50 hover:text-red-600'
-                          onClick={() => handleDeleteOption(option)}
-                        >
-                          <Trash2 className='h-4 w-4' />
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </motion.div>
-              ))}
-            </div>
-          )}
-        </motion.div>
-      </motion.div>
-    </div>
+    <TaxonomyManager<EquipmentInterface, EquipmentFormData>
+      eyebrow='Espace administrateur'
+      eyebrowIcon={Shield}
+      title='Équipements'
+      subtitle='Gérez les équipements disponibles dans les hébergements (lave-linge, wifi, etc.).'
+      backHref='/admin'
+      backLabel='Retour au panel admin'
+      icon={Sofa}
+      kpiTone='blue'
+      itemLabelSingular='équipement'
+      itemLabelPlural='équipements'
+      searchPlaceholder='Rechercher un équipement…'
+      getItemId={item => item.id}
+      getItemName={item => item.name ?? ''}
+      searchMatches={(item, q) =>
+        (item.name ?? '').toLowerCase().includes(q) ||
+        (item.icon ?? '').toLowerCase().includes(q)
+      }
+      extraColumns={extraColumns}
+      fields={[
+        {
+          name: 'name',
+          label: 'Nom',
+          type: 'text',
+          required: true,
+          placeholder: 'Ex: Lave-linge, Wifi, Climatisation',
+        },
+        {
+          name: 'icon',
+          label: 'Icône',
+          type: 'text',
+          placeholder: "Nom de l'icône Lucide (optionnel)",
+          help: 'Laisser vide pour utiliser l’icône par défaut.',
+        },
+      ]}
+      emptyFormData={{ name: '', icon: '' }}
+      toFormData={item => ({ name: item.name ?? '', icon: item.icon ?? '' })}
+      adapter={adapter}
+    />
   )
 }

--- a/src/app/admin/extras/page.tsx
+++ b/src/app/admin/extras/page.tsx
@@ -1,36 +1,10 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/input'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/shadcnui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/shadcnui/dialog'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import { Label } from '@/components/ui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import { Plus, Edit, Trash2 } from 'lucide-react'
-import { toast } from 'sonner'
+import { PlusCircle, Shield } from 'lucide-react'
 import { ExtraPriceType } from '@prisma/client'
+import { TaxonomyManager, type TaxonomyAdapter } from '@/components/admin/ui/TaxonomyManager'
+import type { DataTableColumn } from '@/components/admin/ui/DataTable'
+import { formatCurrency } from '@/lib/utils/formatNumber'
 
 interface ProductExtra {
   id: string
@@ -46,6 +20,14 @@ interface ProductExtra {
   }
 }
 
+interface ExtraFormData {
+  name: string
+  description: string
+  priceEUR: string
+  priceMGA: string
+  type: ExtraPriceType | ''
+}
+
 const PRICE_TYPE_LABELS: Record<ExtraPriceType, string> = {
   PER_DAY: 'Par jour',
   PER_PERSON: 'Par personne',
@@ -53,328 +35,184 @@ const PRICE_TYPE_LABELS: Record<ExtraPriceType, string> = {
   PER_BOOKING: 'Par réservation',
 }
 
-export default function ExtrasPage() {
-  const [extras, setExtras] = useState<ProductExtra[]>([])
-  const [loading, setLoading] = useState(true)
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [editingExtra, setEditingExtra] = useState<ProductExtra | null>(null)
-  const [formData, setFormData] = useState({
-    name: '',
-    description: '',
-    priceEUR: '',
-    priceMGA: '',
-    type: '' as ExtraPriceType | '',
-  })
-
-  useEffect(() => {
-    fetchExtras()
-  }, [])
-
-  const fetchExtras = async () => {
-    try {
-      const response = await fetch('/api/admin/extras', {
-        cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      })
-      if (response.ok) {
-        const data = await response.json()
-        setExtras(data)
-      } else {
-        toast.error('Erreur lors du chargement des extras')
-      }
-    } catch {
-      toast.error('Erreur lors du chargement des extras')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    if (!formData.name.trim() || !formData.priceEUR || !formData.priceMGA || !formData.type) {
-      toast.error('Tous les champs obligatoires doivent être renseignés')
-      return
-    }
-
-    // Validation des prix
-    const priceEUR = parseFloat(formData.priceEUR)
-    const priceMGA = parseFloat(formData.priceMGA)
-
-    if (isNaN(priceEUR) || priceEUR < 0) {
-      toast.error('Le prix en EUR doit être un nombre positif')
-      return
-    }
-
-    if (isNaN(priceMGA) || priceMGA < 0) {
-      toast.error('Le prix en MGA doit être un nombre positif')
-      return
-    }
-
-    try {
-      const url = editingExtra ? `/api/admin/extras/${editingExtra.id}` : '/api/admin/extras'
-
-      const method = editingExtra ? 'PUT' : 'POST'
-
-      const response = await fetch(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          ...formData,
-          priceEUR,
-          priceMGA,
-        }),
-      })
-
-      if (response.ok) {
-        toast.success(editingExtra ? 'Extra mis à jour avec succès' : 'Extra créé avec succès')
-        setDialogOpen(false)
-        resetForm()
-        fetchExtras()
-      } else {
-        const error = await response.json()
-        toast.error(error.error || 'Une erreur est survenue')
-      }
-    } catch {
-      toast.error('Erreur lors de la sauvegarde')
-    }
-  }
-
-  const handleEdit = (extra: ProductExtra) => {
-    setEditingExtra(extra)
-    setFormData({
-      name: extra.name,
-      description: extra.description || '',
-      priceEUR: extra.priceEUR.toString(),
-      priceMGA: extra.priceMGA.toString(),
-      type: extra.type,
+const adapter: TaxonomyAdapter<ProductExtra, ExtraFormData> = {
+  fetchAll: async () => {
+    const response = await fetch('/api/admin/extras', {
+      cache: 'no-store',
+      headers: { 'Cache-Control': 'no-cache' },
     })
-    setDialogOpen(true)
-  }
-
-  const handleDelete = async (extra: ProductExtra) => {
-    if (!confirm('Êtes-vous sûr de vouloir supprimer cet extra ?')) {
-      return
+    if (!response.ok) throw new Error('Erreur lors du chargement des extras')
+    return response.json()
+  },
+  create: async data => {
+    const response = await fetch('/api/admin/extras', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...data,
+        priceEUR: parseFloat(data.priceEUR),
+        priceMGA: parseFloat(data.priceMGA),
+      }),
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la création')
     }
-
-    try {
-      const response = await fetch(`/api/admin/extras/${extra.id}`, {
-        method: 'DELETE',
-      })
-
-      if (response.ok) {
-        toast.success('Extra supprimé avec succès')
-        fetchExtras()
-      } else {
-        const error = await response.json()
-        toast.error(error.error || 'Erreur lors de la suppression')
-      }
-    } catch {
-      toast.error('Erreur lors de la suppression')
+    return response.json()
+  },
+  update: async (id, data) => {
+    const response = await fetch(`/api/admin/extras/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...data,
+        priceEUR: parseFloat(data.priceEUR),
+        priceMGA: parseFloat(data.priceMGA),
+      }),
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la mise à jour')
     }
-  }
-
-  const resetForm = () => {
-    setFormData({ name: '', description: '', priceEUR: '', priceMGA: '', type: '' })
-    setEditingExtra(null)
-  }
-
-  const handleDialogOpenChange = (open: boolean) => {
-    setDialogOpen(open)
-    if (!open) {
-      resetForm()
+    return response.json()
+  },
+  delete: async id => {
+    const response = await fetch(`/api/admin/extras/${id}`, { method: 'DELETE' })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la suppression')
     }
-  }
+    return true
+  },
+}
 
-  if (loading) {
-    return (
-      <div className='container mx-auto px-4 py-8'>
-        <div className='flex items-center justify-center min-h-[400px]'>
-          <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600'></div>
-        </div>
+const extraColumns: Array<DataTableColumn<ProductExtra>> = [
+  {
+    key: 'price',
+    header: 'Prix',
+    sortable: true,
+    sortAccessor: item => item.priceEUR,
+    align: 'right',
+    render: item => (
+      <div className='space-y-0.5 text-right'>
+        <p className='text-sm font-semibold tabular-nums text-slate-900'>
+          {formatCurrency(item.priceEUR)}
+        </p>
+        <p className='text-xs tabular-nums text-slate-500'>
+          {item.priceMGA.toLocaleString('fr-FR')} Ar
+        </p>
       </div>
-    )
-  }
+    ),
+    cellClassName: 'whitespace-nowrap',
+  },
+  {
+    key: 'type',
+    header: 'Tarification',
+    sortable: true,
+    sortAccessor: item => item.type,
+    render: item => (
+      <span className='inline-flex items-center rounded-full bg-indigo-50 px-2.5 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-indigo-200'>
+        {PRICE_TYPE_LABELS[item.type]}
+      </span>
+    ),
+    cellClassName: 'whitespace-nowrap',
+  },
+]
 
+export default function ExtrasPage() {
   return (
-    <div className='container mx-auto px-4 py-8'>
-      <div className='flex items-center justify-between mb-8'>
-        <div>
-          <h1 className='text-3xl font-bold text-gray-900'>Extras</h1>
-          <p className='text-gray-600 mt-2'>
-            Gérez les options payantes disponibles pour les hébergements
-          </p>
-        </div>
-
-        <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
-          <DialogTrigger asChild>
-            <Button>
-              <Plus className='w-4 h-4 mr-2' />
-              Ajouter un extra
-            </Button>
-          </DialogTrigger>
-          <DialogContent className='max-w-md'>
-            <DialogHeader>
-              <DialogTitle>{editingExtra ? "Modifier l'extra" : 'Ajouter un extra'}</DialogTitle>
-              <DialogDescription>
-                {editingExtra
-                  ? "Modifiez les informations de l'extra"
-                  : 'Créez un nouvel extra payant pour les hébergements'}
-              </DialogDescription>
-            </DialogHeader>
-            <form onSubmit={handleSubmit}>
-              <div className='grid gap-4 py-4'>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='name' className='text-right'>
-                    Nom *
-                  </Label>
-                  <Input
-                    id='name'
-                    value={formData.name}
-                    onChange={e => setFormData({ ...formData, name: e.target.value })}
-                    className='col-span-3'
-                    placeholder='Ex: Petit déjeuner'
-                    required
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='description' className='text-right'>
-                    Description
-                  </Label>
-                  <Input
-                    id='description'
-                    value={formData.description}
-                    onChange={e => setFormData({ ...formData, description: e.target.value })}
-                    className='col-span-3'
-                    placeholder="Description de l'extra (optionnel)"
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='priceEUR' className='text-right'>
-                    Prix EUR *
-                  </Label>
-                  <Input
-                    id='priceEUR'
-                    type='number'
-                    step='0.01'
-                    min='0'
-                    value={formData.priceEUR}
-                    onChange={e => setFormData({ ...formData, priceEUR: e.target.value })}
-                    className='col-span-3'
-                    placeholder='0.00'
-                    required
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='priceMGA' className='text-right'>
-                    Prix MGA *
-                  </Label>
-                  <Input
-                    id='priceMGA'
-                    type='number'
-                    step='1'
-                    min='0'
-                    value={formData.priceMGA}
-                    onChange={e => setFormData({ ...formData, priceMGA: e.target.value })}
-                    className='col-span-3'
-                    placeholder='0'
-                    required
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='type' className='text-right'>
-                    Type *
-                  </Label>
-                  <Select
-                    value={formData.type}
-                    onValueChange={(value: ExtraPriceType) =>
-                      setFormData({ ...formData, type: value })
-                    }
-                    required
-                  >
-                    <SelectTrigger className='col-span-3'>
-                      <SelectValue placeholder='Sélectionner un type' />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Object.entries(PRICE_TYPE_LABELS).map(([value, label]) => (
-                        <SelectItem key={value} value={value}>
-                          {label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-              <DialogFooter>
-                <Button type='submit'>{editingExtra ? 'Mettre à jour' : 'Créer'}</Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
-      </div>
-
-      <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
-        {extras.map(extra => (
-          <Card key={extra.id}>
-            <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-              <div className='flex items-center space-x-2'>
-                <Plus className='w-5 h-5 text-green-600' />
-                <CardTitle className='text-lg'>{extra.name}</CardTitle>
-              </div>
-              <div className='flex space-x-1'>
-                <Button variant='ghost' size='sm' onClick={() => handleEdit(extra)}>
-                  <Edit className='w-4 h-4' />
-                </Button>
-                <Button
-                  variant='ghost'
-                  size='sm'
-                  onClick={() => handleDelete(extra)}
-                  className='text-red-600 hover:text-red-800'
-                >
-                  <Trash2 className='w-4 h-4' />
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent>
-              {extra.description && (
-                <CardDescription className='mb-3'>{extra.description}</CardDescription>
-              )}
-              <div className='space-y-2 mb-3'>
-                <div className='flex justify-between text-sm'>
-                  <span className='font-medium'>Prix EUR:</span>
-                  <span>{extra.priceEUR.toFixed(2)} €</span>
-                </div>
-                <div className='flex justify-between text-sm'>
-                  <span className='font-medium'>Prix MGA:</span>
-                  <span>{extra.priceMGA.toLocaleString()} Ar</span>
-                </div>
-              </div>
-              <div className='flex items-center justify-between'>
-                <Badge variant='secondary'>
-                  {extra._count.products} produit{extra._count.products !== 1 ? 's' : ''}
-                </Badge>
-                <Badge variant='outline'>{PRICE_TYPE_LABELS[extra.type]}</Badge>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      {extras.length === 0 && (
-        <div className='text-center py-12'>
-          <Plus className='w-12 h-12 text-gray-400 mx-auto mb-4' />
-          <h3 className='text-lg font-medium text-gray-900 mb-2'>Aucun extra</h3>
-          <p className='text-gray-500 mb-4'>Commencez par créer votre premier extra payant</p>
-          <Button onClick={() => setDialogOpen(true)}>
-            <Plus className='w-4 h-4 mr-2' />
-            Ajouter un extra
-          </Button>
-        </div>
-      )}
-    </div>
+    <TaxonomyManager<ProductExtra, ExtraFormData>
+      eyebrow='Espace administrateur'
+      eyebrowIcon={Shield}
+      title='Extras payants'
+      subtitle='Gérez les options payantes proposées en supplément sur les hébergements (petit déjeuner, ménage, etc.).'
+      backHref='/admin'
+      backLabel='Retour au panel admin'
+      icon={PlusCircle}
+      kpiTone='orange'
+      itemLabelSingular='extra'
+      itemLabelPlural='extras'
+      searchPlaceholder='Rechercher un extra…'
+      getItemId={item => item.id}
+      getItemName={item => item.name}
+      getItemCount={item => item._count?.products ?? 0}
+      searchMatches={(item, q) =>
+        item.name.toLowerCase().includes(q) ||
+        (item.description?.toLowerCase().includes(q) ?? false)
+      }
+      extraColumns={extraColumns}
+      fields={[
+        {
+          name: 'name',
+          label: 'Nom',
+          type: 'text',
+          required: true,
+          placeholder: 'Ex: Petit déjeuner, Ménage',
+        },
+        {
+          name: 'description',
+          label: 'Description',
+          type: 'textarea',
+          placeholder: "Description de l'extra (optionnel)",
+        },
+        {
+          name: 'priceEUR',
+          label: 'Prix EUR',
+          type: 'number',
+          required: true,
+          step: '0.01',
+          min: '0',
+          placeholder: '0.00',
+        },
+        {
+          name: 'priceMGA',
+          label: 'Prix MGA',
+          type: 'number',
+          required: true,
+          step: '1',
+          min: '0',
+          placeholder: '0',
+        },
+        {
+          name: 'type',
+          label: 'Tarification',
+          type: 'select',
+          required: true,
+          placeholder: 'Sélectionner un type',
+          options: Object.entries(PRICE_TYPE_LABELS).map(([value, label]) => ({
+            value,
+            label,
+          })),
+        },
+      ]}
+      emptyFormData={{
+        name: '',
+        description: '',
+        priceEUR: '',
+        priceMGA: '',
+        type: '',
+      }}
+      toFormData={item => ({
+        name: item.name,
+        description: item.description ?? '',
+        priceEUR: item.priceEUR.toString(),
+        priceMGA: item.priceMGA.toString(),
+        type: item.type,
+      })}
+      validate={data => {
+        if (!data.name.trim()) return 'Le nom est requis'
+        if (!data.type) return 'La tarification est requise'
+        const priceEUR = parseFloat(data.priceEUR)
+        const priceMGA = parseFloat(data.priceMGA)
+        if (isNaN(priceEUR) || priceEUR < 0) {
+          return 'Le prix EUR doit être un nombre positif'
+        }
+        if (isNaN(priceMGA) || priceMGA < 0) {
+          return 'Le prix MGA doit être un nombre positif'
+        }
+        return null
+      }}
+      adapter={adapter}
+    />
   )
 }

--- a/src/app/admin/highlights/page.tsx
+++ b/src/app/admin/highlights/page.tsx
@@ -1,28 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/input'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/shadcnui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import { Plus, Edit, Trash2, Highlighter } from 'lucide-react'
-import { toast } from 'sonner'
+import { Highlighter, Shield } from 'lucide-react'
+import { TaxonomyManager, type TaxonomyAdapter } from '@/components/admin/ui/TaxonomyManager'
+import type { DataTableColumn } from '@/components/admin/ui/DataTable'
 
 interface PropertyHighlight {
   id: string
@@ -36,259 +16,135 @@ interface PropertyHighlight {
   }
 }
 
-export default function HighlightsPage() {
-  const [highlights, setHighlights] = useState<PropertyHighlight[]>([])
-  const [loading, setLoading] = useState(true)
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [editingHighlight, setEditingHighlight] = useState<PropertyHighlight | null>(null)
-  const [formData, setFormData] = useState({
-    name: '',
-    description: '',
-    icon: '',
-  })
+interface HighlightFormData {
+  name: string
+  description: string
+  icon: string
+}
 
-  useEffect(() => {
-    fetchHighlights()
-  }, [])
-
-  const fetchHighlights = async () => {
-    try {
-      const response = await fetch('/api/admin/highlights', {
-        cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      })
-      if (response.ok) {
-        const data = await response.json()
-        setHighlights(data)
-      } else {
-        toast.error('Erreur lors du chargement des points forts')
-      }
-    } catch {
-      toast.error('Erreur lors du chargement des points forts')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    if (!formData.name.trim()) {
-      toast.error('Le nom du point fort est requis')
-      return
-    }
-
-    try {
-      const url = editingHighlight
-        ? `/api/admin/highlights/${editingHighlight.id}`
-        : '/api/admin/highlights'
-
-      const method = editingHighlight ? 'PUT' : 'POST'
-
-      const response = await fetch(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData),
-      })
-
-      if (response.ok) {
-        toast.success(
-          editingHighlight ? 'Point fort mis à jour avec succès' : 'Point fort créé avec succès'
-        )
-        setDialogOpen(false)
-        resetForm()
-        fetchHighlights()
-      } else {
-        const error = await response.json()
-        toast.error(error.error || 'Une erreur est survenue')
-      }
-    } catch {
-      toast.error('Erreur lors de la sauvegarde')
-    }
-  }
-
-  const handleEdit = (highlight: PropertyHighlight) => {
-    setEditingHighlight(highlight)
-    setFormData({
-      name: highlight.name,
-      description: highlight.description || '',
-      icon: highlight.icon || '',
+const adapter: TaxonomyAdapter<PropertyHighlight, HighlightFormData> = {
+  fetchAll: async () => {
+    const response = await fetch('/api/admin/highlights', {
+      cache: 'no-store',
+      headers: { 'Cache-Control': 'no-cache' },
     })
-    setDialogOpen(true)
-  }
-
-  const handleDelete = async (highlight: PropertyHighlight) => {
-    if (!confirm('Êtes-vous sûr de vouloir supprimer ce point fort ?')) {
-      return
+    if (!response.ok) {
+      throw new Error('Erreur lors du chargement des points forts')
     }
-
-    try {
-      const response = await fetch(`/api/admin/highlights/${highlight.id}`, {
-        method: 'DELETE',
-      })
-
-      if (response.ok) {
-        toast.success('Point fort supprimé avec succès')
-        fetchHighlights()
-      } else {
-        const error = await response.json()
-        toast.error(error.error || 'Erreur lors de la suppression')
-      }
-    } catch {
-      toast.error('Erreur lors de la suppression')
+    return response.json()
+  },
+  create: async data => {
+    const response = await fetch('/api/admin/highlights', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la création')
     }
-  }
-
-  const resetForm = () => {
-    setFormData({ name: '', description: '', icon: '' })
-    setEditingHighlight(null)
-  }
-
-  const handleDialogOpenChange = (open: boolean) => {
-    setDialogOpen(open)
-    if (!open) {
-      resetForm()
+    return response.json()
+  },
+  update: async (id, data) => {
+    const response = await fetch(`/api/admin/highlights/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la mise à jour')
     }
-  }
+    return response.json()
+  },
+  delete: async id => {
+    const response = await fetch(`/api/admin/highlights/${id}`, {
+      method: 'DELETE',
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la suppression')
+    }
+    return true
+  },
+}
 
-  if (loading) {
-    return (
-      <div className='container mx-auto px-4 py-8'>
-        <div className='flex items-center justify-center min-h-[400px]'>
-          <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600'></div>
-        </div>
-      </div>
-    )
-  }
+const extraColumns: Array<DataTableColumn<PropertyHighlight>> = [
+  {
+    key: 'description',
+    header: 'Description',
+    render: item => (
+      <p className='line-clamp-2 max-w-md text-sm text-slate-600'>
+        {item.description ?? '—'}
+      </p>
+    ),
+  },
+  {
+    key: 'icon',
+    header: 'Icône',
+    render: item =>
+      item.icon ? (
+        <span className='inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 font-mono text-xs text-slate-600'>
+          {item.icon}
+        </span>
+      ) : (
+        <span className='text-xs text-slate-400'>—</span>
+      ),
+    cellClassName: 'whitespace-nowrap',
+  },
+]
 
+export default function HighlightsPage() {
   return (
-    <div className='container mx-auto px-4 py-8'>
-      <div className='flex items-center justify-between mb-8'>
-        <div>
-          <h1 className='text-3xl font-bold text-gray-900'>Points forts</h1>
-          <p className='text-gray-600 mt-2'>
-            Gérez les points forts disponibles pour valoriser les hébergements
-          </p>
-        </div>
-
-        <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
-          <DialogTrigger asChild>
-            <Button>
-              <Plus className='w-4 h-4 mr-2' />
-              Ajouter un point fort
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                {editingHighlight ? 'Modifier le point fort' : 'Ajouter un point fort'}
-              </DialogTitle>
-              <DialogDescription>
-                {editingHighlight
-                  ? 'Modifiez les informations du point fort'
-                  : 'Créez un nouveau point fort pour valoriser les hébergements'}
-              </DialogDescription>
-            </DialogHeader>
-            <form onSubmit={handleSubmit}>
-              <div className='grid gap-4 py-4'>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='name' className='text-right'>
-                    Nom *
-                  </Label>
-                  <Input
-                    id='name'
-                    value={formData.name}
-                    onChange={e => setFormData({ ...formData, name: e.target.value })}
-                    className='col-span-3'
-                    placeholder='Ex: Spa, Massage, Piscine'
-                    required
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='description' className='text-right'>
-                    Description
-                  </Label>
-                  <Input
-                    id='description'
-                    value={formData.description}
-                    onChange={e => setFormData({ ...formData, description: e.target.value })}
-                    className='col-span-3'
-                    placeholder='Description du point fort (optionnel)'
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='icon' className='text-right'>
-                    Icône
-                  </Label>
-                  <Input
-                    id='icon'
-                    value={formData.icon}
-                    onChange={e => setFormData({ ...formData, icon: e.target.value })}
-                    className='col-span-3'
-                    placeholder="Nom de l'icône Lucide (optionnel)"
-                  />
-                </div>
-              </div>
-              <DialogFooter>
-                <Button type='submit'>{editingHighlight ? 'Mettre à jour' : 'Créer'}</Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
-      </div>
-
-      <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
-        {highlights.map(highlight => (
-          <Card key={highlight.id}>
-            <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-              <div className='flex items-center space-x-2'>
-                <Highlighter className='w-5 h-5 text-yellow-600' />
-                <CardTitle className='text-lg'>{highlight.name}</CardTitle>
-              </div>
-              <div className='flex space-x-1'>
-                <Button variant='ghost' size='sm' onClick={() => handleEdit(highlight)}>
-                  <Edit className='w-4 h-4' />
-                </Button>
-                <Button
-                  variant='ghost'
-                  size='sm'
-                  onClick={() => handleDelete(highlight)}
-                  className='text-red-600 hover:text-red-800'
-                >
-                  <Trash2 className='w-4 h-4' />
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent>
-              {highlight.description && (
-                <CardDescription className='mb-3'>{highlight.description}</CardDescription>
-              )}
-              <div className='flex items-center justify-between'>
-                <Badge variant='secondary'>
-                  {highlight._count.products} produit{highlight._count.products !== 1 ? 's' : ''}
-                </Badge>
-                {highlight.icon && <Badge variant='outline'>Icône: {highlight.icon}</Badge>}
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      {highlights.length === 0 && (
-        <div className='text-center py-12'>
-          <Highlighter className='w-12 h-12 text-gray-400 mx-auto mb-4' />
-          <h3 className='text-lg font-medium text-gray-900 mb-2'>Aucun point fort</h3>
-          <p className='text-gray-500 mb-4'>Commencez par créer votre premier point fort</p>
-          <Button onClick={() => setDialogOpen(true)}>
-            <Plus className='w-4 h-4 mr-2' />
-            Ajouter un point fort
-          </Button>
-        </div>
-      )}
-    </div>
+    <TaxonomyManager<PropertyHighlight, HighlightFormData>
+      eyebrow='Espace administrateur'
+      eyebrowIcon={Shield}
+      title='Points forts'
+      subtitle='Gérez les points forts qui valorisent les hébergements et apparaissent sur les fiches produit.'
+      backHref='/admin'
+      backLabel='Retour au panel admin'
+      icon={Highlighter}
+      kpiTone='amber'
+      itemLabelSingular='point fort'
+      itemLabelPlural='points forts'
+      searchPlaceholder='Rechercher un point fort…'
+      getItemId={item => item.id}
+      getItemName={item => item.name}
+      getItemCount={item => item._count?.products ?? 0}
+      searchMatches={(item, q) =>
+        item.name.toLowerCase().includes(q) ||
+        (item.description?.toLowerCase().includes(q) ?? false)
+      }
+      extraColumns={extraColumns}
+      fields={[
+        {
+          name: 'name',
+          label: 'Nom',
+          type: 'text',
+          required: true,
+          placeholder: 'Ex: Spa, Piscine, Vue panoramique',
+        },
+        {
+          name: 'description',
+          label: 'Description',
+          type: 'textarea',
+          placeholder: 'Description du point fort (optionnel)',
+        },
+        {
+          name: 'icon',
+          label: 'Icône',
+          type: 'text',
+          placeholder: "Nom de l'icône Lucide (optionnel)",
+          help: 'Laisser vide pour utiliser l’icône par défaut.',
+        },
+      ]}
+      emptyFormData={{ name: '', description: '', icon: '' }}
+      toFormData={item => ({
+        name: item.name,
+        description: item.description ?? '',
+        icon: item.icon ?? '',
+      })}
+      adapter={adapter}
+    />
   )
 }

--- a/src/app/admin/homepage/page.tsx
+++ b/src/app/admin/homepage/page.tsx
@@ -55,6 +55,7 @@ export default function HomepageSettingsPage() {
 
   const [heroImage, setHeroImage] = useState<string | null>(null)
   const [howItWorksImage, setHowItWorksImage] = useState<string | null>(null)
+  const [authImage, setAuthImage] = useState<string | null>(null)
 
   useEffect(() => {
     if (isAuthenticated && (!session?.user?.roles || !isAdmin(session.user.roles))) {
@@ -70,6 +71,7 @@ export default function HomepageSettingsPage() {
           const data = await response.json()
           setHeroImage(data.heroBackgroundImage || null)
           setHowItWorksImage(data.howItWorksImage || null)
+          setAuthImage(data.authBackgroundImage || null)
         }
       } catch (err) {
         setError('Erreur lors du chargement des paramètres')
@@ -93,6 +95,7 @@ export default function HomepageSettingsPage() {
         body: JSON.stringify({
           heroBackgroundImage: heroImage,
           howItWorksImage: howItWorksImage,
+          authBackgroundImage: authImage,
         }),
       })
 
@@ -178,7 +181,7 @@ export default function HomepageSettingsPage() {
         )}
 
         {/* Settings Cards */}
-        <div className='grid gap-6 md:grid-cols-2'>
+        <div className='grid gap-6 md:grid-cols-2 lg:grid-cols-3'>
           {/* Hero Section Image */}
           <motion.div variants={itemVariants}>
             <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm h-full'>
@@ -220,6 +223,31 @@ export default function HomepageSettingsPage() {
                   onImageChange={setHowItWorksImage}
                   entityType='homepage'
                   entityId='how-it-works'
+                />
+              </CardContent>
+            </Card>
+          </motion.div>
+
+          {/* Auth Page Left Panel Image */}
+          <motion.div variants={itemVariants}>
+            <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm h-full'>
+              <CardHeader>
+                <CardTitle className='flex items-center gap-2'>
+                  <ImageIcon className='h-5 w-5 text-emerald-600' />
+                  Page d&apos;authentification
+                </CardTitle>
+                <CardDescription>
+                  Image de fond du panneau gauche des pages de connexion, inscription et
+                  réinitialisation (desktop uniquement). Format portrait recommandé. Si aucune image
+                  n&apos;est définie, le dégradé actuel sera affiché.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ImageUpload
+                  currentImage={authImage}
+                  onImageChange={setAuthImage}
+                  entityType='homepage'
+                  entityId='auth-background'
                 />
               </CardContent>
             </Card>

--- a/src/app/admin/included-services/page.tsx
+++ b/src/app/admin/included-services/page.tsx
@@ -1,28 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/input'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/shadcnui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import { Plus, Edit, Trash2, Package } from 'lucide-react'
-import { toast } from 'sonner'
+import { Package, Shield } from 'lucide-react'
+import { TaxonomyManager, type TaxonomyAdapter } from '@/components/admin/ui/TaxonomyManager'
+import type { DataTableColumn } from '@/components/admin/ui/DataTable'
 
 interface IncludedService {
   id: string
@@ -36,259 +16,135 @@ interface IncludedService {
   }
 }
 
-export default function IncludedServicesPage() {
-  const [services, setServices] = useState<IncludedService[]>([])
-  const [loading, setLoading] = useState(true)
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [editingService, setEditingService] = useState<IncludedService | null>(null)
-  const [formData, setFormData] = useState({
-    name: '',
-    description: '',
-    icon: '',
-  })
+interface ServiceFormData {
+  name: string
+  description: string
+  icon: string
+}
 
-  useEffect(() => {
-    fetchServices()
-  }, [])
-
-  const fetchServices = async () => {
-    try {
-      const response = await fetch('/api/admin/included-services', {
-        cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      })
-      if (response.ok) {
-        const data = await response.json()
-        setServices(data)
-      } else {
-        toast.error('Erreur lors du chargement des services')
-      }
-    } catch {
-      toast.error('Erreur lors du chargement des services')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    if (!formData.name.trim()) {
-      toast.error('Le nom du service est requis')
-      return
-    }
-
-    try {
-      const url = editingService
-        ? `/api/admin/included-services/${editingService.id}`
-        : '/api/admin/included-services'
-
-      const method = editingService ? 'PUT' : 'POST'
-
-      const response = await fetch(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData),
-      })
-
-      if (response.ok) {
-        toast.success(
-          editingService ? 'Service mis à jour avec succès' : 'Service créé avec succès'
-        )
-        setDialogOpen(false)
-        resetForm()
-        fetchServices()
-      } else {
-        const error = await response.json()
-        toast.error(error.error || 'Une erreur est survenue')
-      }
-    } catch {
-      toast.error('Erreur lors de la sauvegarde')
-    }
-  }
-
-  const handleEdit = (service: IncludedService) => {
-    setEditingService(service)
-    setFormData({
-      name: service.name,
-      description: service.description || '',
-      icon: service.icon || '',
+const adapter: TaxonomyAdapter<IncludedService, ServiceFormData> = {
+  fetchAll: async () => {
+    const response = await fetch('/api/admin/included-services', {
+      cache: 'no-store',
+      headers: { 'Cache-Control': 'no-cache' },
     })
-    setDialogOpen(true)
-  }
-
-  const handleDelete = async (service: IncludedService) => {
-    if (!confirm('Êtes-vous sûr de vouloir supprimer ce service ?')) {
-      return
+    if (!response.ok) {
+      throw new Error('Erreur lors du chargement des services inclus')
     }
-
-    try {
-      const response = await fetch(`/api/admin/included-services/${service.id}`, {
-        method: 'DELETE',
-      })
-
-      if (response.ok) {
-        toast.success('Service supprimé avec succès')
-        fetchServices()
-      } else {
-        const error = await response.json()
-        toast.error(error.error || 'Erreur lors de la suppression')
-      }
-    } catch {
-      toast.error('Erreur lors de la suppression')
+    return response.json()
+  },
+  create: async data => {
+    const response = await fetch('/api/admin/included-services', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la création')
     }
-  }
-
-  const resetForm = () => {
-    setFormData({ name: '', description: '', icon: '' })
-    setEditingService(null)
-  }
-
-  const handleDialogOpenChange = (open: boolean) => {
-    setDialogOpen(open)
-    if (!open) {
-      resetForm()
+    return response.json()
+  },
+  update: async (id, data) => {
+    const response = await fetch(`/api/admin/included-services/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la mise à jour')
     }
-  }
+    return response.json()
+  },
+  delete: async id => {
+    const response = await fetch(`/api/admin/included-services/${id}`, {
+      method: 'DELETE',
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la suppression')
+    }
+    return true
+  },
+}
 
-  if (loading) {
-    return (
-      <div className='container mx-auto px-4 py-8'>
-        <div className='flex items-center justify-center min-h-[400px]'>
-          <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600'></div>
-        </div>
-      </div>
-    )
-  }
+const extraColumns: Array<DataTableColumn<IncludedService>> = [
+  {
+    key: 'description',
+    header: 'Description',
+    render: item => (
+      <p className='line-clamp-2 max-w-md text-sm text-slate-600'>
+        {item.description ?? '—'}
+      </p>
+    ),
+  },
+  {
+    key: 'icon',
+    header: 'Icône',
+    render: item =>
+      item.icon ? (
+        <span className='inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 font-mono text-xs text-slate-600'>
+          {item.icon}
+        </span>
+      ) : (
+        <span className='text-xs text-slate-400'>—</span>
+      ),
+    cellClassName: 'whitespace-nowrap',
+  },
+]
 
+export default function IncludedServicesPage() {
   return (
-    <div className='container mx-auto px-4 py-8'>
-      <div className='flex items-center justify-between mb-8'>
-        <div>
-          <h1 className='text-3xl font-bold text-gray-900'>Services inclus</h1>
-          <p className='text-gray-600 mt-2'>
-            Gérez les services inclus disponibles pour les hébergements
-          </p>
-        </div>
-
-        <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
-          <DialogTrigger asChild>
-            <Button>
-              <Plus className='w-4 h-4 mr-2' />
-              Ajouter un service
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                {editingService ? 'Modifier le service' : 'Ajouter un service inclus'}
-              </DialogTitle>
-              <DialogDescription>
-                {editingService
-                  ? 'Modifiez les informations du service inclus'
-                  : 'Créez un nouveau service inclus pour les hébergements'}
-              </DialogDescription>
-            </DialogHeader>
-            <form onSubmit={handleSubmit}>
-              <div className='grid gap-4 py-4'>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='name' className='text-right'>
-                    Nom *
-                  </Label>
-                  <Input
-                    id='name'
-                    value={formData.name}
-                    onChange={e => setFormData({ ...formData, name: e.target.value })}
-                    className='col-span-3'
-                    placeholder='Ex: Service de ménage'
-                    required
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='description' className='text-right'>
-                    Description
-                  </Label>
-                  <Input
-                    id='description'
-                    value={formData.description}
-                    onChange={e => setFormData({ ...formData, description: e.target.value })}
-                    className='col-span-3'
-                    placeholder='Description du service (optionnel)'
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='icon' className='text-right'>
-                    Icône
-                  </Label>
-                  <Input
-                    id='icon'
-                    value={formData.icon}
-                    onChange={e => setFormData({ ...formData, icon: e.target.value })}
-                    className='col-span-3'
-                    placeholder="Nom de l'icône Lucide (optionnel)"
-                  />
-                </div>
-              </div>
-              <DialogFooter>
-                <Button type='submit'>{editingService ? 'Mettre à jour' : 'Créer'}</Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
-      </div>
-
-      <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
-        {services.map(service => (
-          <Card key={service.id}>
-            <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-              <div className='flex items-center space-x-2'>
-                <Package className='w-5 h-5 text-blue-600' />
-                <CardTitle className='text-lg'>{service.name}</CardTitle>
-              </div>
-              <div className='flex space-x-1'>
-                <Button variant='ghost' size='sm' onClick={() => handleEdit(service)}>
-                  <Edit className='w-4 h-4' />
-                </Button>
-                <Button
-                  variant='ghost'
-                  size='sm'
-                  onClick={() => handleDelete(service)}
-                  className='text-red-600 hover:text-red-800'
-                >
-                  <Trash2 className='w-4 h-4' />
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent>
-              {service.description && (
-                <CardDescription className='mb-3'>{service.description}</CardDescription>
-              )}
-              <div className='flex items-center justify-between'>
-                <Badge variant='secondary'>
-                  {service._count.products} produit{service._count.products !== 1 ? 's' : ''}
-                </Badge>
-                {service.icon && <Badge variant='outline'>Icône: {service.icon}</Badge>}
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      {services.length === 0 && (
-        <div className='text-center py-12'>
-          <Package className='w-12 h-12 text-gray-400 mx-auto mb-4' />
-          <h3 className='text-lg font-medium text-gray-900 mb-2'>Aucun service inclus</h3>
-          <p className='text-gray-500 mb-4'>Commencez par créer votre premier service inclus</p>
-          <Button onClick={() => setDialogOpen(true)}>
-            <Plus className='w-4 h-4 mr-2' />
-            Ajouter un service
-          </Button>
-        </div>
-      )}
-    </div>
+    <TaxonomyManager<IncludedService, ServiceFormData>
+      eyebrow='Espace administrateur'
+      eyebrowIcon={Shield}
+      title='Services inclus'
+      subtitle='Gérez les services gratuits inclus dans les hébergements (wifi, parking, etc.).'
+      backHref='/admin'
+      backLabel='Retour au panel admin'
+      icon={Package}
+      kpiTone='emerald'
+      itemLabelSingular='service inclus'
+      itemLabelPlural='services inclus'
+      searchPlaceholder='Rechercher un service…'
+      getItemId={item => item.id}
+      getItemName={item => item.name}
+      getItemCount={item => item._count?.products ?? 0}
+      searchMatches={(item, q) =>
+        item.name.toLowerCase().includes(q) ||
+        (item.description?.toLowerCase().includes(q) ?? false)
+      }
+      extraColumns={extraColumns}
+      fields={[
+        {
+          name: 'name',
+          label: 'Nom',
+          type: 'text',
+          required: true,
+          placeholder: 'Ex: Wifi gratuit, Parking, Climatisation',
+        },
+        {
+          name: 'description',
+          label: 'Description',
+          type: 'textarea',
+          placeholder: 'Description du service (optionnel)',
+        },
+        {
+          name: 'icon',
+          label: 'Icône',
+          type: 'text',
+          placeholder: "Nom de l'icône Lucide (optionnel)",
+          help: 'Laisser vide pour utiliser l’icône par défaut.',
+        },
+      ]}
+      emptyFormData={{ name: '', description: '', icon: '' }}
+      toFormData={item => ({
+        name: item.name,
+        description: item.description ?? '',
+        icon: item.icon ?? '',
+      })}
+      adapter={adapter}
+    />
   )
 }

--- a/src/app/admin/meals/page.tsx
+++ b/src/app/admin/meals/page.tsx
@@ -1,510 +1,67 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
-import { useAuth } from '@/hooks/useAuth'
-import { isAdmin } from '@/hooks/useAdminAuth'
-import Link from 'next/link'
-import { motion, Variants } from 'framer-motion'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/shadcnui/input'
-import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
+import { Soup, Shield } from 'lucide-react'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/shadcnui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import {
-  Loader2,
-  Search,
-  Eye,
-  Soup,
-  Plus,
-  ArrowLeft,
-  CheckCircle,
-  Edit3,
-  Trash2,
-} from 'lucide-react'
-import { SecurityInterface } from '@/lib/interface/securityInterface'
+  createMeal,
+  deleteMeal,
+  findAllMeals,
+  updateMeal,
+} from '@/lib/services/meals.service'
 import { MealsInterface } from '@/lib/interface/mealsInterface'
-import { findAllMeals, createMeal, updateMeal, deleteMeal } from '@/lib/services/meals.service'
+import { TaxonomyManager, type TaxonomyAdapter } from '@/components/admin/ui/TaxonomyManager'
 
-const containerVariants: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
-  },
+interface MealFormData {
+  name: string
 }
 
-const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: 'tween' as const,
-      duration: 0.5,
-      ease: 'easeOut',
-    },
+const adapter: TaxonomyAdapter<MealsInterface, MealFormData> = {
+  fetchAll: async () => {
+    const result = await findAllMeals()
+    return result ?? []
+  },
+  create: async data => {
+    const created = await createMeal(data.name)
+    return created ?? null
+  },
+  update: async (id, data) => {
+    const updated = await updateMeal(id, data.name)
+    return updated ?? null
+  },
+  delete: async id => {
+    const success = await deleteMeal(id)
+    return Boolean(success)
   },
 }
 
 export default function MealsPage() {
-  const {
-    session,
-    isLoading: isAuthLoading,
-    isAuthenticated,
-  } = useAuth({ required: true, redirectTo: '/auth' })
-  const router = useRouter()
-  const [meals, setMeals] = useState<MealsInterface[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState('')
-  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
-  const [newOptionName, setNewOptionName] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
-
-  // États pour l'édition
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
-  const [editingOption, setEditingOption] = useState<MealsInterface | null>(null)
-  const [editOptionName, setEditOptionName] = useState('')
-
-  // États pour la suppression
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
-  const [deletingOption, setDeletingOption] = useState<MealsInterface | null>(null)
-
-  useEffect(() => {
-    if (isAuthenticated && (!session?.user?.roles || !isAdmin(session.user.roles))) {
-      router.push('/')
-    }
-  }, [isAuthenticated, session, router])
-
-  useEffect(() => {
-    const fetchMeals = async () => {
-      try {
-        const mealsData = await findAllMeals()
-        if (mealsData) {
-          setMeals(mealsData)
-        }
-      } catch (err) {
-        setError('Erreur lors du chargement des options de repas')
-        console.error(err)
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchMeals()
-  }, [])
-
-  const filteredMeals = meals.filter((option: SecurityInterface) =>
-    option.name?.toLowerCase().includes(searchTerm.toLowerCase())
-  )
-
-  const handleAddOption = async () => {
-    if (!newOptionName.trim()) return
-
-    setIsSubmitting(true)
-    try {
-      const newOption = await createMeal(newOptionName)
-
-      if (newOption) {
-        setMeals([...meals, newOption])
-        setNewOptionName('')
-        setIsAddDialogOpen(false)
-      } else {
-        setError("Erreur lors de la création de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la création:', err)
-      setError("Erreur lors de la création de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleEditOption = (option: MealsInterface) => {
-    setEditingOption(option)
-    setEditOptionName(option.name || '')
-    setIsEditDialogOpen(true)
-  }
-
-  const handleUpdateOption = async () => {
-    if (!editingOption || !editOptionName.trim()) return
-
-    setIsSubmitting(true)
-    try {
-      const updatedOption = await updateMeal(editingOption.id, editOptionName)
-
-      if (updatedOption) {
-        setMeals(meals.map(opt => (opt.id === editingOption.id ? updatedOption : opt)))
-        setEditOptionName('')
-        setEditingOption(null)
-        setIsEditDialogOpen(false)
-      } else {
-        setError("Erreur lors de la modification de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la modification:', err)
-      setError("Erreur lors de la modification de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleDeleteOption = (option: MealsInterface) => {
-    setDeletingOption(option)
-    setIsDeleteDialogOpen(true)
-  }
-
-  const handleConfirmDelete = async () => {
-    if (!deletingOption) return
-
-    setIsSubmitting(true)
-    try {
-      const success = await deleteMeal(deletingOption.id)
-
-      if (success) {
-        setMeals(meals.filter(opt => opt.id !== deletingOption.id))
-        setDeletingOption(null)
-        setIsDeleteDialogOpen(false)
-      } else {
-        setError("Erreur lors de la suppression de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la suppression:', err)
-      setError("Erreur lors de la suppression de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  if (isAuthLoading || loading) {
-    return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
-        </div>
-      </div>
-    )
-  }
-
-  if (!session) {
-    return null
-  }
-
-  if (error) {
-    return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive'>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        </div>
-      </div>
-    )
-  }
-
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
-      <motion.div
-        className='max-w-7xl mx-auto p-6 space-y-8'
-        variants={containerVariants}
-        initial='hidden'
-        animate='visible'
-      >
-        {/* Header with breadcrumb */}
-        <motion.div variants={itemVariants} className='space-y-4'>
-          <Button variant='ghost' size='sm' asChild className='text-slate-600 hover:text-slate-800'>
-            <Link href='/admin' className='flex items-center gap-2'>
-              <ArrowLeft className='h-4 w-4' />
-              Retour au dashboard
-            </Link>
-          </Button>
-
-          <div className='flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4'>
-            <div>
-              <div className='flex items-center gap-2 mb-2'>
-                <Soup className='h-8 w-8 text-orange-600' />
-                <h1 className='text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-800 via-orange-700 to-red-700'>
-                  Gestion des options de repas
-                </h1>
-              </div>
-              <p className='text-slate-600 text-lg'>
-                {meals.length} option{meals.length > 1 ? 's' : ''} enregistrée
-                {meals.length > 1 ? 's' : ''}
-              </p>
-            </div>
-
-            <div className='flex items-center gap-3'>
-              <div className='relative'>
-                <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4' />
-                <Input
-                  type='text'
-                  placeholder='Rechercher une option...'
-                  value={searchTerm}
-                  onChange={e => setSearchTerm(e.target.value)}
-                  className='pl-10 w-full sm:w-64'
-                />
-              </div>
-
-              <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-                <DialogTrigger asChild>
-                  <Button className='bg-orange-600 hover:bg-orange-700 text-white shadow-lg'>
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter une option
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className='sm:max-w-md'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Soup className='h-5 w-5 text-orange-600' />
-                      Nouvelle option de repas
-                    </DialogTitle>
-                    <DialogDescription>
-                      Ajoutez une nouvelle option de repas à la liste disponible.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='optionName'>Nom de l&apos;option</Label>
-                      <Input
-                        id='optionName'
-                        placeholder='Ex: Petit déjeuner, Déjeuner, Dîner...'
-                        value={newOptionName}
-                        onChange={e => setNewOptionName(e.target.value)}
-                        onKeyDown={e => e.key === 'Enter' && !isSubmitting && handleAddOption()}
-                      />
-                    </div>
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsAddDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleAddOption}
-                      disabled={!newOptionName.trim() || isSubmitting}
-                      className='bg-orange-600 hover:bg-orange-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Création...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Créer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Dialog d'édition */}
-              <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Edit3 className='h-5 w-5 text-orange-600' />
-                      Modifier l&apos;option de repas
-                    </DialogTitle>
-                    <DialogDescription>Modifiez le nom de cette option de repas.</DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='editOptionName'>Nom de l&apos;option</Label>
-                      <Input
-                        id='editOptionName'
-                        placeholder='Ex: Petit déjeuner, Dîner...'
-                        value={editOptionName}
-                        onChange={e => setEditOptionName(e.target.value)}
-                        onKeyDown={e => e.key === 'Enter' && !isSubmitting && handleUpdateOption()}
-                      />
-                    </div>
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsEditDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleUpdateOption}
-                      disabled={!editOptionName.trim() || isSubmitting}
-                      className='bg-orange-600 hover:bg-orange-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Modification...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Modifier
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Dialog de suppression */}
-              <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Trash2 className='h-5 w-5 text-red-600' />
-                      Supprimer l&apos;option de repas
-                    </DialogTitle>
-                    <DialogDescription>
-                      Êtes-vous sûr de vouloir supprimer l&apos;option &quot;{deletingOption?.name}
-                      &quot; ? Cette action est irréversible.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsDeleteDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleConfirmDelete}
-                      disabled={isSubmitting}
-                      variant='destructive'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Suppression...
-                        </>
-                      ) : (
-                        <>
-                          <Trash2 className='h-4 w-4 mr-2' />
-                          Supprimer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-            </div>
-          </div>
-        </motion.div>
-
-        {/* Content */}
-        <motion.div variants={itemVariants}>
-          {filteredMeals.length === 0 ? (
-            <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm'>
-              <CardContent className='text-center py-12'>
-                <Soup className='h-16 w-16 text-slate-300 mx-auto mb-4' />
-                <h3 className='text-xl font-semibold text-slate-600 mb-2'>
-                  {searchTerm ? 'Aucun résultat' : 'Aucune option de repas'}
-                </h3>
-                <p className='text-slate-500 mb-6'>
-                  {searchTerm
-                    ? 'Aucune option ne correspond à votre recherche.'
-                    : 'Commencez par ajouter votre première option de repas.'}
-                </p>
-                {!searchTerm && (
-                  <Button
-                    onClick={() => setIsAddDialogOpen(true)}
-                    className='bg-orange-600 hover:bg-orange-700'
-                  >
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter une option
-                  </Button>
-                )}
-              </CardContent>
-            </Card>
-          ) : (
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 items-stretch'>
-              {filteredMeals.map((option, index) => (
-                <motion.div
-                  key={option.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.05 }}
-                >
-                  <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm hover:shadow-xl transition-all duration-300 group h-full'>
-                    <CardHeader className='pb-3'>
-                      <div className='flex items-start justify-between'>
-                        <div className='flex items-center gap-3'>
-                          <div className='p-2 bg-orange-50 rounded-lg group-hover:bg-orange-100 transition-colors'>
-                            <Soup className='h-5 w-5 text-orange-600' />
-                          </div>
-                          <div>
-                            <CardTitle className='text-lg font-semibold text-slate-800'>
-                              {option.name || 'Option sans nom'}
-                            </CardTitle>
-                          </div>
-                        </div>
-                        <Badge
-                          variant='secondary'
-                          className='bg-green-50 text-green-700 border-green-200'
-                        >
-                          Actif
-                        </Badge>
-                      </div>
-                    </CardHeader>
-                    <CardContent className='pt-0'>
-                      <div className='flex items-center gap-2'>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          asChild
-                          className='flex-1 hover:bg-orange-50 hover:text-orange-600'
-                        >
-                          <Link href={`/admin/meals/${option.id}`}>
-                            <Eye className='h-4 w-4 mr-2' />
-                            Voir détails
-                          </Link>
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-orange-50 hover:text-orange-600'
-                          onClick={() => handleEditOption(option)}
-                        >
-                          <Edit3 className='h-4 w-4' />
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-red-50 hover:text-red-600'
-                          onClick={() => handleDeleteOption(option)}
-                        >
-                          <Trash2 className='h-4 w-4' />
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </motion.div>
-              ))}
-            </div>
-          )}
-        </motion.div>
-      </motion.div>
-    </div>
+    <TaxonomyManager<MealsInterface, MealFormData>
+      eyebrow='Espace administrateur'
+      eyebrowIcon={Shield}
+      title='Options de repas'
+      subtitle='Gérez les formules de repas disponibles dans le catalogue (petit-déjeuner, demi-pension, etc.).'
+      backHref='/admin'
+      backLabel='Retour au panel admin'
+      icon={Soup}
+      kpiTone='amber'
+      itemLabelSingular='option de repas'
+      itemLabelPlural='options de repas'
+      searchPlaceholder='Rechercher une option de repas…'
+      getItemId={item => item.id}
+      getItemName={item => item.name ?? ''}
+      searchMatches={(item, q) => (item.name ?? '').toLowerCase().includes(q)}
+      fields={[
+        {
+          name: 'name',
+          label: 'Nom',
+          type: 'text',
+          required: true,
+          placeholder: 'Ex: Petit-déjeuner, Demi-pension, Pension complète',
+        },
+      ]}
+      emptyFormData={{ name: '' }}
+      toFormData={item => ({ name: item.name ?? '' })}
+      adapter={adapter}
+    />
   )
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -5,8 +5,8 @@ import { useEffect, useState } from 'react'
 import { useAuth } from '@/hooks/useAuth'
 import { motion, Variants } from 'framer-motion'
 import { isAdmin, isFullAdmin } from '@/hooks/useAdminAuth'
-import { Separator } from '@/components/ui/shadcnui/separator'
 import {
+  ShieldCheck,
   ClipboardCheck,
   Users,
   BarChart2,
@@ -18,47 +18,59 @@ import {
   Calendar,
   TrendingUp,
   Shield,
-  CheckCircle2,
-  Clock,
   Cctv,
   Soup,
   BrushCleaning,
   Calculator,
   Wallet,
   Image as ImageIcon,
+  Banknote,
+  UserPlus,
+  CalendarCheck,
+  ClipboardList,
+  Loader2,
+  RefreshCw,
 } from 'lucide-react'
-import { StatsOverview } from './components/StatsOverview'
+import { Button } from '@/components/ui/shadcnui/button'
+import { Separator } from '@/components/ui/shadcnui/separator'
 import { ActionCardGroup } from './components/ActionCardGroup'
-import { getAdminStatsYearly } from '@/lib/services/stats.service'
+import {
+  getAdminDashboardStats,
+  type AdminDashboardStats,
+} from '@/lib/services/stats.service'
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard, KpiMetric } from '@/components/admin/ui/KpiCard'
+import { PriorityList } from '@/components/admin/ui/PriorityList'
 
 const containerVariants: Variants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.1,
+      staggerChildren: 0.08,
     },
   },
 }
 
 const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
+  hidden: { opacity: 0, y: 16 },
   visible: {
     opacity: 1,
     y: 0,
     transition: {
-      type: 'spring',
-      stiffness: 100,
-      damping: 15,
+      type: 'tween',
+      duration: 0.4,
+      ease: 'easeOut',
     },
   },
 }
 
-interface Stats {
-  users: number
-  product: number
-  productWaiting: number
-  rent: number
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(amount)
 }
 
 export default function AdminDashboard() {
@@ -68,8 +80,9 @@ export default function AdminDashboard() {
     isAuthenticated,
   } = useAuth({ required: true, redirectTo: '/auth' })
   const router = useRouter()
-  const [stats, setStats] = useState<Stats | null>(null)
+  const [stats, setStats] = useState<AdminDashboardStats | null>(null)
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
 
   useEffect(() => {
     if (isAuthenticated && (!session?.user?.roles || !isAdmin(session.user.roles))) {
@@ -77,80 +90,143 @@ export default function AdminDashboard() {
     }
   }, [isAuthenticated, session, router])
 
-  useEffect(() => {
-    const fetchStats = async () => {
-      try {
-        const data = await getAdminStatsYearly()
-        setStats(data)
-      } catch (error) {
-        console.error('Erreur lors du chargement des statistiques:', error)
-      } finally {
-        setLoading(false)
-      }
+  const fetchStats = async (opts?: { silent?: boolean }) => {
+    const silent = opts?.silent ?? false
+    try {
+      if (silent) setRefreshing(true)
+      else setLoading(true)
+      const data = await getAdminDashboardStats()
+      setStats(data)
+    } catch (error) {
+      console.error('Erreur lors du chargement des statistiques:', error)
+    } finally {
+      if (silent) setRefreshing(false)
+      else setLoading(false)
     }
+  }
 
+  useEffect(() => {
     fetchStats()
   }, [])
 
-  // Quick stats cards for dashboard overview - filtered by role
-  const allQuickStats = [
+  const isAdminFull = isFullAdmin(session?.user?.roles)
+
+  // Hero KPI row — tailored to the user's role
+  const heroKpis = [
     {
-      title: 'Utilisateurs',
-      value: stats?.users || 0,
+      label: 'À valider',
+      value: stats?.productsWaiting ?? 0,
+      hint:
+        (stats?.productsWaiting ?? 0) > 0
+          ? 'annonces en attente d’action'
+          : 'aucune annonce en attente',
+      icon: ClipboardList,
+      tone: 'amber' as const,
+      href: '/admin/validation',
+      show: true,
+    },
+    {
+      label: 'Réservations (mois)',
+      value: stats?.rentsThisMonth ?? 0,
+      hint: 'ce mois-ci',
+      icon: CalendarCheck,
+      tone: 'blue' as const,
+      href: '/admin/reservations',
+      show: isAdminFull,
+    },
+    {
+      label: 'Revenus (mois)',
+      value: formatCurrency(stats?.revenueThisMonth ?? 0),
+      hint: 'volume total encaissé',
+      icon: Banknote,
+      tone: 'emerald' as const,
+      href: '/admin/stats',
+      show: isAdminFull,
+    },
+    {
+      label: 'Nouveaux utilisateurs',
+      value: stats?.newUsersThisWeek ?? 0,
+      hint: 'sur les 7 derniers jours',
+      icon: UserPlus,
+      tone: 'purple' as const,
+      href: '/admin/users',
+      show: isAdminFull,
+    },
+  ].filter(k => k.show)
+
+  // Secondary metrics — context
+  const secondaryMetrics = [
+    {
+      label: 'annonces actives',
+      value: stats?.productsActive ?? 0,
+      icon: Home,
+      tone: 'slate' as const,
+      href: '/admin/products',
+      show: true,
+    },
+    {
+      label: 'utilisateurs au total',
+      value: stats?.usersTotal ?? 0,
       icon: Users,
-      color: 'text-blue-600',
-      bgColor: 'bg-blue-50',
-      adminOnly: true, // Hide from HOST_MANAGER
+      tone: 'slate' as const,
+      href: '/admin/users',
+      show: isAdminFull,
     },
     {
-      title: 'Produits actifs',
-      value: stats?.product || 0,
-      icon: CheckCircle2,
-      color: 'text-green-600',
-      bgColor: 'bg-green-50',
-      adminOnly: false,
-    },
-    {
-      title: 'En attente',
-      value: stats?.productWaiting || 0,
-      icon: Clock,
-      color: 'text-orange-600',
-      bgColor: 'bg-orange-50',
-      adminOnly: false,
-    },
-    {
-      title: 'Locations',
-      value: stats?.rent || 0,
+      label: 'réservations sur l’année',
+      value: stats?.rentsYearly ?? 0,
       icon: Calendar,
-      color: 'text-purple-600',
-      bgColor: 'bg-purple-50',
-      adminOnly: true, // Hide business metrics from HOST_MANAGER
+      tone: 'slate' as const,
+      href: '/admin/reservations',
+      show: isAdminFull,
+    },
+  ].filter(m => m.show)
+
+  // Priority list — only items that actually need action appear
+  const priorities = [
+    {
+      icon: ClipboardCheck,
+      title: 'Annonces à valider',
+      description: 'Nouvelles soumissions et révisions demandées',
+      count: stats?.productsWaitingValidation ?? 0,
+      href: '/admin/validation',
+      tone: 'amber' as const,
+    },
+    {
+      icon: Wallet,
+      title: 'Retraits en attente',
+      description: 'Demandes de retrait des hôtes à traiter',
+      count: stats?.withdrawalsPending ?? 0,
+      href: '/admin/withdrawals',
+      tone: 'purple' as const,
+    },
+    {
+      icon: MessageSquare,
+      title: 'Avis à modérer',
+      description: 'Avis utilisateurs en attente d’approbation',
+      count: stats?.reviewsPendingModeration ?? 0,
+      href: '/admin/reviews',
+      tone: 'blue' as const,
     },
   ]
 
-  // Filter stats based on user role
-  const quickStats = allQuickStats.filter(stat => {
-    if (stat.adminOnly) {
-      return isFullAdmin(session?.user?.roles)
-    }
-    return true
-  })
-
-  // Grouped navigation cards - filtered by role
+  // Grouped navigation cards at the bottom — role-filtered
   const allCardGroups = [
     {
       title: 'Gestion des Contenus',
       description: 'Gérez les annonces, validations et modérations',
       icon: Shield,
+      tone: 'blue' as const,
       cards: [
         {
           title: 'Validation des annonces',
           description: 'Valider les nouvelles annonces',
           icon: ClipboardCheck,
           href: '/admin/validation',
+          tone: 'amber' as const,
           badge:
-            stats?.productWaiting && stats.productWaiting > 0
-              ? `${stats.productWaiting} en attente`
+            stats?.productsWaitingValidation && stats.productsWaitingValidation > 0
+              ? `${stats.productsWaitingValidation} en attente`
               : null,
           badgeVariant: 'destructive' as const,
         },
@@ -159,7 +235,8 @@ export default function AdminDashboard() {
           description: 'Voir et gérer tous les hébergements',
           icon: Home,
           href: '/admin/products',
-          badge: `${stats?.product || 0} actifs`,
+          tone: 'blue' as const,
+          badge: `${stats?.productsActive ?? 0} actifs`,
           badgeVariant: 'secondary' as const,
         },
         {
@@ -167,12 +244,19 @@ export default function AdminDashboard() {
           description: 'Modérer les avis utilisateurs',
           icon: MessageSquare,
           href: '/admin/reviews',
+          tone: 'purple' as const,
+          badge:
+            stats?.reviewsPendingModeration && stats.reviewsPendingModeration > 0
+              ? `${stats.reviewsPendingModeration} à modérer`
+              : null,
+          badgeVariant: 'destructive' as const,
         },
         {
           title: 'Refus de location',
           description: 'Gérer les litiges et refus',
           icon: XCircle,
           href: '/admin/rejections',
+          tone: 'red' as const,
         },
       ],
     },
@@ -180,14 +264,16 @@ export default function AdminDashboard() {
       title: 'Gestion des Utilisateurs',
       description: 'Administration des comptes et rôles',
       icon: Users,
-      adminOnly: true, // Hide from HOST_MANAGER
+      tone: 'indigo' as const,
+      adminOnly: true,
       cards: [
         {
           title: 'Utilisateurs',
           description: 'Gérer les comptes utilisateurs',
           icon: Users,
           href: '/admin/users',
-          badge: `${stats?.users || 0} inscrits`,
+          tone: 'indigo' as const,
+          badge: `${stats?.usersTotal ?? 0} inscrits`,
           badgeVariant: 'secondary' as const,
         },
         {
@@ -195,7 +281,8 @@ export default function AdminDashboard() {
           description: 'Voir toutes les réservations',
           icon: Calendar,
           href: '/admin/reservations',
-          badge: `${stats?.rent || 0} cette année`,
+          tone: 'blue' as const,
+          badge: `${stats?.rentsYearly ?? 0} cette année`,
           badgeVariant: 'secondary' as const,
         },
       ],
@@ -204,158 +291,226 @@ export default function AdminDashboard() {
       title: 'Business & Analytics',
       description: 'Statistiques, paiements et promotions',
       icon: TrendingUp,
-      adminOnly: true, // Hide from HOST_MANAGER
+      tone: 'emerald' as const,
+      adminOnly: true,
       cards: [
         {
           title: 'Statistiques',
           description: 'Analytics et performances',
           icon: BarChart2,
           href: '/admin/stats',
+          tone: 'emerald' as const,
         },
         {
           title: 'Paiements',
           description: 'Gestion des transactions',
           icon: CreditCard,
           href: '/admin/payment',
+          tone: 'emerald' as const,
         },
         {
           title: 'Annonces sponsorisées',
           description: 'Gérer les mises en avant',
           icon: Star,
           href: '/admin/promoted',
+          tone: 'amber' as const,
         },
         {
           title: 'Configuration des commissions',
           description: 'Gérer les taux de commission par type de logement',
           icon: Calculator,
           href: '/admin/commissions',
+          tone: 'slate' as const,
         },
         {
           title: 'Gestion des retraits',
           description: 'Gérer les demandes de retrait des hôtes',
           icon: Wallet,
           href: '/admin/withdrawals',
+          tone: 'purple' as const,
+          badge:
+            stats?.withdrawalsPending && stats.withdrawalsPending > 0
+              ? `${stats.withdrawalsPending} en attente`
+              : null,
+          badgeVariant: 'destructive' as const,
         },
       ],
     },
     {
-      title: 'Gestion des Options',
-      description: 'Configuration des équipements, repas et sécurité',
+      title: 'Configuration & Options',
+      description: 'Taxonomies, équipements, sécurité et homepage',
       icon: Shield,
+      tone: 'slate' as const,
       cards: [
         {
           title: 'Gestion des options de sécurité',
           description: 'Voir et gérer toutes les options de sécurité',
           icon: Cctv,
           href: '/admin/security',
+          tone: 'red' as const,
         },
         {
           title: 'Gestion des options de repas',
           description: 'Voir et gérer toutes les options de repas',
           icon: Soup,
           href: '/admin/meals',
+          tone: 'orange' as const,
         },
         {
           title: "Gestion des options d'équipements",
           description: "Voir et gérer toutes les options d'équipements",
           icon: BrushCleaning,
           href: '/admin/equipments',
+          tone: 'slate' as const,
         },
         {
           title: 'Gestion des types de logements',
           description: 'Voir et gérer tous les types de logements',
           icon: Home,
           href: '/admin/typeRent',
+          tone: 'blue' as const,
         },
         {
           title: "Images de la page d'accueil",
-          description: 'Configurer les images de la homepage',
+          description: 'Configurer les images de la homepage et de l’auth',
           icon: ImageIcon,
           href: '/admin/homepage',
+          tone: 'indigo' as const,
         },
       ],
     },
   ]
 
-  // Filter card groups based on user role
   const cardGroups = allCardGroups.filter(group => {
-    if (group.adminOnly) {
-      return isFullAdmin(session?.user?.roles)
-    }
+    if (group.adminOnly) return isAdminFull
     return true
   })
 
   if (isAuthLoading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
         </div>
       </div>
     )
   }
 
-  if (!session) {
-    return null
-  }
+  if (!session) return null
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
       <motion.div
-        className='max-w-7xl mx-auto p-6 space-y-8'
+        className='mx-auto max-w-7xl space-y-10 p-6'
         variants={containerVariants}
         initial='hidden'
         animate='visible'
       >
-        {/* Header Section */}
-        <motion.div className='text-center space-y-4' variants={itemVariants}>
-          <div className='inline-flex items-center gap-2 px-4 py-2 bg-blue-100 text-blue-700 rounded-full text-sm font-medium'>
-            <Shield className='h-4 w-4' />
-            Panel Administrateur
-          </div>
-          <h1 className='text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-800 via-blue-700 to-indigo-700'>
-            Dashboard Administrateur
-          </h1>
-          <p className='text-slate-600 max-w-2xl mx-auto text-lg'>
-            Gérez efficacement votre plateforme avec une interface claire et organisée
-          </p>
+        {/* Header */}
+        <motion.div variants={itemVariants}>
+          <PageHeader
+            eyebrow='Espace administrateur'
+            eyebrowIcon={ShieldCheck}
+            title='Tableau de bord'
+            subtitle='Une vue d’ensemble de votre plateforme. Les actions urgentes sont mises en avant ci-dessous.'
+            actions={
+              <Button
+                onClick={() => fetchStats({ silent: true })}
+                disabled={refreshing || loading}
+                variant='outline'
+                className='gap-2 border-slate-200 bg-white/80 text-slate-700 shadow-sm hover:bg-slate-50'
+              >
+                {refreshing ? (
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                ) : (
+                  <RefreshCw className='h-4 w-4' />
+                )}
+                {refreshing ? 'Actualisation…' : 'Actualiser'}
+              </Button>
+            }
+          />
         </motion.div>
 
-        {/* Quick Stats Overview */}
-        {!loading && stats && (
-          <motion.div variants={itemVariants}>
-            <StatsOverview stats={quickStats} />
-          </motion.div>
-        )}
-
-        {/* Loading State for Stats */}
-        {loading && (
-          <motion.div variants={itemVariants}>
-            <StatsOverview stats={[]} loading={true} />
-          </motion.div>
-        )}
-
-        {/* Grouped Admin Sections */}
-        <div className='space-y-8'>
-          {cardGroups.map((group, groupIndex) => (
-            <motion.div
-              key={group.title}
-              variants={itemVariants}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: groupIndex * 0.2 }}
-            >
-              <ActionCardGroup
-                title={group.title}
-                description={group.description}
-                icon={group.icon}
-                cards={group.cards ?? []}
+        {/* Hero KPI row */}
+        <motion.div variants={itemVariants}>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {heroKpis.map(kpi => (
+              <KpiCard
+                key={kpi.label}
+                label={kpi.label}
+                value={kpi.value}
+                hint={kpi.hint}
+                icon={kpi.icon}
+                tone={kpi.tone}
+                href={kpi.href}
+                loading={loading}
               />
-              {groupIndex < cardGroups.length - 1 && <Separator className='my-8 bg-slate-200' />}
-            </motion.div>
-          ))}
-        </div>
+            ))}
+          </div>
+        </motion.div>
+
+        {/* Two-column: priorities + secondary metrics */}
+        <motion.div variants={itemVariants}>
+          <div className='grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]'>
+            <PriorityList items={priorities} loading={loading} />
+            <div className='space-y-3'>
+              <h2 className='px-1 text-sm font-semibold uppercase tracking-wide text-slate-500'>
+                Vue d’ensemble
+              </h2>
+              <div className='space-y-3'>
+                {secondaryMetrics.map(m => (
+                  <KpiMetric
+                    key={m.label}
+                    label={m.label}
+                    value={m.value}
+                    icon={m.icon}
+                    tone={m.tone}
+                    href={m.href}
+                    loading={loading}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        </motion.div>
+
+        {/* All admin sections */}
+        <motion.div variants={itemVariants}>
+          <div className='mb-6 flex items-center justify-between'>
+            <h2 className='text-xl font-semibold text-slate-900'>Toutes les sections</h2>
+            <span className='text-sm text-slate-500'>
+              {cardGroups.length} catégorie{cardGroups.length > 1 ? 's' : ''}
+            </span>
+          </div>
+          <div className='space-y-8'>
+            {cardGroups.map((group, groupIndex) => (
+              <div key={group.title}>
+                <ActionCardGroup
+                  title={group.title}
+                  description={group.description}
+                  icon={group.icon}
+                  tone={group.tone}
+                  cards={group.cards ?? []}
+                />
+                {groupIndex < cardGroups.length - 1 && (
+                  <Separator className='my-8 bg-slate-200' />
+                )}
+              </div>
+            ))}
+          </div>
+        </motion.div>
       </motion.div>
     </div>
   )

--- a/src/app/admin/payment/[id]/page.tsx
+++ b/src/app/admin/payment/[id]/page.tsx
@@ -9,6 +9,40 @@ import {
   requestPaymentInfo,
 } from '@/lib/services/payment.service'
 import { PaymentStatus, PaymentMethod, PaymentReqStatus } from '@prisma/client'
+import { formatCurrency } from '@/lib/utils/formatNumber'
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard } from '@/components/admin/ui/KpiCard'
+import { Button } from '@/components/ui/shadcnui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/shadcnui/dialog'
+import {
+  Shield,
+  Banknote,
+  Percent,
+  Coins,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  MessageSquare,
+  Loader2,
+  CreditCard,
+  User as UserIcon,
+  Mail,
+  Home,
+  MapPin,
+  Calendar,
+  History,
+  AlertTriangle,
+  Wallet,
+  FileText,
+  Send,
+} from 'lucide-react'
 
 interface PayRequestDetails {
   id: string
@@ -34,7 +68,6 @@ interface PayRequestDetails {
     checkOut: string
     totalPrice: number
   }
-  // Historique des actions (à implémenter dans le service)
   history?: Array<{
     id: string
     action: string
@@ -49,7 +82,250 @@ interface PayRequestDetails {
 
 type ActionType = 'approve' | 'reject' | 'request_info'
 
-export default function PaymentDetailsPage({ params }: { params: Promise<{ id: string }> }) {
+const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
+  SEPA_VIREMENT: 'Virement SEPA',
+  PRIPEO: 'Pripeo',
+  MOBILE_MONEY: 'Mobile Money',
+  PAYPAL: 'PayPal',
+  MONEYGRAM: 'MoneyGram',
+  TAPTAP: 'Taptap',
+  INTERNATIONAL: 'Virement International',
+  OTHER: 'Autre',
+}
+
+const REQUEST_TYPE_CONFIG: Partial<
+  Record<
+    PaymentStatus,
+    {
+      label: string
+      tone: string
+      icon: React.ComponentType<{ className?: string }>
+    }
+  >
+> = {
+  FULL_TRANSFER_REQ: {
+    label: 'Paiement intégral',
+    tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: Banknote,
+  },
+  MID_TRANSFER_REQ: {
+    label: 'Paiement 50%',
+    tone: 'bg-blue-50 text-blue-700 ring-blue-200',
+    icon: Percent,
+  },
+  REST_TRANSFER_REQ: {
+    label: 'Solde restant',
+    tone: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: Coins,
+  },
+}
+
+const STATUS_CONFIG: Record<
+  PaymentReqStatus,
+  {
+    label: string
+    tone: string
+    icon: React.ComponentType<{ className?: string }>
+  }
+> = {
+  RECEIVED: {
+    label: 'En attente',
+    tone: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: Clock,
+  },
+  DONE: {
+    label: 'Terminée',
+    tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: CheckCircle2,
+  },
+  REFUSED: {
+    label: 'Refusée',
+    tone: 'bg-red-50 text-red-700 ring-red-200',
+    icon: XCircle,
+  },
+}
+
+const ACTION_CONFIG: Record<
+  ActionType,
+  {
+    title: string
+    description: string
+    buttonLabel: string
+    icon: React.ComponentType<{ className?: string }>
+    iconBg: string
+    iconText: string
+    submitButtonClass: string
+  }
+> = {
+  approve: {
+    title: 'Approuver la demande',
+    description:
+      "Le paiement sera approuvé et l'hôte sera notifié par email.",
+    buttonLabel: 'Approuver',
+    icon: CheckCircle2,
+    iconBg: 'bg-emerald-50',
+    iconText: 'text-emerald-600',
+    submitButtonClass: 'bg-emerald-600 hover:bg-emerald-700 text-white',
+  },
+  reject: {
+    title: 'Refuser la demande',
+    description:
+      "Cette action ne peut pas être annulée. L'hôte sera notifié par email.",
+    buttonLabel: 'Refuser',
+    icon: XCircle,
+    iconBg: 'bg-red-50',
+    iconText: 'text-red-600',
+    submitButtonClass: 'bg-red-600 hover:bg-red-700 text-white',
+  },
+  request_info: {
+    title: 'Demander des informations',
+    description:
+      "L'hôte recevra un email avec votre demande d'informations supplémentaires.",
+    buttonLabel: 'Envoyer la demande',
+    icon: MessageSquare,
+    iconBg: 'bg-blue-50',
+    iconText: 'text-blue-600',
+    submitButtonClass: 'bg-blue-600 hover:bg-blue-700 text-white',
+  },
+}
+
+function RequestTypePill({ type }: { type: PaymentStatus }) {
+  const config = REQUEST_TYPE_CONFIG[type]
+  if (!config) {
+    return (
+      <span className='inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200'>
+        {type}
+      </span>
+    )
+  }
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.label}
+    </span>
+  )
+}
+
+function RequestStatusPill({ status }: { status: PaymentReqStatus }) {
+  const config = STATUS_CONFIG[status]
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3.5 w-3.5' />
+      {config.label}
+    </span>
+  )
+}
+
+const INFO_TILE_TONE: Record<
+  'blue' | 'indigo' | 'emerald' | 'amber' | 'red' | 'slate',
+  { bg: string; text: string }
+> = {
+  blue: { bg: 'bg-blue-50', text: 'text-blue-600' },
+  indigo: { bg: 'bg-indigo-50', text: 'text-indigo-600' },
+  emerald: { bg: 'bg-emerald-50', text: 'text-emerald-600' },
+  amber: { bg: 'bg-amber-50', text: 'text-amber-600' },
+  red: { bg: 'bg-red-50', text: 'text-red-600' },
+  slate: { bg: 'bg-slate-100', text: 'text-slate-600' },
+}
+
+function InfoTile({
+  label,
+  value,
+  hint,
+  icon: Icon,
+  tone = 'slate',
+}: {
+  label: string
+  value: string
+  hint?: string
+  icon: React.ComponentType<{ className?: string }>
+  tone?: keyof typeof INFO_TILE_TONE
+}) {
+  const toneClass = INFO_TILE_TONE[tone]
+  return (
+    <div className='rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm'>
+      <div className='flex items-start justify-between gap-4'>
+        <div className='min-w-0 space-y-1'>
+          <p className='text-sm font-medium text-slate-500'>{label}</p>
+          <p
+            className={`text-lg font-semibold leading-tight ${toneClass.text}`}
+          >
+            {value}
+          </p>
+          {hint && <p className='text-xs text-slate-500'>{hint}</p>}
+        </div>
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${toneClass.bg} ${toneClass.text}`}
+        >
+          <Icon className='h-5 w-5' />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SectionCard({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string
+  icon: React.ComponentType<{ className?: string }>
+  children: React.ReactNode
+}) {
+  return (
+    <div className='rounded-2xl border border-slate-200/80 bg-white shadow-sm'>
+      <div className='flex items-center gap-3 border-b border-slate-100 px-6 py-4'>
+        <div className='flex h-9 w-9 items-center justify-center rounded-lg bg-slate-100 text-slate-600'>
+          <Icon className='h-4 w-4' />
+        </div>
+        <h2 className='text-sm font-semibold uppercase tracking-wide text-slate-500'>
+          {title}
+        </h2>
+      </div>
+      <div className='p-6'>{children}</div>
+    </div>
+  )
+}
+
+function InfoRow({
+  label,
+  value,
+}: {
+  label: string
+  value: React.ReactNode
+}) {
+  return (
+    <div>
+      <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+        {label}
+      </p>
+      <div className='mt-1 text-sm text-slate-900'>{value}</div>
+    </div>
+  )
+}
+
+function formatDateTime(dateString: string) {
+  return new Date(dateString).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export default function PaymentDetailsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
   const router = useRouter()
   const resolvedParams = use(params)
   const [payRequest, setPayRequest] = useState<PayRequestDetails | null>(null)
@@ -58,12 +334,11 @@ export default function PaymentDetailsPage({ params }: { params: Promise<{ id: s
   const [showModal, setShowModal] = useState(false)
   const [actionType, setActionType] = useState<ActionType>('approve')
   const [actionNote, setActionNote] = useState('')
+  const [noteError, setNoteError] = useState<string | null>(null)
 
   const fetchPayRequestDetails = useCallback(async () => {
     try {
       setLoading(true)
-      // Pour l'instant, on utilise getAllPaymentRequest et on filtre
-      // TODO: Créer une fonction getPaymentRequestById dans le service
       const result = await getPaymentRequestById(resolvedParams.id)
       setPayRequest(result)
     } catch (error) {
@@ -80,16 +355,31 @@ export default function PaymentDetailsPage({ params }: { params: Promise<{ id: s
   const openModal = (action: ActionType) => {
     setActionType(action)
     setActionNote('')
+    setNoteError(null)
     setShowModal(true)
   }
 
   const closeModal = () => {
+    if (updating) return
     setShowModal(false)
     setActionNote('')
+    setNoteError(null)
   }
 
   const handleAction = async () => {
     if (!payRequest) return
+
+    if (
+      (actionType === 'reject' || actionType === 'request_info') &&
+      !actionNote.trim()
+    ) {
+      setNoteError(
+        actionType === 'reject'
+          ? 'Veuillez fournir une raison pour le refus.'
+          : 'Veuillez spécifier quelles informations sont nécessaires.'
+      )
+      return
+    }
 
     try {
       setUpdating(true)
@@ -97,131 +387,43 @@ export default function PaymentDetailsPage({ params }: { params: Promise<{ id: s
       if (actionType === 'approve') {
         await approvePaymentRequest(payRequest.id)
       } else if (actionType === 'reject') {
-        if (!actionNote.trim()) {
-          alert('Veuillez fournir une raison pour le refus')
-          return
-        }
         await rejectPaymentRequest(payRequest.id, actionNote)
       } else if (actionType === 'request_info') {
-        if (!actionNote.trim()) {
-          alert('Veuillez spécifier quelles informations sont nécessaires')
-          return
-        }
         await requestPaymentInfo(payRequest.id, actionNote)
       }
 
       await fetchPayRequestDetails()
-      closeModal()
+      setShowModal(false)
+      setActionNote('')
+      setNoteError(null)
     } catch (error) {
       console.error("Erreur lors de l'action:", error)
-      alert("Une erreur s'est produite lors du traitement de la demande")
+      setNoteError("Une erreur s'est produite lors du traitement de la demande.")
     } finally {
       setUpdating(false)
     }
   }
 
-  const goBack = () => {
-    router.push('/admin/payment')
-  }
-
-  const getPaymentMethodLabel = (method: PaymentMethod) => {
-    const labels: Record<PaymentMethod, string> = {
-      SEPA_VIREMENT: 'Virement SEPA',
-      PRIPEO: 'Pripeo',
-      MOBILE_MONEY: 'Mobile Money',
-      PAYPAL: 'PayPal',
-      MONEYGRAM: 'MoneyGram',
-      TAPTAP: 'Taptap',
-      INTERNATIONAL: 'Virement International',
-      OTHER: 'Autre',
-    }
-    return labels[method] || method
-  }
-
-  const getPaymentRequestLabel = (type: PaymentStatus) => {
-    const labels: Partial<Record<PaymentStatus, string>> = {
-      FULL_TRANSFER_REQ: 'Paiement intégral',
-      MID_TRANSFER_REQ: 'Paiement de 50%',
-      REST_TRANSFER_REQ: 'Solde restant',
-    }
-    return labels[type] || type
-  }
-
-  const getStatusBadge = (type: PaymentStatus) => {
-    switch (type) {
-      case PaymentStatus.FULL_TRANSFER_REQ:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800'>
-            💰 {getPaymentRequestLabel(type)}
-          </span>
-        )
-      case PaymentStatus.MID_TRANSFER_REQ:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800'>
-            📊 {getPaymentRequestLabel(type)}
-          </span>
-        )
-      case PaymentStatus.REST_TRANSFER_REQ:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-orange-100 text-orange-800'>
-            💳 {getPaymentRequestLabel(type)}
-          </span>
-        )
-      default:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800'>
-            {getPaymentRequestLabel(type)}
-          </span>
-        )
-    }
-  }
-
-  const getRequestStatusBadge = (status: PaymentReqStatus) => {
-    switch (status) {
-      case PaymentReqStatus.RECEIVED:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800'>
-            ⏳ Reçu
-          </span>
-        )
-      case PaymentReqStatus.DONE:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800'>
-            ✅ Terminé
-          </span>
-        )
-      case PaymentReqStatus.REFUSED:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800'>
-            ❌ Refusé
-          </span>
-        )
-      default:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800'>
-            {status}
-          </span>
-        )
-    }
-  }
-
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('fr-FR', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-  }
-
   if (loading) {
     return (
-      <div className='min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6'>
-        <div className='flex items-center justify-center min-h-[calc(100vh-4rem)]'>
-          <div className='text-center'>
-            <div className='animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4'></div>
-            <p className='text-gray-600'>Chargement des détails de la demande...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-6xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='grid gap-6 lg:grid-cols-3'>
+            <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white lg:col-span-2' />
+            <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
           </div>
         </div>
       </div>
@@ -230,485 +432,457 @@ export default function PaymentDetailsPage({ params }: { params: Promise<{ id: s
 
   if (!payRequest) {
     return (
-      <div className='min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6'>
-        <div className='max-w-4xl mx-auto'>
-          <div className='bg-white rounded-xl shadow-sm p-8 text-center'>
-            <div className='text-6xl mb-4'>❌</div>
-            <h2 className='text-xl font-bold text-gray-900 mb-2'>Demande introuvable</h2>
-            <p className='text-gray-600 mt-1'>
-              Cette réservation n&apos;existe pas ou a été supprimée.
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-4xl space-y-8 p-6'>
+          <PageHeader
+            backHref='/admin/payment'
+            backLabel='Retour aux demandes'
+            eyebrow='Espace administrateur'
+            title='Demande introuvable'
+            subtitle='Cette demande de paiement n’existe pas ou a été supprimée.'
+          />
+          <div className='rounded-2xl border border-slate-200/80 bg-white p-12 text-center shadow-sm'>
+            <div className='mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 text-red-600'>
+              <AlertTriangle className='h-8 w-8' />
+            </div>
+            <h2 className='mt-4 text-lg font-bold text-slate-900'>
+              Demande introuvable
+            </h2>
+            <p className='mt-2 text-sm text-slate-500'>
+              Vérifiez l’identifiant de la demande ou revenez à la liste.
             </p>
-            <button
-              onClick={goBack}
-              className='px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors'
+            <Button
+              onClick={() => router.push('/admin/payment')}
+              className='mt-6'
             >
               Retour à la liste
-            </button>
+            </Button>
           </div>
         </div>
       </div>
     )
   }
 
+  const amount = Number(payRequest.prices || 0)
+  const shortId = payRequest.id.slice(-6).toUpperCase()
+  const actionConfig = ACTION_CONFIG[actionType]
+  const ActionIcon = actionConfig.icon
+  const isPending = payRequest.status === PaymentReqStatus.RECEIVED
+
   return (
-    <div className='min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6'>
-      <div className='max-w-6xl mx-auto'>
-        {/* Header */}
-        <div className='mb-8 flex items-center justify-between'>
-          <div className='flex items-center gap-4'>
-            <button
-              onClick={goBack}
-              className='p-2 rounded-lg bg-white shadow-sm hover:shadow-md transition-shadow border border-gray-200'
-            >
-              <svg
-                className='w-5 h-5 text-gray-600'
-                fill='none'
-                stroke='currentColor'
-                viewBox='0 0 24 24'
-              >
-                <path
-                  strokeLinecap='round'
-                  strokeLinejoin='round'
-                  strokeWidth={2}
-                  d='M10 19l-7-7m0 0l7-7m-7 7h18'
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <div className='mx-auto max-w-6xl space-y-8 p-6'>
+        <PageHeader
+          backHref='/admin/payment'
+          backLabel='Retour aux demandes'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title={`Demande #${shortId}`}
+          subtitle='Consultez les détails de la demande de paiement et validez, refusez ou demandez des informations complémentaires.'
+          actions={<RequestStatusPill status={payRequest.status} />}
+        />
+
+        {/* KPI summary row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Montant'
+            value={formatCurrency(amount)}
+            hint='à verser à l’hôte'
+            icon={Wallet}
+            tone='emerald'
+          />
+          <InfoTile
+            label='Type'
+            value={
+              REQUEST_TYPE_CONFIG[payRequest.PaymentRequest]?.label ??
+              payRequest.PaymentRequest
+            }
+            hint='nature du versement'
+            icon={CreditCard}
+            tone='blue'
+          />
+          <InfoTile
+            label='Méthode'
+            value={PAYMENT_METHOD_LABELS[payRequest.method] ?? payRequest.method}
+            hint='canal de paiement'
+            icon={Banknote}
+            tone='indigo'
+          />
+          <InfoTile
+            label='Statut'
+            value={STATUS_CONFIG[payRequest.status].label}
+            hint={isPending ? 'à traiter en priorité' : 'demande clôturée'}
+            icon={STATUS_CONFIG[payRequest.status].icon}
+            tone={
+              payRequest.status === PaymentReqStatus.DONE
+                ? 'emerald'
+                : payRequest.status === PaymentReqStatus.REFUSED
+                  ? 'red'
+                  : 'amber'
+            }
+          />
+        </div>
+
+        {/* Main grid */}
+        <div className='grid gap-6 lg:grid-cols-3'>
+          {/* Left column */}
+          <div className='space-y-6 lg:col-span-2'>
+            {/* Request info */}
+            <SectionCard title='Informations de la demande' icon={FileText}>
+              <div className='grid gap-5 sm:grid-cols-2'>
+                <InfoRow
+                  label='Type de paiement'
+                  value={<RequestTypePill type={payRequest.PaymentRequest} />}
                 />
-              </svg>
-            </button>
-            <div>
-              <h1 className='text-3xl font-bold text-gray-900'>
-                Détails de la demande de paiement
-              </h1>
-              <p className='text-gray-600 mt-1'>
-                Demande #{payRequest.id.slice(0, 8)}... • Date non disponible
-              </p>
-            </div>
-          </div>
-          <div className='flex items-center gap-3'>{getRequestStatusBadge(payRequest.status)}</div>
-        </div>
-
-        {/* Main Content Grid */}
-        <div className='grid grid-cols-1 lg:grid-cols-3 gap-8'>
-          {/* Informations principales */}
-          <div className='lg:col-span-2 space-y-6'>
-            {/* Détails de la demande */}
-            <div className='bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden'>
-              <div className='bg-gradient-to-r from-blue-50 to-indigo-50 px-6 py-4 border-b border-gray-200'>
-                <h2 className='text-lg font-semibold text-gray-900'>Informations de la demande</h2>
-              </div>
-              <div className='p-6 space-y-4'>
-                <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
-                  <div>
-                    <label className='text-sm font-medium text-gray-500'>Type de paiement</label>
-                    <div className='mt-1'>{getStatusBadge(payRequest.PaymentRequest)}</div>
-                  </div>
-                  <div>
-                    <label className='text-sm font-medium text-gray-500'>Montant</label>
-                    <div className='mt-1 text-2xl font-bold text-green-600'>
-                      {Number(payRequest.prices).toLocaleString('fr-FR', {
-                        style: 'currency',
-                        currency: 'EUR',
-                      })}
-                    </div>
-                  </div>
-                  <div>
-                    <label className='text-sm font-medium text-gray-500'>Méthode de paiement</label>
-                    <div className='mt-1 text-gray-900'>
-                      {getPaymentMethodLabel(payRequest.method)}
-                    </div>
-                  </div>
-                  <div>
-                    <label className='text-sm font-medium text-gray-500'>Statut</label>
-                    <div className='mt-1'>{getRequestStatusBadge(payRequest.status)}</div>
-                  </div>
-                </div>
-                {payRequest.notes && (
-                  <div>
-                    <label className='text-sm font-medium text-gray-500'>
-                      Notes de l&apos;hôte
-                    </label>
-                    <div className='mt-1 p-3 bg-gray-50 rounded-lg border'>
-                      <p className='text-gray-900'>{payRequest.notes}</p>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Informations de l'hôte */}
-            <div className='bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden'>
-              <div className='bg-gradient-to-r from-green-50 to-emerald-50 px-6 py-4 border-b border-gray-200'>
-                <h2 className='text-lg font-semibold text-gray-900'>Informations de l&apos;hôte</h2>
-              </div>
-              <div className='p-6'>
-                <div className='flex items-start gap-4'>
-                  <div className='bg-blue-100 p-3 rounded-lg'>
-                    <svg
-                      className='w-6 h-6 text-blue-600'
-                      fill='none'
-                      stroke='currentColor'
-                      viewBox='0 0 24 24'
-                    >
-                      <path
-                        strokeLinecap='round'
-                        strokeLinejoin='round'
-                        strokeWidth={2}
-                        d='M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z'
-                      />
-                    </svg>
-                  </div>
-                  <div className='flex-1'>
-                    <h3 className='text-lg font-semibold text-gray-900'>
-                      {payRequest.user.name || 'Sans nom'}
-                    </h3>
-                    <p className='text-gray-600'>{payRequest.user.email}</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Informations de la réservation */}
-            <div className='bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden'>
-              <div className='bg-gradient-to-r from-purple-50 to-pink-50 px-6 py-4 border-b border-gray-200'>
-                <h2 className='text-lg font-semibold text-gray-900'>Détails de la réservation</h2>
-              </div>
-              <div className='p-6'>
-                <div className='space-y-4'>
-                  <div>
-                    <label className='text-sm font-medium text-gray-500'>Propriété</label>
-                    <div className='mt-1 text-gray-900 font-medium'>
-                      {payRequest.rent.product.name}
-                    </div>
-                    <div className='text-sm text-gray-600'>{payRequest.rent.product.address}</div>
-                  </div>
-                  <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
-                    <div>
-                      <label className='text-sm font-medium text-gray-500'>Check-in</label>
-                      <div className='mt-1 text-gray-900'>
-                        {new Date(payRequest.rent.checkIn).toLocaleDateString('fr-FR')}
-                      </div>
-                    </div>
-                    <div>
-                      <label className='text-sm font-medium text-gray-500'>Check-out</label>
-                      <div className='mt-1 text-gray-900'>
-                        {new Date(payRequest.rent.checkOut).toLocaleDateString('fr-FR')}
-                      </div>
-                    </div>
-                    <div>
-                      <label className='text-sm font-medium text-gray-500'>Prix total</label>
-                      <div className='mt-1 text-gray-900 font-semibold'>
-                        {payRequest.rent.totalPrice.toLocaleString('fr-FR', {
-                          style: 'currency',
-                          currency: 'EUR',
-                        })}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Historique des actions */}
-            <div className='bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden'>
-              <div className='bg-gradient-to-r from-amber-50 to-orange-50 px-6 py-4 border-b border-gray-200'>
-                <h2 className='text-lg font-semibold text-gray-900'>
-                  Historique des modifications
-                </h2>
-              </div>
-              <div className='p-6'>
-                {payRequest.history && payRequest.history.length > 0 ? (
-                  <div className='space-y-4'>
-                    {payRequest.history.map(entry => (
-                      <div
-                        key={entry.id}
-                        className='flex gap-4 pb-4 border-b border-gray-100 last:border-b-0'
-                      >
-                        <div className='bg-blue-100 p-2 rounded-lg h-fit'>
-                          <svg
-                            className='w-4 h-4 text-blue-600'
-                            fill='none'
-                            stroke='currentColor'
-                            viewBox='0 0 24 24'
-                          >
-                            <path
-                              strokeLinecap='round'
-                              strokeLinejoin='round'
-                              strokeWidth={2}
-                              d='M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'
-                            />
-                          </svg>
-                        </div>
-                        <div className='flex-1'>
-                          <div className='flex items-center justify-between'>
-                            <h4 className='font-medium text-gray-900'>{entry.action}</h4>
-                            <span className='text-sm text-gray-500'>
-                              {formatDate(entry.createdAt)}
-                            </span>
-                          </div>
-                          {entry.note && <p className='text-gray-600 mt-1'>{entry.note}</p>}
-                          {entry.adminUser && (
-                            <p className='text-sm text-gray-500 mt-1'>
-                              Par: {entry.adminUser.name || entry.adminUser.email}
-                            </p>
-                          )}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <div className='text-center py-8 text-gray-500'>
-                    <svg
-                      className='w-12 h-12 mx-auto mb-3 text-gray-300'
-                      fill='none'
-                      stroke='currentColor'
-                      viewBox='0 0 24 24'
-                    >
-                      <path
-                        strokeLinecap='round'
-                        strokeLinejoin='round'
-                        strokeWidth={2}
-                        d='M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'
-                      />
-                    </svg>
-                    <p>Aucun historique de modifications disponible</p>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-
-          {/* Actions sidebar */}
-          <div className='space-y-6'>
-            {/* Actions rapides */}
-            <div className='bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden'>
-              <div className='bg-gradient-to-r from-indigo-50 to-blue-50 px-6 py-4 border-b border-gray-200'>
-                <h2 className='text-lg font-semibold text-gray-900'>Actions</h2>
-              </div>
-              <div className='p-6 space-y-3'>
-                {payRequest.status === PaymentReqStatus.RECEIVED && (
-                  <>
-                    <button
-                      onClick={() => openModal('approve')}
-                      disabled={updating}
-                      className='w-full px-4 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2'
-                    >
-                      <span>✅</span>
-                      <span>Approuver la demande</span>
-                    </button>
-                    <button
-                      onClick={() => openModal('reject')}
-                      disabled={updating}
-                      className='w-full px-4 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2'
-                    >
-                      <span>❌</span>
-                      <span>Refuser la demande</span>
-                    </button>
-                    <button
-                      onClick={() => openModal('request_info')}
-                      disabled={updating}
-                      className='w-full px-4 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2'
-                    >
-                      <span>ℹ️</span>
-                      <span>Demander des infos</span>
-                    </button>
-                  </>
-                )}
-                {payRequest.status === PaymentReqStatus.DONE && (
-                  <div className='p-4 bg-green-50 rounded-lg border border-green-200'>
-                    <div className='flex items-center gap-2 text-green-800'>
-                      <span>✅</span>
-                      <span className='font-medium'>Demande approuvée</span>
-                    </div>
-                    <p className='text-sm text-green-700 mt-1'>
-                      Cette demande de paiement a été approuvée et traitée.
-                    </p>
-                  </div>
-                )}
-                {payRequest.status === PaymentReqStatus.REFUSED && (
-                  <div className='p-4 bg-red-50 rounded-lg border border-red-200'>
-                    <div className='flex items-center gap-2 text-red-800'>
-                      <span>❌</span>
-                      <span className='font-medium'>Demande refusée</span>
-                    </div>
-                    <p className='text-sm text-red-700 mt-1'>
-                      Cette demande de paiement a été refusée.
-                    </p>
-                  </div>
-                )}
-                <button
-                  onClick={goBack}
-                  className='w-full px-4 py-3 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors flex items-center justify-center gap-2'
-                >
-                  <span>↩️</span>
-                  <span>Retour à la liste</span>
-                </button>
-              </div>
-            </div>
-
-            {/* Résumé */}
-            <div className='bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden'>
-              <div className='bg-gradient-to-r from-gray-50 to-slate-50 px-6 py-4 border-b border-gray-200'>
-                <h2 className='text-lg font-semibold text-gray-900'>Résumé</h2>
-              </div>
-              <div className='p-6 space-y-3'>
-                <div className='flex justify-between items-center'>
-                  <span className='text-gray-600'>Créé le:</span>
-                  <span className='font-medium text-gray-900'>Non disponible</span>
-                </div>
-                <div className='flex justify-between items-center'>
-                  <span className='text-gray-600'>Modifié le:</span>
-                  <span className='font-medium text-gray-900'>Non disponible</span>
-                </div>
-                <div className='flex justify-between items-center'>
-                  <span className='text-gray-600'>ID demande:</span>
-                  <span className='font-mono text-sm text-gray-900'>
-                    {payRequest.id.slice(0, 8)}...
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Modal pour les actions */}
-        {showModal && (
-          <div className='fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-50'>
-            <div className='bg-white rounded-2xl shadow-2xl max-w-lg w-full border border-gray-100 overflow-hidden transform transition-all'>
-              {/* Header */}
-              <div
-                className={`p-6 ${
-                  actionType === 'approve'
-                    ? 'bg-gradient-to-r from-green-600 to-green-700'
-                    : actionType === 'reject'
-                      ? 'bg-gradient-to-r from-red-600 to-red-700'
-                      : 'bg-gradient-to-r from-blue-600 to-blue-700'
-                }`}
-              >
-                <div className='flex items-center gap-3'>
-                  <div className='bg-white/20 p-3 rounded-xl'>
-                    <span className='text-2xl'>
-                      {actionType === 'reject' && '❌'}
-                      {actionType === 'request_info' && 'ℹ️'}
-                      {actionType === 'approve' && '✅'}
+                <InfoRow
+                  label='Montant'
+                  value={
+                    <span className='text-2xl font-bold tabular-nums text-emerald-600'>
+                      {formatCurrency(amount)}
                     </span>
+                  }
+                />
+                <InfoRow
+                  label='Méthode de paiement'
+                  value={
+                    PAYMENT_METHOD_LABELS[payRequest.method] ?? payRequest.method
+                  }
+                />
+                <InfoRow
+                  label='Statut'
+                  value={<RequestStatusPill status={payRequest.status} />}
+                />
+              </div>
+              {payRequest.notes && (
+                <div className='mt-6'>
+                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                    Notes de l&apos;hôte
+                  </p>
+                  <div className='mt-2 rounded-xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700'>
+                    {payRequest.notes}
                   </div>
-                  <div>
-                    <h3 className='text-xl font-bold text-white'>
-                      {actionType === 'reject' && 'Refuser la demande'}
-                      {actionType === 'request_info' && 'Demander des informations'}
-                      {actionType === 'approve' && 'Approuver la demande'}
-                    </h3>
-                    <p className='text-white/80 text-sm mt-1'>Action sur la demande de paiement</p>
+                </div>
+              )}
+            </SectionCard>
+
+            {/* Host info */}
+            <SectionCard title='Hôte' icon={UserIcon}>
+              <div className='flex items-start gap-4'>
+                <div className='flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-500 text-lg font-bold text-white shadow-sm'>
+                  {(payRequest.user.name || payRequest.user.email)
+                    .charAt(0)
+                    .toUpperCase()}
+                </div>
+                <div className='min-w-0 flex-1'>
+                  <p className='text-base font-semibold text-slate-900'>
+                    {payRequest.user.name || 'Sans nom'}
+                  </p>
+                  <div className='mt-1 flex items-center gap-1.5 text-sm text-slate-600'>
+                    <Mail className='h-3.5 w-3.5 text-slate-400' />
+                    <a
+                      href={`mailto:${payRequest.user.email}`}
+                      className='hover:text-blue-600'
+                    >
+                      {payRequest.user.email}
+                    </a>
                   </div>
                 </div>
               </div>
+            </SectionCard>
 
-              {/* Contenu */}
-              <div className='p-6'>
-                {/* Champ de saisie pour les actions nécessitant une note */}
-                {(actionType === 'reject' || actionType === 'request_info') && (
-                  <div className='mb-6'>
-                    <label className='block text-sm font-semibold text-gray-700 mb-3'>
-                      {actionType === 'reject' ? 'Raison du refus:' : 'Informations demandées:'}
-                    </label>
-                    <textarea
-                      value={actionNote}
-                      onChange={e => setActionNote(e.target.value)}
-                      className='w-full p-4 border-2 border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 resize-none bg-gray-50 focus:bg-white'
-                      rows={4}
-                      placeholder={
-                        actionType === 'reject'
-                          ? 'Expliquez clairement pourquoi cette demande est refusée...'
-                          : 'Spécifiez quelles informations supplémentaires sont nécessaires...'
-                      }
-                    />
-                  </div>
-                )}
-
-                {/* Alerte d'information */}
-                <div
-                  className={`mb-6 p-4 rounded-xl border-l-4 ${
-                    actionType === 'approve'
-                      ? 'bg-green-50 border-green-400'
-                      : actionType === 'reject'
-                        ? 'bg-red-50 border-red-400'
-                        : 'bg-blue-50 border-blue-400'
-                  }`}
-                >
-                  <p
-                    className={`text-sm ${
-                      actionType === 'approve'
-                        ? 'text-green-700'
-                        : actionType === 'reject'
-                          ? 'text-red-700'
-                          : 'text-blue-700'
-                    }`}
-                  >
-                    {actionType === 'approve' &&
-                      'Le paiement sera approuvé et l&apos;utilisateur sera notifié par email.'}
-                    {actionType === 'reject' &&
-                      'Cette action ne peut pas être annulée. L&apos;utilisateur sera notifié par email.'}
-                    {actionType === 'request_info' &&
-                      'L&apos;utilisateur recevra un email avec votre demande d&apos;informations supplémentaires.'}
+            {/* Reservation info */}
+            <SectionCard title='Réservation associée' icon={Home}>
+              <div className='space-y-5'>
+                <div>
+                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                    Hébergement
+                  </p>
+                  <p className='mt-1 text-base font-semibold text-slate-900'>
+                    {payRequest.rent.product.name}
+                  </p>
+                  <p className='mt-1 flex items-center gap-1.5 text-sm text-slate-500'>
+                    <MapPin className='h-3.5 w-3.5' />
+                    {payRequest.rent.product.address}
                   </p>
                 </div>
+                <div className='grid gap-4 sm:grid-cols-3'>
+                  <div className='rounded-xl bg-slate-50 p-3'>
+                    <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                      Arrivée
+                    </p>
+                    <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                      <Calendar className='h-4 w-4 text-blue-600' />
+                      {new Date(payRequest.rent.checkIn).toLocaleDateString(
+                        'fr-FR',
+                        { day: '2-digit', month: 'short', year: 'numeric' }
+                      )}
+                    </p>
+                  </div>
+                  <div className='rounded-xl bg-slate-50 p-3'>
+                    <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                      Départ
+                    </p>
+                    <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                      <Calendar className='h-4 w-4 text-blue-600' />
+                      {new Date(payRequest.rent.checkOut).toLocaleDateString(
+                        'fr-FR',
+                        { day: '2-digit', month: 'short', year: 'numeric' }
+                      )}
+                    </p>
+                  </div>
+                  <div className='rounded-xl bg-slate-50 p-3'>
+                    <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                      Prix total
+                    </p>
+                    <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                      <Wallet className='h-4 w-4 text-emerald-600' />
+                      {formatCurrency(payRequest.rent.totalPrice)}
+                    </p>
+                  </div>
+                </div>
               </div>
+            </SectionCard>
 
-              {/* Footer */}
-              <div className='bg-gray-50 px-6 py-4 flex justify-end space-x-3'>
-                <button
-                  onClick={closeModal}
-                  className='px-6 py-2.5 text-gray-600 hover:text-gray-800 font-medium rounded-xl hover:bg-gray-100 transition-all duration-200 border border-gray-200'
-                >
-                  Annuler
-                </button>
-                <button
-                  onClick={handleAction}
-                  disabled={updating}
-                  className={`px-6 py-2.5 text-white font-medium rounded-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 shadow-lg hover:shadow-xl ${
-                    actionType === 'approve'
-                      ? 'bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800'
-                      : actionType === 'reject'
-                        ? 'bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800'
-                        : 'bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800'
-                  }`}
-                >
-                  {updating ? (
-                    <>
-                      <svg
-                        className='w-4 h-4 animate-spin'
-                        fill='none'
-                        stroke='currentColor'
-                        viewBox='0 0 24 24'
-                      >
-                        <path
-                          strokeLinecap='round'
-                          strokeLinejoin='round'
-                          strokeWidth={2}
-                          d='M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15'
-                        />
-                      </svg>
-                      Traitement...
-                    </>
-                  ) : (
-                    <>
-                      <span>
-                        {actionType === 'approve' && '✅'}
-                        {actionType === 'reject' && '❌'}
-                        {actionType === 'request_info' && '📤'}
-                      </span>
-                      {actionType === 'approve'
-                        ? 'Approuver'
-                        : actionType === 'reject'
-                          ? 'Refuser'
-                          : 'Envoyer la demande'}
-                    </>
-                  )}
-                </button>
+            {/* History */}
+            <SectionCard title='Historique des modifications' icon={History}>
+              {payRequest.history && payRequest.history.length > 0 ? (
+                <ul className='space-y-4'>
+                  {payRequest.history.map(entry => (
+                    <li
+                      key={entry.id}
+                      className='flex gap-4 border-b border-slate-100 pb-4 last:border-b-0 last:pb-0'
+                    >
+                      <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600'>
+                        <Clock className='h-4 w-4' />
+                      </div>
+                      <div className='min-w-0 flex-1'>
+                        <div className='flex items-start justify-between gap-3'>
+                          <p className='text-sm font-semibold text-slate-900'>
+                            {entry.action}
+                          </p>
+                          <span className='shrink-0 text-xs text-slate-500'>
+                            {formatDateTime(entry.createdAt)}
+                          </span>
+                        </div>
+                        {entry.note && (
+                          <p className='mt-1 text-sm text-slate-600'>
+                            {entry.note}
+                          </p>
+                        )}
+                        {entry.adminUser && (
+                          <p className='mt-1 text-xs text-slate-500'>
+                            Par {entry.adminUser.name || entry.adminUser.email}
+                          </p>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <div className='flex flex-col items-center justify-center py-8 text-center'>
+                  <div className='flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100 text-slate-400'>
+                    <History className='h-6 w-6' />
+                  </div>
+                  <p className='mt-3 text-sm text-slate-500'>
+                    Aucun historique disponible pour le moment
+                  </p>
+                </div>
+              )}
+            </SectionCard>
+          </div>
+
+          {/* Right column — actions + summary */}
+          <div className='space-y-6'>
+            <SectionCard title='Actions' icon={CheckCircle2}>
+              {isPending ? (
+                <div className='space-y-3'>
+                  <Button
+                    onClick={() => openModal('approve')}
+                    disabled={updating}
+                    className='w-full justify-center gap-2 bg-emerald-600 text-white hover:bg-emerald-700'
+                  >
+                    <CheckCircle2 className='h-4 w-4' />
+                    Approuver la demande
+                  </Button>
+                  <Button
+                    onClick={() => openModal('reject')}
+                    disabled={updating}
+                    variant='outline'
+                    className='w-full justify-center gap-2 border-red-200 text-red-700 hover:bg-red-50'
+                  >
+                    <XCircle className='h-4 w-4' />
+                    Refuser la demande
+                  </Button>
+                  <Button
+                    onClick={() => openModal('request_info')}
+                    disabled={updating}
+                    variant='outline'
+                    className='w-full justify-center gap-2 border-blue-200 text-blue-700 hover:bg-blue-50'
+                  >
+                    <MessageSquare className='h-4 w-4' />
+                    Demander des infos
+                  </Button>
+                </div>
+              ) : payRequest.status === PaymentReqStatus.DONE ? (
+                <div className='rounded-xl border border-emerald-200 bg-emerald-50/60 p-4'>
+                  <div className='flex items-center gap-2 text-emerald-800'>
+                    <CheckCircle2 className='h-4 w-4' />
+                    <span className='text-sm font-semibold'>
+                      Demande approuvée
+                    </span>
+                  </div>
+                  <p className='mt-1 text-xs text-emerald-700'>
+                    Cette demande de paiement a été approuvée et traitée.
+                  </p>
+                </div>
+              ) : (
+                <div className='rounded-xl border border-red-200 bg-red-50/60 p-4'>
+                  <div className='flex items-center gap-2 text-red-800'>
+                    <XCircle className='h-4 w-4' />
+                    <span className='text-sm font-semibold'>Demande refusée</span>
+                  </div>
+                  <p className='mt-1 text-xs text-red-700'>
+                    Cette demande de paiement a été refusée.
+                  </p>
+                </div>
+              )}
+            </SectionCard>
+
+            <SectionCard title='Résumé' icon={FileText}>
+              <dl className='space-y-3 text-sm'>
+                <div className='flex items-center justify-between'>
+                  <dt className='text-slate-500'>ID demande</dt>
+                  <dd className='font-mono text-xs text-slate-900'>
+                    #{shortId}
+                  </dd>
+                </div>
+                <div className='flex items-center justify-between'>
+                  <dt className='text-slate-500'>Créée le</dt>
+                  <dd className='font-medium text-slate-900'>
+                    {payRequest.createdAt
+                      ? formatDateTime(payRequest.createdAt)
+                      : '—'}
+                  </dd>
+                </div>
+                <div className='flex items-center justify-between'>
+                  <dt className='text-slate-500'>Mise à jour</dt>
+                  <dd className='font-medium text-slate-900'>
+                    {payRequest.updatedAt
+                      ? formatDateTime(payRequest.updatedAt)
+                      : '—'}
+                  </dd>
+                </div>
+              </dl>
+            </SectionCard>
+          </div>
+        </div>
+      </div>
+
+      {/* Action modal */}
+      <Dialog open={showModal} onOpenChange={open => !open && closeModal()}>
+        <DialogContent className='sm:max-w-[520px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div
+                className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl ring-1 ring-slate-100 ${actionConfig.iconBg} ${actionConfig.iconText}`}
+              >
+                <ActionIcon className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>
+                  {actionConfig.title}
+                </DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  {actionConfig.description}
+                </DialogDescription>
               </div>
             </div>
+          </DialogHeader>
+
+          <div className='space-y-4 py-2'>
+            {/* Amount recap */}
+            <div className='flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50/60 px-4 py-3'>
+              <div className='min-w-0'>
+                <p className='truncate text-sm font-semibold text-slate-900'>
+                  {payRequest.user.name || payRequest.user.email}
+                </p>
+                <p className='truncate text-xs text-slate-500'>
+                  {payRequest.rent.product.name}
+                </p>
+              </div>
+              <p className='shrink-0 text-lg font-bold tabular-nums text-slate-900'>
+                {formatCurrency(amount)}
+              </p>
+            </div>
+
+            {/* Note textarea for reject / request_info */}
+            {(actionType === 'reject' || actionType === 'request_info') && (
+              <div>
+                <label
+                  htmlFor='action-note'
+                  className='mb-2 block text-sm font-semibold text-slate-700'
+                >
+                  {actionType === 'reject'
+                    ? 'Raison du refus'
+                    : 'Informations demandées'}
+                </label>
+                <textarea
+                  id='action-note'
+                  value={actionNote}
+                  onChange={e => {
+                    setActionNote(e.target.value)
+                    if (noteError) setNoteError(null)
+                  }}
+                  rows={4}
+                  placeholder={
+                    actionType === 'reject'
+                      ? 'Expliquez clairement pourquoi cette demande est refusée…'
+                      : 'Spécifiez quelles informations supplémentaires sont nécessaires…'
+                  }
+                  className='w-full resize-none rounded-xl border border-slate-200 bg-white p-3 text-sm text-slate-900 outline-none ring-offset-0 transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20'
+                />
+                {noteError && (
+                  <p className='mt-2 flex items-center gap-1.5 text-xs font-medium text-red-600'>
+                    <AlertTriangle className='h-3.5 w-3.5' />
+                    {noteError}
+                  </p>
+                )}
+              </div>
+            )}
           </div>
-        )}
-      </div>
+
+          <DialogFooter className='gap-2'>
+            <Button
+              variant='outline'
+              onClick={closeModal}
+              disabled={updating}
+            >
+              Annuler
+            </Button>
+            <Button
+              onClick={handleAction}
+              disabled={updating}
+              className={`gap-2 ${actionConfig.submitButtonClass}`}
+            >
+              {updating ? (
+                <>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Traitement…
+                </>
+              ) : (
+                <>
+                  {actionType === 'request_info' ? (
+                    <Send className='h-4 w-4' />
+                  ) : (
+                    <ActionIcon className='h-4 w-4' />
+                  )}
+                  {actionConfig.buttonLabel}
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/src/app/admin/payment/page.tsx
+++ b/src/app/admin/payment/page.tsx
@@ -1,12 +1,36 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
+import { motion } from 'framer-motion'
 import { useAuth } from '@/hooks/useAuth'
 import { isFullAdmin } from '@/hooks/useAdminAuth'
 import { getAllPaymentRequest } from '@/lib/services/payment.service'
-import { PaymentStatus, PaymentMethod, PaymentReqStatus } from '@prisma/client'
+import { PaymentStatus, PaymentReqStatus } from '@prisma/client'
 import { formatCurrency } from '@/lib/utils/formatNumber'
+import { Button } from '@/components/ui/shadcnui/button'
+import {
+  Banknote,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  TrendingUp,
+  Wallet,
+  Shield,
+  Eye,
+  CreditCard,
+  Percent,
+  Coins,
+} from 'lucide-react'
+
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard } from '@/components/admin/ui/KpiCard'
+import { FilterBar } from '@/components/admin/ui/FilterBar'
+import {
+  DataTable,
+  type DataTableColumn,
+  type DataTableSort,
+} from '@/components/admin/ui/DataTable'
 
 interface PayRequest {
   id: string
@@ -14,7 +38,7 @@ interface PayRequest {
   PaymentRequest: PaymentStatus
   prices: string
   notes: string
-  method: PaymentMethod
+  method: string
   status: PaymentReqStatus
   user: {
     name: string | null
@@ -27,6 +51,91 @@ interface PayRequest {
   }
 }
 
+const REQUEST_TYPE_CONFIG: Partial<
+  Record<PaymentStatus, { label: string; tone: string; icon: React.ComponentType<{ className?: string }> }>
+> = {
+  FULL_TRANSFER_REQ: {
+    label: 'Paiement intégral',
+    tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: Banknote,
+  },
+  MID_TRANSFER_REQ: {
+    label: 'Paiement 50%',
+    tone: 'bg-blue-50 text-blue-700 ring-blue-200',
+    icon: Percent,
+  },
+  REST_TRANSFER_REQ: {
+    label: 'Solde restant',
+    tone: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: Coins,
+  },
+}
+
+const STATUS_CONFIG: Record<
+  PaymentReqStatus,
+  { label: string; tone: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  RECEIVED: {
+    label: 'En attente',
+    tone: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: Clock,
+  },
+  DONE: {
+    label: 'Terminé',
+    tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: CheckCircle2,
+  },
+  REFUSED: {
+    label: 'Refusé',
+    tone: 'bg-red-50 text-red-700 ring-red-200',
+    icon: XCircle,
+  },
+}
+
+const STATUS_FILTERS: Array<{
+  value: PaymentReqStatus | 'ALL'
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}> = [
+  { value: 'ALL', label: 'Toutes', icon: Wallet },
+  { value: PaymentReqStatus.RECEIVED, label: 'En attente', icon: Clock },
+  { value: PaymentReqStatus.DONE, label: 'Terminées', icon: CheckCircle2 },
+  { value: PaymentReqStatus.REFUSED, label: 'Refusées', icon: XCircle },
+]
+
+function RequestTypePill({ type }: { type: PaymentStatus }) {
+  const config = REQUEST_TYPE_CONFIG[type]
+  if (!config) {
+    return (
+      <span className='inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200'>
+        {type}
+      </span>
+    )
+  }
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.label}
+    </span>
+  )
+}
+
+function RequestStatusPill({ status }: { status: PaymentReqStatus }) {
+  const config = STATUS_CONFIG[status]
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.label}
+    </span>
+  )
+}
+
 export default function PaymentAdminPage() {
   const {
     session,
@@ -34,12 +143,13 @@ export default function PaymentAdminPage() {
     isAuthenticated,
   } = useAuth({ required: true, redirectTo: '/auth' })
   const router = useRouter()
+
   const [payRequests, setPayRequests] = useState<PayRequest[]>([])
-  const [filteredRequests, setFilteredRequests] = useState<PayRequest[]>([])
   const [loading, setLoading] = useState(true)
   const [statusFilter, setStatusFilter] = useState<PaymentReqStatus | 'ALL'>('ALL')
+  const [searchValue, setSearchValue] = useState('')
+  const [sort, setSort] = useState<DataTableSort | null>({ key: 'amount', direction: 'desc' })
 
-  // Security check - Only ADMIN can access payment management
   useEffect(() => {
     if (isAuthenticated && (!session?.user?.roles || !isFullAdmin(session.user.roles))) {
       router.push('/')
@@ -47,302 +157,262 @@ export default function PaymentAdminPage() {
   }, [isAuthenticated, session, router])
 
   useEffect(() => {
+    const fetchPayRequests = async () => {
+      try {
+        const result = await getAllPaymentRequest()
+        setPayRequests(result.payRequest)
+      } catch (error) {
+        console.error('Erreur lors du chargement des demandes de paiement:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
     fetchPayRequests()
   }, [])
-
-  useEffect(() => {
-    // Filtrer les demandes selon le statut sélectionné
-    if (statusFilter === 'ALL') {
-      setFilteredRequests(payRequests)
-    } else {
-      setFilteredRequests(payRequests.filter(req => req.status === statusFilter))
-    }
-  }, [payRequests, statusFilter])
-
-  const fetchPayRequests = async () => {
-    try {
-      console.log('Fetching payment requests...')
-      const result = await getAllPaymentRequest()
-      console.log('Payment requests result:', result)
-      setPayRequests(result.payRequest)
-    } catch (error) {
-      console.error('Erreur lors du chargement des demandes de paiement:', error)
-    } finally {
-      setLoading(false)
-    }
-  }
 
   const handleViewDetails = (requestId: string) => {
     router.push(`/admin/payment/${requestId}`)
   }
 
-  const getPaymentRequestLabel = (type: PaymentStatus) => {
-    const labels: Partial<Record<PaymentStatus, string>> = {
-      FULL_TRANSFER_REQ: 'Paiement intégral',
-      MID_TRANSFER_REQ: 'Paiement de 50%',
-      REST_TRANSFER_REQ: 'Solde restant',
+  const filteredRequests = useMemo(() => {
+    let rows = payRequests
+    if (statusFilter !== 'ALL') {
+      rows = rows.filter(r => r.status === statusFilter)
     }
-    return labels[type] || type
-  }
+    if (searchValue.trim()) {
+      const q = searchValue.toLowerCase()
+      rows = rows.filter(
+        r =>
+          r.user.name?.toLowerCase().includes(q) ||
+          r.user.email.toLowerCase().includes(q) ||
+          r.rent?.product?.name?.toLowerCase().includes(q)
+      )
+    }
+    return rows
+  }, [payRequests, statusFilter, searchValue])
 
-  const getStatusBadge = (type: PaymentStatus) => {
-    switch (type) {
-      case PaymentStatus.FULL_TRANSFER_REQ:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800'>
-            💰 {getPaymentRequestLabel(type)}
-          </span>
-        )
-      case PaymentStatus.MID_TRANSFER_REQ:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800'>
-            📊 {getPaymentRequestLabel(type)}
-          </span>
-        )
-      case PaymentStatus.REST_TRANSFER_REQ:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800'>
-            💳 {getPaymentRequestLabel(type)}
-          </span>
-        )
-      default:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800'>
-            {getPaymentRequestLabel(type)}
-          </span>
-        )
-    }
-  }
+  const stats = useMemo(() => {
+    const total = payRequests.length
+    const pending = payRequests.filter(r => r.status === PaymentReqStatus.RECEIVED).length
+    const done = payRequests.filter(r => r.status === PaymentReqStatus.DONE).length
+    const refused = payRequests.filter(r => r.status === PaymentReqStatus.REFUSED).length
 
-  const getRequestStatusBadge = (status: PaymentReqStatus) => {
-    switch (status) {
-      case PaymentReqStatus.RECEIVED:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800'>
-            ⏳ Reçu
-          </span>
-        )
-      case PaymentReqStatus.DONE:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800'>
-            ✅ Terminé
-          </span>
-        )
-      case PaymentReqStatus.REFUSED:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800'>
-            ❌ Refusé
-          </span>
-        )
-      default:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800'>
-            {status}
-          </span>
-        )
-    }
-  }
+    const totalAmount = payRequests
+      .filter(r => r.status !== PaymentReqStatus.REFUSED)
+      .reduce((sum, r) => sum + Number(r.prices || 0), 0)
+    const pendingAmount = payRequests
+      .filter(r => r.status === PaymentReqStatus.RECEIVED)
+      .reduce((sum, r) => sum + Number(r.prices || 0), 0)
+
+    return { total, pending, done, refused, totalAmount, pendingAmount }
+  }, [payRequests])
+
+  const columns: DataTableColumn<PayRequest>[] = [
+    {
+      key: 'type',
+      header: 'Type',
+      render: r => (
+        <div className='space-y-1'>
+          <RequestTypePill type={r.PaymentRequest} />
+          {r.notes && (
+            <p className='line-clamp-1 text-xs text-slate-500' title={r.notes}>
+              {r.notes}
+            </p>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'amount',
+      header: 'Montant',
+      sortable: true,
+      sortAccessor: r => Number(r.prices || 0),
+      align: 'right',
+      render: r => (
+        <p className='text-sm font-bold tabular-nums text-slate-900'>
+          {formatCurrency(Number(r.prices || 0))}
+        </p>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'host',
+      header: 'Hôte',
+      sortable: true,
+      sortAccessor: r => (r.user.name || r.user.email).toLowerCase(),
+      render: r => (
+        <div className='min-w-0'>
+          <p className='truncate text-sm font-semibold text-slate-900'>
+            {r.user.name || 'Sans nom'}
+          </p>
+          <p className='truncate text-xs text-slate-500'>{r.user.email}</p>
+        </div>
+      ),
+    },
+    {
+      key: 'product',
+      header: 'Hébergement',
+      render: r => (
+        <p className='truncate text-sm text-slate-700' title={r.rent?.product?.name}>
+          {r.rent?.product?.name ?? '—'}
+        </p>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Statut',
+      sortable: true,
+      sortAccessor: r => r.status,
+      render: r => <RequestStatusPill status={r.status} />,
+      cellClassName: 'whitespace-nowrap',
+    },
+  ]
 
   if (isAuthLoading || loading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
         </div>
       </div>
     )
   }
 
-  if (!session) {
-    return null
-  }
+  if (!session) return null
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6'>
-      <div className='max-w-7xl mx-auto'>
-        {/* Header */}
-        <div className='mb-8'>
-          <h1 className='text-3xl font-bold text-gray-900 mb-2'>🏦 Gestion des Paiements</h1>
-          <p className='text-gray-600'>
-            Gérez les demandes de paiement des hôtes et effectuez les actions nécessaires
-          </p>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <PageHeader
+          backHref='/admin'
+          backLabel='Retour au panel admin'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title='Gestion des paiements'
+          subtitle='Consultez et traitez les demandes de paiement des hôtes. Cliquez sur une ligne pour voir les détails et valider ou refuser le versement.'
+        />
+
+        {/* KPI row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Total demandes'
+            value={stats.total}
+            hint='toutes statuts confondus'
+            icon={Wallet}
+            tone='blue'
+          />
+          <KpiCard
+            label='En attente'
+            value={stats.pending}
+            hint='à traiter en priorité'
+            icon={Clock}
+            tone='amber'
+          />
+          <KpiCard
+            label='Montant en attente'
+            value={formatCurrency(stats.pendingAmount)}
+            hint='demandes reçues non traitées'
+            icon={TrendingUp}
+            tone='purple'
+          />
+          <KpiCard
+            label='Montant total'
+            value={formatCurrency(stats.totalAmount)}
+            hint='hors refusées'
+            icon={CreditCard}
+            tone='emerald'
+          />
         </div>
 
-        {/* Stats */}
-        <div className='grid grid-cols-1 md:grid-cols-4 gap-6 mb-8'>
-          <div className='bg-white rounded-xl shadow-sm p-6 border border-gray-200'>
-            <div className='flex items-center'>
-              <div className='text-2xl mr-4'>📋</div>
-              <div>
-                <p className='text-sm font-medium text-gray-600'>Total</p>
-                <p className='text-2xl font-bold text-gray-900'>{payRequests.length}</p>
-              </div>
-            </div>
-          </div>
-          <div className='bg-white rounded-xl shadow-sm p-6 border border-gray-200'>
-            <div className='flex items-center'>
-              <div className='text-2xl mr-4'>⏰</div>
-              <div>
-                <p className='text-sm font-medium text-gray-600'>En attente</p>
-                <p className='text-2xl font-bold text-orange-600'>
-                  {payRequests.filter(req => req.status === PaymentReqStatus.RECEIVED).length}
-                </p>
-              </div>
-            </div>
-          </div>
-          <div className='bg-white rounded-xl shadow-sm p-6 border border-gray-200'>
-            <div className='flex items-center'>
-              <div className='text-2xl mr-4'>✅</div>
-              <div>
-                <p className='text-sm font-medium text-gray-600'>Terminé</p>
-                <p className='text-2xl font-bold text-green-600'>
-                  {payRequests.filter(req => req.status === PaymentReqStatus.DONE).length}
-                </p>
-              </div>
-            </div>
-          </div>
-          <div className='bg-white rounded-xl shadow-sm p-6 border border-gray-200'>
-            <div className='flex items-center'>
-              <div className='text-2xl mr-4'>❌</div>
-              <div>
-                <p className='text-sm font-medium text-gray-600'>Refusé</p>
-                <p className='text-2xl font-bold text-red-600'>
-                  {payRequests.filter(req => req.status === PaymentReqStatus.REFUSED).length}
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Filtres */}
-        <div className='mb-6 flex flex-wrap items-center gap-4'>
-          <div className='flex items-center gap-2'>
-            <span className='text-sm font-medium text-gray-700'>Filtrer par statut:</span>
-            <select
-              value={statusFilter}
-              onChange={e => setStatusFilter(e.target.value as PaymentReqStatus | 'ALL')}
-              className='px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm'
-            >
-              <option value='ALL'>Tous ({payRequests.length})</option>
-              <option value={PaymentReqStatus.RECEIVED}>
-                En attente (
-                {payRequests.filter(req => req.status === PaymentReqStatus.RECEIVED).length})
-              </option>
-              <option value={PaymentReqStatus.DONE}>
-                Terminé ({payRequests.filter(req => req.status === PaymentReqStatus.DONE).length})
-              </option>
-              <option value={PaymentReqStatus.REFUSED}>
-                Refusé ({payRequests.filter(req => req.status === PaymentReqStatus.REFUSED).length})
-              </option>
-            </select>
-          </div>
-          <div className='flex items-center gap-2 text-sm text-gray-600'>
-            <span>💰 Montant total visible:</span>
-            <span className='font-semibold text-gray-900'>
-              {formatCurrency(filteredRequests.reduce((sum, req) => sum + Number(req.prices), 0))}
-            </span>
-          </div>
-        </div>
-
-        {/* Debug info */}
-        <div className='mb-6 p-4 bg-blue-50 rounded-lg border border-blue-200'>
-          <p className='text-sm text-blue-800'>
-            🔍 Debug: {filteredRequests.length} demande(s) affichée(s) sur {payRequests.length} au
-            total
-          </p>
-        </div>
-
-        {/* Requests Table */}
-        <div className='bg-white rounded-xl shadow-sm overflow-hidden border border-gray-200'>
-          {filteredRequests.length === 0 ? (
-            <div className='text-center py-12'>
-              <div className='text-6xl mb-4'>📭</div>
-              <h3 className='text-lg font-medium text-gray-900 mb-2'>
-                {statusFilter === 'ALL'
-                  ? 'Aucune demande de paiement'
-                  : `Aucune demande ${
-                      statusFilter === PaymentReqStatus.RECEIVED
-                        ? 'en attente'
-                        : statusFilter === PaymentReqStatus.DONE
-                          ? 'terminée'
-                          : 'refusée'
+        {/* Status filter chips */}
+        <div className='flex flex-wrap items-center gap-2'>
+          {STATUS_FILTERS.map(f => {
+            const Icon = f.icon
+            const active = statusFilter === f.value
+            return (
+              <button
+                key={f.value}
+                onClick={() => setStatusFilter(f.value)}
+                className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+                  active
+                    ? 'bg-slate-900 text-white shadow-sm'
+                    : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50'
+                }`}
+              >
+                <Icon className='h-3 w-3' />
+                {f.label}
+                {f.value !== 'ALL' && (
+                  <span
+                    className={`ml-1 inline-flex min-w-[1.25rem] items-center justify-center rounded-full px-1 text-[10px] font-bold ${
+                      active ? 'bg-white/20' : 'bg-slate-100'
                     }`}
-              </h3>
-              <p className='text-gray-600'>
-                {statusFilter === 'ALL'
-                  ? 'Aucune demande de paiement n&apos;a encore été créée.'
-                  : 'Changez le filtre pour voir d&apos;autres demandes.'}
-              </p>
-            </div>
-          ) : (
-            <div className='overflow-x-auto'>
-              <table className='min-w-full divide-y divide-gray-200'>
-                <thead className='bg-gray-50'>
-                  <tr>
-                    <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
-                      Type & Montant
-                    </th>
-                    <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
-                      Status
-                    </th>
-                    <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
-                      Hôte
-                    </th>
-                    <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
-                      Date demande
-                    </th>
-                    <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
-                      Actions
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className='bg-white divide-y divide-gray-200'>
-                  {filteredRequests.map(request => (
-                    <tr key={request.id} className='hover:bg-gray-50 transition-colors'>
-                      <td className='px-6 py-4'>
-                        <div className='flex flex-col space-y-2'>
-                          {getStatusBadge(request.PaymentRequest)}
-                          <div className='text-lg font-semibold text-gray-900'>
-                            {formatCurrency(Number(request.prices))}
-                          </div>
-                        </div>
-                      </td>
-                      <td className='px-6 py-4'>{getRequestStatusBadge(request.status)}</td>
-                      <td className='px-6 py-4'>
-                        <div className='flex items-center'>
-                          <div className='text-lg mr-2'>👤</div>
-                          <div>
-                            <div className='text-sm font-medium text-gray-900'>
-                              {request.user.name || 'Sans nom'}
-                            </div>
-                            <div className='text-sm text-gray-500'>{request.user.email}</div>
-                          </div>
-                        </div>
-                      </td>
-                      <td className='px-6 py-4'>
-                        <div className='flex items-center'>
-                          <div className='text-lg mr-2'>📅</div>
-                          <div className='text-sm text-gray-900'>Non disponible</div>
-                        </div>
-                      </td>
-                      <td className='px-6 py-4'>
-                        <button
-                          onClick={() => handleViewDetails(request.id)}
-                          className='px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 transition-colors flex items-center space-x-2'
-                        >
-                          <span>👁️</span>
-                          <span>Voir détails</span>
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+                  >
+                    {f.value === PaymentReqStatus.RECEIVED
+                      ? stats.pending
+                      : f.value === PaymentReqStatus.DONE
+                        ? stats.done
+                        : stats.refused}
+                  </span>
+                )}
+              </button>
+            )
+          })}
         </div>
-      </div>
+
+        {/* Search */}
+        <FilterBar
+          searchValue={searchValue}
+          onSearchChange={setSearchValue}
+          searchPlaceholder='Rechercher par hôte, email ou hébergement…'
+        />
+
+        {/* Data table */}
+        <DataTable<PayRequest>
+          columns={columns}
+          rows={filteredRequests}
+          getRowId={r => r.id}
+          loading={loading}
+          sort={sort}
+          onSortChange={setSort}
+          rowActions={request => (
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => handleViewDetails(request.id)}
+              className='gap-1 text-slate-600 hover:text-slate-900'
+            >
+              <Eye className='h-4 w-4' />
+              Détails
+            </Button>
+          )}
+          emptyState={{
+            icon: Wallet,
+            title: 'Aucune demande de paiement',
+            subtitle:
+              searchValue || statusFilter !== 'ALL'
+                ? 'Essayez d’ajuster vos filtres.'
+                : 'Aucune demande n’a encore été créée.',
+          }}
+        />
+      </motion.div>
     </div>
   )
 }

--- a/src/app/admin/reservations/page.tsx
+++ b/src/app/admin/reservations/page.tsx
@@ -1,18 +1,16 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { motion } from 'framer-motion'
 import { useAuth } from '@/hooks/useAuth'
 import { isFullAdmin } from '@/hooks/useAdminAuth'
 import { useAdminReservationsPaginated } from '@/hooks/useAdminPaginated'
 import { useAdminReservationStatusChange } from '@/hooks/useAdminReservationMutations'
 import Pagination from '@/components/ui/Pagination'
-import { motion, Variants } from 'framer-motion'
-import { Card, CardContent } from '@/components/ui/shadcnui/card'
 import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/shadcnui/input'
 import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
-import { Loader2, Search, CalendarDays, XCircle } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -23,37 +21,170 @@ import {
   Label,
 } from '@/shadcnui'
 import { Textarea } from '@/components/ui/shadcnui/textarea'
-import { ReservationCard } from '@/components/reservations/ReservationCard'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/shadcnui/dropdown-menu'
+import {
+  Loader2,
+  CalendarDays,
+  Clock,
+  CheckCircle2,
+  DoorOpen,
+  DoorClosed,
+  XCircle,
+  Ban,
+  MoreHorizontal,
+  MapPin,
+  Eye,
+  Shield,
+  ArrowRight,
+  CreditCard,
+  AlertCircle,
+} from 'lucide-react'
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard, KpiMetric } from '@/components/admin/ui/KpiCard'
+import { FilterBar } from '@/components/admin/ui/FilterBar'
+import { DataTable, type DataTableColumn } from '@/components/admin/ui/DataTable'
 
-const containerVariants: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
+type RentStatus = 'WAITING' | 'RESERVED' | 'CHECKIN' | 'CHECKOUT' | 'CANCEL'
+
+type PaymentStatus =
+  | 'NOT_PAID'
+  | 'CLIENT_PAID'
+  | 'MID_TRANSFER_REQ'
+  | 'MID_TRANSFER_DONE'
+  | 'REST_TRANSFER_REQ'
+  | 'REST_TRANSFER_DONE'
+  | 'FULL_TRANSFER_REQ'
+  | 'FULL_TRANSFER_DONE'
+  | 'REFUNDED'
+  | 'DISPUTE'
+
+interface AdminReservationRow {
+  id: string
+  arrivingDate: string
+  leavingDate: string
+  status: RentStatus
+  payment: PaymentStatus
+  totalAmount: number | null
+  numberOfNights: number | null
+  numberPeople: number | null
+  createdAt: string
+  accepted: boolean
+  confirmed: boolean
+  product: {
+    id: string
+    name: string
+    address: string
+    owner: { id: string; name: string | null; email: string }
+  }
+  user: {
+    id: string
+    name: string | null
+    lastname: string | null
+    email: string
+  }
+}
+
+const STATUS_LABEL: Record<
+  RentStatus,
+  { label: string; tone: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  WAITING: {
+    label: 'En attente',
+    tone: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: Clock,
+  },
+  RESERVED: {
+    label: 'Confirmée',
+    tone: 'bg-blue-50 text-blue-700 ring-blue-200',
+    icon: CheckCircle2,
+  },
+  CHECKIN: {
+    label: 'Check-in',
+    tone: 'bg-indigo-50 text-indigo-700 ring-indigo-200',
+    icon: DoorOpen,
+  },
+  CHECKOUT: {
+    label: 'Check-out',
+    tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: DoorClosed,
+  },
+  CANCEL: {
+    label: 'Annulée',
+    tone: 'bg-red-50 text-red-700 ring-red-200',
+    icon: Ban,
   },
 }
 
-const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.5,
-    },
-  },
+const PAYMENT_LABEL: Record<PaymentStatus, { label: string; tone: string }> = {
+  NOT_PAID: { label: 'Non payé', tone: 'bg-slate-100 text-slate-700' },
+  CLIENT_PAID: { label: 'Payé', tone: 'bg-emerald-50 text-emerald-700' },
+  MID_TRANSFER_REQ: { label: '50% demandé', tone: 'bg-amber-50 text-amber-700' },
+  MID_TRANSFER_DONE: { label: '50% versé', tone: 'bg-blue-50 text-blue-700' },
+  REST_TRANSFER_REQ: { label: 'Solde demandé', tone: 'bg-amber-50 text-amber-700' },
+  REST_TRANSFER_DONE: { label: 'Soldé', tone: 'bg-emerald-50 text-emerald-700' },
+  FULL_TRANSFER_REQ: { label: '100% demandé', tone: 'bg-amber-50 text-amber-700' },
+  FULL_TRANSFER_DONE: { label: '100% versé', tone: 'bg-emerald-50 text-emerald-700' },
+  REFUNDED: { label: 'Remboursé', tone: 'bg-red-50 text-red-700' },
+  DISPUTE: { label: 'Litige', tone: 'bg-red-50 text-red-700' },
 }
 
-const STATS_CARDS = [
-  { key: 'total', label: 'Total', gradient: 'from-blue-500 to-blue-600', textMuted: 'text-blue-100', iconColor: 'text-blue-200' },
-  { key: 'WAITING', label: 'En attente', gradient: 'from-yellow-400 to-yellow-500', textMuted: 'text-yellow-100', iconColor: 'text-yellow-200' },
-  { key: 'RESERVED', label: 'Confirmées', gradient: 'from-blue-400 to-indigo-500', textMuted: 'text-blue-100', iconColor: 'text-blue-200' },
-  { key: 'CHECKIN', label: 'Check-in', gradient: 'from-green-400 to-green-500', textMuted: 'text-green-100', iconColor: 'text-green-200' },
-  { key: 'CHECKOUT', label: 'Check-out', gradient: 'from-gray-400 to-gray-500', textMuted: 'text-gray-100', iconColor: 'text-gray-200' },
-  { key: 'CANCEL', label: 'Annulées', gradient: 'from-red-400 to-red-500', textMuted: 'text-red-100', iconColor: 'text-red-200' },
+const STATUS_FILTERS: Array<{
+  value: '' | RentStatus
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}> = [
+  { value: '', label: 'Toutes', icon: CalendarDays },
+  { value: 'WAITING', label: 'En attente', icon: Clock },
+  { value: 'RESERVED', label: 'Confirmées', icon: CheckCircle2 },
+  { value: 'CHECKIN', label: 'Check-in', icon: DoorOpen },
+  { value: 'CHECKOUT', label: 'Check-out', icon: DoorClosed },
+  { value: 'CANCEL', label: 'Annulées', icon: Ban },
 ]
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(amount)
+}
+
+function formatDate(date: string | Date): string {
+  return new Date(date).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+function StatusPill({ status }: { status: RentStatus }) {
+  const config = STATUS_LABEL[status]
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.label}
+    </span>
+  )
+}
+
+function PaymentPill({ payment }: { payment: PaymentStatus }) {
+  const config = PAYMENT_LABEL[payment]
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${config.tone}`}>
+      {config.label}
+    </span>
+  )
+}
 
 export default function AdminReservationsPage() {
   const {
@@ -68,7 +199,6 @@ export default function AdminReservationsPage() {
     stats,
     pagination,
     loading,
-    isFetching,
     error: hookError,
     searchTerm,
     statusFilter,
@@ -89,11 +219,15 @@ export default function AdminReservationsPage() {
     }
   }, [isAuthenticated, session, router])
 
-  const handleStatusAction = (rentId: string, status: 'RESERVED' | 'CHECKIN' | 'CHECKOUT' | 'CANCEL') => {
+  const openCancelDialog = (rentId: string) => {
+    setCancelTargetId(rentId)
+    setCancelReason('')
+    setCancelDialogOpen(true)
+  }
+
+  const handleStatusAction = (rentId: string, status: Exclude<RentStatus, 'WAITING'>) => {
     if (status === 'CANCEL') {
-      setCancelTargetId(rentId)
-      setCancelReason('')
-      setCancelDialogOpen(true)
+      openCancelDialog(rentId)
       return
     }
     statusMutation.mutate({ rentId, status })
@@ -113,12 +247,145 @@ export default function AdminReservationsPage() {
     )
   }
 
+  const totalRevenue = useMemo(
+    () =>
+      (reservations as AdminReservationRow[])
+        .filter(
+          r =>
+            r.payment !== 'NOT_PAID' &&
+            r.payment !== 'REFUNDED' &&
+            r.payment !== 'DISPUTE' &&
+            r.status !== 'CANCEL'
+        )
+        .reduce((sum, r) => sum + (r.totalAmount ?? 0), 0),
+    [reservations]
+  )
+
+  const columns: DataTableColumn<AdminReservationRow>[] = [
+    {
+      key: 'reference',
+      header: 'Référence',
+      sortable: true,
+      sortAccessor: r => new Date(r.createdAt),
+      render: r => (
+        <div className='min-w-0'>
+          <p className='text-sm font-semibold text-slate-900'>#{r.id.slice(-6).toUpperCase()}</p>
+          <p className='truncate text-xs text-slate-500'>Créée le {formatDate(r.createdAt)}</p>
+        </div>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'guest',
+      header: 'Voyageur',
+      sortable: true,
+      sortAccessor: r => (r.user.name || r.user.email).toLowerCase(),
+      render: r => {
+        const displayName = [r.user.name, r.user.lastname].filter(Boolean).join(' ') || '—'
+        return (
+          <div className='min-w-0'>
+            <p className='truncate text-sm font-medium text-slate-900'>{displayName}</p>
+            <p className='truncate text-xs text-slate-500'>{r.user.email}</p>
+          </div>
+        )
+      },
+    },
+    {
+      key: 'product',
+      header: 'Hébergement',
+      render: r => (
+        <Link
+          href={`/admin/validation/${r.product.id}`}
+          className='group block min-w-0'
+        >
+          <p className='truncate text-sm font-medium text-slate-900 group-hover:text-blue-700'>
+            {r.product.name}
+          </p>
+          <p className='flex items-center gap-1 truncate text-xs text-slate-500'>
+            <MapPin className='h-3 w-3' />
+            {r.product.address}
+          </p>
+        </Link>
+      ),
+    },
+    {
+      key: 'host',
+      header: 'Hôte',
+      render: r => {
+        const hostName = r.product.owner.name || r.product.owner.email
+        return (
+          <p className='truncate text-sm text-slate-700' title={r.product.owner.email}>
+            {hostName}
+          </p>
+        )
+      },
+    },
+    {
+      key: 'stay',
+      header: 'Séjour',
+      sortable: true,
+      sortAccessor: r => new Date(r.arrivingDate),
+      render: r => (
+        <div className='min-w-0'>
+          <p className='flex items-center gap-1 text-xs text-slate-900 whitespace-nowrap'>
+            {formatDate(r.arrivingDate)}
+            <ArrowRight className='h-3 w-3 text-slate-400' />
+            {formatDate(r.leavingDate)}
+          </p>
+          <p className='text-xs text-slate-500'>
+            {r.numberOfNights ?? '—'} nuits · {r.numberPeople ?? '—'} voyageur
+            {(r.numberPeople ?? 0) > 1 ? 's' : ''}
+          </p>
+        </div>
+      ),
+    },
+    {
+      key: 'amount',
+      header: 'Montant',
+      sortable: true,
+      sortAccessor: r => r.totalAmount ?? 0,
+      align: 'right',
+      render: r => (
+        <div className='text-right'>
+          <p className='text-sm font-bold tabular-nums text-slate-900'>
+            {r.totalAmount != null ? formatCurrency(r.totalAmount) : '—'}
+          </p>
+          <div className='mt-0.5 flex justify-end'>
+            <PaymentPill payment={r.payment} />
+          </div>
+        </div>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'status',
+      header: 'Statut',
+      sortable: true,
+      sortAccessor: r => r.status,
+      render: r => <StatusPill status={r.status} />,
+      cellClassName: 'whitespace-nowrap',
+    },
+  ]
+
   if (isAuthLoading || loading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin' />
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-16 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
+          <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
         </div>
       </div>
     )
@@ -126,210 +393,285 @@ export default function AdminReservationsPage() {
 
   if (!session) return null
 
-  if (hookError) {
-    return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive' className='rounded-2xl'>
+  return (
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <PageHeader
+          backHref='/admin'
+          backLabel='Retour au panel admin'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title='Gestion des réservations'
+          subtitle='Consultez, filtrez et gérez toutes les réservations de la plateforme. Les actions d’approbation, de check-in et d’annulation sont disponibles depuis le menu de chaque ligne.'
+        />
+
+        {hookError && (
+          <Alert variant='destructive'>
             <AlertDescription>
               {hookError.message || 'Erreur lors du chargement des réservations'}
             </AlertDescription>
           </Alert>
+        )}
+
+        {/* KPI row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Total'
+            value={stats.total || 0}
+            hint='réservations au total'
+            icon={CalendarDays}
+            tone='blue'
+            loading={loading}
+          />
+          <KpiCard
+            label='À traiter'
+            value={(stats.WAITING || 0) as number}
+            hint='en attente de confirmation'
+            icon={Clock}
+            tone='amber'
+            loading={loading}
+          />
+          <KpiCard
+            label='Confirmées'
+            value={(stats.RESERVED || 0) as number}
+            hint='prêtes pour le check-in'
+            icon={CheckCircle2}
+            tone='indigo'
+            loading={loading}
+          />
+          <KpiCard
+            label='Revenus (page)'
+            value={formatCurrency(totalRevenue)}
+            hint='sur la page actuelle, hors annulées'
+            icon={CreditCard}
+            tone='emerald'
+            loading={loading}
+          />
         </div>
-      </div>
-    )
-  }
 
-  return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100'>
-      <div className='container mx-auto p-6 space-y-8'>
-        {/* Header */}
-        <motion.div
-          className='text-center space-y-4'
-          variants={containerVariants}
-          initial='hidden'
-          animate='visible'
-        >
-          <motion.div
-            variants={itemVariants}
-            className='inline-flex items-center justify-center w-16 h-16 rounded-full bg-gradient-to-r from-blue-500 to-indigo-600 shadow-lg mb-4'
-          >
-            <CalendarDays className='w-8 h-8 text-white' />
-          </motion.div>
-          <motion.h1
-            variants={itemVariants}
-            className='text-4xl font-bold bg-gradient-to-r from-gray-900 via-blue-800 to-indigo-800 bg-clip-text text-transparent'
-          >
-            Gestion des Réservations
-          </motion.h1>
-          <motion.p variants={itemVariants} className='text-gray-600 text-lg max-w-2xl mx-auto'>
-            Consultez, filtrez et gérez toutes les réservations de la plateforme
-          </motion.p>
-        </motion.div>
+        {/* Secondary metrics */}
+        <div className='grid gap-3 sm:grid-cols-3'>
+          <KpiMetric
+            label='check-in'
+            value={(stats.CHECKIN || 0) as number}
+            icon={DoorOpen}
+            tone='slate'
+          />
+          <KpiMetric
+            label='check-out'
+            value={(stats.CHECKOUT || 0) as number}
+            icon={DoorClosed}
+            tone='slate'
+          />
+          <KpiMetric
+            label='annulées'
+            value={(stats.CANCEL || 0) as number}
+            icon={Ban}
+            tone='red'
+          />
+        </div>
 
-        {/* Stats Cards */}
-        <motion.div
-          variants={containerVariants}
-          initial='hidden'
-          animate='visible'
-          className='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4'
-        >
-          {STATS_CARDS.map(({ key, label, gradient, textMuted, iconColor }) => {
-            const isActive = (key === 'total' && !statusFilter) || statusFilter === key
+        {/* Status filter chips */}
+        <div className='flex flex-wrap items-center gap-2'>
+          {STATUS_FILTERS.map(filter => {
+            const Icon = filter.icon
+            const active =
+              (filter.value === '' && !statusFilter) || statusFilter === filter.value
             return (
-              <motion.div key={key} variants={itemVariants}>
-                <Card
-                  className={`border-0 shadow-lg cursor-pointer transition-all duration-300 hover:shadow-xl ${
-                    key === 'total' || isActive
-                      ? `bg-gradient-to-r ${gradient} text-white`
-                      : 'bg-white/80 backdrop-blur-sm hover:scale-[1.02]'
-                  }`}
-                  onClick={() => handleStatusFilter(key === 'total' ? '' : statusFilter === key ? '' : key)}
-                >
-                  <CardContent className='p-4'>
-                    <div className='flex items-center justify-between'>
-                      <div>
-                        <p className={`text-xs font-medium ${key === 'total' || isActive ? textMuted : 'text-gray-500'}`}>
-                          {label}
-                          {isActive && key !== 'total' && ' (Filtré)'}
-                        </p>
-                        <p className={`text-2xl font-bold ${key === 'total' || isActive ? '' : 'text-gray-900'}`}>
-                          {stats[key] || 0}
-                        </p>
-                      </div>
-                      <CalendarDays className={`h-6 w-6 ${key === 'total' || isActive ? iconColor : 'text-gray-300'}`} />
-                    </div>
-                  </CardContent>
-                </Card>
-              </motion.div>
+              <button
+                key={filter.value || 'all'}
+                onClick={() => handleStatusFilter(active ? '' : filter.value)}
+                className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+                  active
+                    ? 'bg-slate-900 text-white shadow-sm'
+                    : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50'
+                }`}
+              >
+                <Icon className='h-3 w-3' />
+                {filter.label}
+              </button>
             )
           })}
-        </motion.div>
-
-        {/* Search */}
-        <motion.div
-          variants={containerVariants}
-          initial='hidden'
-          animate='visible'
-          className='bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border-0'
-        >
-          <motion.div variants={itemVariants} className='relative max-w-md'>
-            {isFetching ? (
-              <Loader2 className='absolute left-3 top-1/2 transform -translate-y-1/2 text-blue-500 h-4 w-4 animate-spin' />
-            ) : (
-              <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4' />
-            )}
-            <Input
-              type='text'
-              placeholder='Rechercher par voyageur, hôte, hébergement...'
-              value={searchTerm}
-              onChange={e => handleSearch(e.target.value)}
-              className='pl-10 py-3 border-0 bg-gray-50 focus:bg-white transition-colors rounded-xl'
-            />
-          </motion.div>
-        </motion.div>
-
-        {/* Reservation Cards Grid */}
-        <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
-          {reservations.map((reservation, index) => (
-            <ReservationCard
-              key={reservation.id}
-              reservation={reservation}
-              index={index}
-              onStatusAction={handleStatusAction}
-            />
-          ))}
         </div>
 
-        {/* Empty State */}
-        {reservations.length === 0 && !loading && (
-          <motion.div variants={itemVariants} className='text-center py-12'>
-            <CalendarDays className='h-12 w-12 text-gray-400 mx-auto mb-4' />
-            <h3 className='text-lg font-medium text-gray-900 mb-2'>Aucune réservation trouvée</h3>
-            <p className='text-gray-500'>
-              Essayez de modifier votre recherche ou vos filtres.
+        {/* Filter bar */}
+        <FilterBar
+          searchValue={searchTerm}
+          onSearchChange={handleSearch}
+          searchPlaceholder='Rechercher par voyageur, hôte, hébergement…'
+        />
+
+        {/* Data table */}
+        <DataTable<AdminReservationRow>
+          columns={columns}
+          rows={reservations as unknown as AdminReservationRow[]}
+          getRowId={r => r.id}
+          loading={loading}
+          rowActions={reservation => {
+            const canConfirm = reservation.status === 'WAITING'
+            const canCheckIn = reservation.status === 'RESERVED'
+            const canCheckOut = reservation.status === 'CHECKIN'
+            const canCancel = !['CANCEL', 'CHECKOUT'].includes(reservation.status)
+            return (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant='ghost'
+                    size='sm'
+                    className='h-8 w-8 p-0'
+                    aria-label='Actions réservation'
+                  >
+                    <MoreHorizontal className='h-4 w-4' />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end' className='w-52'>
+                  <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem asChild>
+                    <Link
+                      href={`/reservations/${reservation.id}`}
+                      className='flex items-center gap-2'
+                    >
+                      <Eye className='h-4 w-4' />
+                      Voir le détail
+                    </Link>
+                  </DropdownMenuItem>
+                  {canConfirm && (
+                    <DropdownMenuItem
+                      onClick={() => handleStatusAction(reservation.id, 'RESERVED')}
+                      className='flex items-center gap-2 text-blue-700'
+                    >
+                      <CheckCircle2 className='h-4 w-4' />
+                      Confirmer
+                    </DropdownMenuItem>
+                  )}
+                  {canCheckIn && (
+                    <DropdownMenuItem
+                      onClick={() => handleStatusAction(reservation.id, 'CHECKIN')}
+                      className='flex items-center gap-2 text-indigo-700'
+                    >
+                      <DoorOpen className='h-4 w-4' />
+                      Marquer check-in
+                    </DropdownMenuItem>
+                  )}
+                  {canCheckOut && (
+                    <DropdownMenuItem
+                      onClick={() => handleStatusAction(reservation.id, 'CHECKOUT')}
+                      className='flex items-center gap-2 text-emerald-700'
+                    >
+                      <DoorClosed className='h-4 w-4' />
+                      Marquer check-out
+                    </DropdownMenuItem>
+                  )}
+                  {canCancel && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onClick={() => openCancelDialog(reservation.id)}
+                        className='flex items-center gap-2 text-red-600 focus:text-red-600'
+                      >
+                        <XCircle className='h-4 w-4' />
+                        Annuler la réservation
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )
+          }}
+          emptyState={{
+            icon: CalendarDays,
+            title: 'Aucune réservation trouvée',
+            subtitle:
+              searchTerm || statusFilter
+                ? 'Essayez d’ajuster votre recherche ou vos filtres.'
+                : 'Aucune réservation n’a encore été effectuée sur la plateforme.',
+          }}
+        />
+
+        {/* Footer: summary + pagination */}
+        {!loading && reservations.length > 0 && (
+          <div className='flex flex-col items-center gap-3 md:flex-row md:justify-between'>
+            <p className='text-sm text-slate-500'>
+              Affichage de {(pagination.currentPage - 1) * pagination.itemsPerPage + 1} à{' '}
+              {Math.min(
+                pagination.currentPage * pagination.itemsPerPage,
+                pagination.totalItems
+              )}{' '}
+              sur {pagination.totalItems} réservations
             </p>
-          </motion.div>
-        )}
-
-        {/* Pagination */}
-        {pagination.totalPages > 1 && (
-          <div className='mt-8 flex justify-center'>
-            <Pagination
-              currentPage={pagination.currentPage}
-              totalPages={pagination.totalPages}
-              onPageChange={goToPage}
-              showPrevNext={true}
-              showNumbers={true}
-              maxVisiblePages={5}
-            />
+            {pagination.totalPages > 1 && (
+              <Pagination
+                currentPage={pagination.currentPage}
+                totalPages={pagination.totalPages}
+                onPageChange={goToPage}
+                showPrevNext={true}
+                showNumbers={true}
+                maxVisiblePages={5}
+              />
+            )}
           </div>
         )}
 
-        {/* Results summary */}
-        {reservations.length > 0 && (
-          <div className='mt-4 text-center text-sm text-gray-500'>
-            Affichage de {(pagination.currentPage - 1) * pagination.itemsPerPage + 1} à{' '}
-            {Math.min(pagination.currentPage * pagination.itemsPerPage, pagination.totalItems)} sur{' '}
-            {pagination.totalItems} réservations
-          </div>
-        )}
-
-        {/* Cancel Dialog */}
+        {/* Cancel dialog */}
         <Dialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
-          <DialogContent className='sm:max-w-md rounded-2xl'>
+          <DialogContent className='sm:max-w-md'>
             <DialogHeader>
-              <DialogTitle className='flex items-center gap-2 text-xl'>
-                <XCircle className='h-5 w-5 text-red-600' />
-                Annuler la réservation
-              </DialogTitle>
-              <DialogDescription>
-                Cette action annulera la réservation et effectuera un remboursement Stripe si applicable.
-              </DialogDescription>
+              <div className='flex items-start gap-3'>
+                <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-red-50 text-red-600 ring-1 ring-red-100'>
+                  <AlertCircle className='h-5 w-5' />
+                </div>
+                <div className='space-y-1'>
+                  <DialogTitle className='text-lg'>Annuler la réservation</DialogTitle>
+                  <DialogDescription className='text-sm text-slate-600'>
+                    Cette action annulera la réservation et effectuera un remboursement Stripe si
+                    applicable. L’hôte et le voyageur seront notifiés.
+                  </DialogDescription>
+                </div>
+              </div>
             </DialogHeader>
-            <div className='space-y-4 py-4'>
+            <div className='space-y-4 py-2'>
               <div className='space-y-2'>
                 <Label htmlFor='cancelReason'>Raison (optionnel)</Label>
                 <Textarea
                   id='cancelReason'
-                  placeholder="Indiquez la raison de l'annulation..."
+                  placeholder='Expliquez la raison de l’annulation…'
                   value={cancelReason}
                   onChange={e => setCancelReason(e.target.value)}
-                  className='rounded-xl'
                   rows={3}
                 />
               </div>
             </div>
-            <DialogFooter>
+            <DialogFooter className='gap-2'>
               <Button
                 variant='outline'
                 onClick={() => setCancelDialogOpen(false)}
                 disabled={statusMutation.isPending}
-                className='rounded-xl'
               >
                 Retour
               </Button>
               <Button
+                variant='destructive'
                 onClick={handleConfirmCancel}
                 disabled={statusMutation.isPending}
-                className='bg-red-600 hover:bg-red-700 text-white rounded-xl'
+                className='gap-2'
               >
                 {statusMutation.isPending ? (
-                  <>
-                    <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                    Annulation...
-                  </>
+                  <Loader2 className='h-4 w-4 animate-spin' />
                 ) : (
-                  <>
-                    <XCircle className='h-4 w-4 mr-2' />
-                    Confirmer l&apos;annulation
-                  </>
+                  <XCircle className='h-4 w-4' />
                 )}
+                Confirmer l’annulation
               </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
-      </div>
+      </motion.div>
     </div>
   )
 }

--- a/src/app/admin/security/page.tsx
+++ b/src/app/admin/security/page.tsx
@@ -1,515 +1,67 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
-import { useAuth } from '@/hooks/useAuth'
-import { isAdmin } from '@/hooks/useAdminAuth'
-import Link from 'next/link'
-import { motion, Variants } from 'framer-motion'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/shadcnui/input'
-import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
+import { ShieldCheck, Shield } from 'lucide-react'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/shadcnui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import {
-  Loader2,
-  Search,
-  Eye,
-  Cctv,
-  Plus,
-  ArrowLeft,
-  CheckCircle,
-  Edit3,
-  Trash2,
-} from 'lucide-react'
-import {
-  findAllSecurity,
   createSecurity,
-  updateSecurity,
   deleteSecurity,
+  findAllSecurity,
+  updateSecurity,
 } from '@/lib/services/security.services'
 import { SecurityInterface } from '@/lib/interface/securityInterface'
+import { TaxonomyManager, type TaxonomyAdapter } from '@/components/admin/ui/TaxonomyManager'
 
-const containerVariants: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
-  },
+interface SecurityFormData {
+  name: string
 }
 
-const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: 'tween' as const,
-      duration: 0.5,
-      ease: 'easeOut',
-    },
+const adapter: TaxonomyAdapter<SecurityInterface, SecurityFormData> = {
+  fetchAll: async () => {
+    const result = await findAllSecurity()
+    return result ?? []
+  },
+  create: async data => {
+    const created = await createSecurity(data.name)
+    return created ?? null
+  },
+  update: async (id, data) => {
+    const updated = await updateSecurity(id, data.name)
+    return updated ?? null
+  },
+  delete: async id => {
+    const success = await deleteSecurity(id)
+    return Boolean(success)
   },
 }
 
 export default function SecurityPage() {
-  const {
-    session,
-    isLoading: isAuthLoading,
-    isAuthenticated,
-  } = useAuth({ required: true, redirectTo: '/auth' })
-  const router = useRouter()
-  const [security, setSecurity] = useState<SecurityInterface[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState('')
-  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
-  const [newOptionName, setNewOptionName] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
-
-  // États pour l'édition
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
-  const [editingOption, setEditingOption] = useState<SecurityInterface | null>(null)
-  const [editOptionName, setEditOptionName] = useState('')
-
-  // États pour la suppression
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
-  const [deletingOption, setDeletingOption] = useState<SecurityInterface | null>(null)
-
-  useEffect(() => {
-    if (isAuthenticated && (!session?.user?.roles || !isAdmin(session.user.roles))) {
-      router.push('/')
-    }
-  }, [isAuthenticated, session, router])
-
-  useEffect(() => {
-    const fetchSecurity = async () => {
-      try {
-        const securityData = await findAllSecurity()
-        if (securityData) {
-          setSecurity(securityData)
-        }
-      } catch (err) {
-        setError('Erreur lors du chargement des options de sécurité')
-        console.error(err)
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchSecurity()
-  }, [])
-
-  const filteredUsers = security.filter(option =>
-    option.name?.toLowerCase().includes(searchTerm.toLowerCase())
-  )
-
-  const handleAddOption = async () => {
-    if (!newOptionName.trim()) return
-
-    setIsSubmitting(true)
-    try {
-      const newOption = await createSecurity(newOptionName)
-
-      if (newOption) {
-        setSecurity([...security, newOption])
-        setNewOptionName('')
-        setIsAddDialogOpen(false)
-      } else {
-        setError("Erreur lors de la création de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la création:', err)
-      setError("Erreur lors de la création de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleEditOption = (option: SecurityInterface) => {
-    setEditingOption(option)
-    setEditOptionName(option.name || '')
-    setIsEditDialogOpen(true)
-  }
-
-  const handleUpdateOption = async () => {
-    if (!editingOption || !editOptionName.trim()) return
-
-    setIsSubmitting(true)
-    try {
-      const updatedOption = await updateSecurity(editingOption.id, editOptionName)
-
-      if (updatedOption) {
-        setSecurity(security.map(opt => (opt.id === editingOption.id ? updatedOption : opt)))
-        setEditOptionName('')
-        setEditingOption(null)
-        setIsEditDialogOpen(false)
-      } else {
-        setError("Erreur lors de la modification de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la modification:', err)
-      setError("Erreur lors de la modification de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleDeleteOption = (option: SecurityInterface) => {
-    setDeletingOption(option)
-    setIsDeleteDialogOpen(true)
-  }
-
-  const handleConfirmDelete = async () => {
-    if (!deletingOption) return
-
-    setIsSubmitting(true)
-    try {
-      const success = await deleteSecurity(deletingOption.id)
-
-      if (success) {
-        setSecurity(security.filter(opt => opt.id !== deletingOption.id))
-        setDeletingOption(null)
-        setIsDeleteDialogOpen(false)
-      } else {
-        setError("Erreur lors de la suppression de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la suppression:', err)
-      setError("Erreur lors de la suppression de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-  if (isAuthLoading || loading) {
-    return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
-        </div>
-      </div>
-    )
-  }
-
-  if (!session) {
-    return null
-  }
-
-  if (error) {
-    return (
-      <div className='min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive'>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        </div>
-      </div>
-    )
-  }
-
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
-      <motion.div
-        className='max-w-7xl mx-auto p-6 space-y-8'
-        variants={containerVariants}
-        initial='hidden'
-        animate='visible'
-      >
-        {/* Header with breadcrumb */}
-        <motion.div variants={itemVariants} className='space-y-4'>
-          <Button variant='ghost' size='sm' asChild className='text-slate-600 hover:text-slate-800'>
-            <Link href='/admin' className='flex items-center gap-2'>
-              <ArrowLeft className='h-4 w-4' />
-              Retour au dashboard
-            </Link>
-          </Button>
-
-          <div className='flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4'>
-            <div>
-              <div className='flex items-center gap-2 mb-2'>
-                <Cctv className='h-8 w-8 text-blue-600' />
-                <h1 className='text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-800 via-blue-700 to-indigo-700'>
-                  Gestion des options de sécurité
-                </h1>
-              </div>
-              <p className='text-slate-600 text-lg'>
-                {security.length} option{security.length > 1 ? 's' : ''} enregistrée
-                {security.length > 1 ? 's' : ''}
-              </p>
-            </div>
-
-            <div className='flex items-center gap-3'>
-              <div className='relative'>
-                <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4' />
-                <Input
-                  type='text'
-                  placeholder='Rechercher une option...'
-                  value={searchTerm}
-                  onChange={e => setSearchTerm(e.target.value)}
-                  className='pl-10 w-full sm:w-64'
-                />
-              </div>
-
-              <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-                <DialogTrigger asChild>
-                  <Button className='bg-blue-600 hover:bg-blue-700 text-white shadow-lg'>
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter une option
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className='sm:max-w-md'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Cctv className='h-5 w-5 text-blue-600' />
-                      Nouvelle option de sécurité
-                    </DialogTitle>
-                    <DialogDescription>
-                      Ajoutez une nouvelle option de sécurité à la liste disponible.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='optionName'>Nom de l&apos;option</Label>
-                      <Input
-                        id='optionName'
-                        placeholder='Ex: Détecteur de fumée, Extincteur...'
-                        value={newOptionName}
-                        onChange={e => setNewOptionName(e.target.value)}
-                        onKeyDown={e => e.key === 'Enter' && !isSubmitting && handleAddOption()}
-                      />
-                    </div>
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsAddDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleAddOption}
-                      disabled={!newOptionName.trim() || isSubmitting}
-                      className='bg-blue-600 hover:bg-blue-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Création...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Créer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Dialog d'édition */}
-              <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Edit3 className='h-5 w-5 text-orange-600' />
-                      Modifier l&apos;option de sécurité
-                    </DialogTitle>
-                    <DialogDescription>
-                      Modifiez le nom de cette option de sécurité.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='editOptionName'>Nom de l&apos;option</Label>
-                      <Input
-                        id='editOptionName'
-                        placeholder='Ex: Détecteur de fumée, Extincteur...'
-                        value={editOptionName}
-                        onChange={e => setEditOptionName(e.target.value)}
-                        onKeyDown={e => e.key === 'Enter' && !isSubmitting && handleUpdateOption()}
-                      />
-                    </div>
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsEditDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleUpdateOption}
-                      disabled={!editOptionName.trim() || isSubmitting}
-                      className='bg-orange-600 hover:bg-orange-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Modification...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Modifier
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Dialog de suppression */}
-              <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Trash2 className='h-5 w-5 text-red-600' />
-                      Supprimer l&apos;option de sécurité
-                    </DialogTitle>
-                    <DialogDescription>
-                      Êtes-vous sûr de vouloir supprimer l&apos;option &quot;{deletingOption?.name}
-                      &quot; ? Cette action est irréversible.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsDeleteDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleConfirmDelete}
-                      disabled={isSubmitting}
-                      variant='destructive'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Suppression...
-                        </>
-                      ) : (
-                        <>
-                          <Trash2 className='h-4 w-4 mr-2' />
-                          Supprimer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-            </div>
-          </div>
-        </motion.div>
-
-        {/* Content */}
-        <motion.div variants={itemVariants}>
-          {filteredUsers.length === 0 ? (
-            <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm'>
-              <CardContent className='text-center py-12'>
-                <Cctv className='h-16 w-16 text-slate-300 mx-auto mb-4' />
-                <h3 className='text-xl font-semibold text-slate-600 mb-2'>
-                  {searchTerm ? 'Aucun résultat' : 'Aucune option de sécurité'}
-                </h3>
-                <p className='text-slate-500 mb-6'>
-                  {searchTerm
-                    ? 'Aucune option ne correspond à votre recherche.'
-                    : 'Commencez par ajouter votre première option de sécurité.'}
-                </p>
-                {!searchTerm && (
-                  <Button
-                    onClick={() => setIsAddDialogOpen(true)}
-                    className='bg-blue-600 hover:bg-blue-700'
-                  >
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter une option
-                  </Button>
-                )}
-              </CardContent>
-            </Card>
-          ) : (
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 items-stretch'>
-              {filteredUsers.map((option, index) => (
-                <motion.div
-                  key={option.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.05 }}
-                >
-                  <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm hover:shadow-xl transition-all duration-300 group h-full'>
-                    <CardHeader className='pb-3'>
-                      <div className='flex items-start justify-between'>
-                        <div className='flex items-center gap-3'>
-                          <div className='p-2 bg-blue-50 rounded-lg group-hover:bg-blue-100 transition-colors'>
-                            <Cctv className='h-5 w-5 text-blue-600' />
-                          </div>
-                          <div>
-                            <CardTitle className='text-lg font-semibold text-slate-800'>
-                              {option.name || 'Option sans nom'}
-                            </CardTitle>
-                          </div>
-                        </div>
-                        <Badge
-                          variant='secondary'
-                          className='bg-green-50 text-green-700 border-green-200'
-                        >
-                          Actif
-                        </Badge>
-                      </div>
-                    </CardHeader>
-                    <CardContent className='pt-0'>
-                      <div className='flex items-center gap-2'>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          asChild
-                          className='flex-1 hover:bg-blue-50 hover:text-blue-600'
-                        >
-                          <Link href={`/admin/security/${option.id}`}>
-                            <Eye className='h-4 w-4 mr-2' />
-                            Voir détails
-                          </Link>
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-orange-50 hover:text-orange-600'
-                          onClick={() => handleEditOption(option)}
-                        >
-                          <Edit3 className='h-4 w-4' />
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-red-50 hover:text-red-600'
-                          onClick={() => handleDeleteOption(option)}
-                        >
-                          <Trash2 className='h-4 w-4' />
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </motion.div>
-              ))}
-            </div>
-          )}
-        </motion.div>
-      </motion.div>
-    </div>
+    <TaxonomyManager<SecurityInterface, SecurityFormData>
+      eyebrow='Espace administrateur'
+      eyebrowIcon={Shield}
+      title='Équipements de sécurité'
+      subtitle='Gérez les équipements de sécurité proposés par les hébergements (détecteur, extincteur, etc.).'
+      backHref='/admin'
+      backLabel='Retour au panel admin'
+      icon={ShieldCheck}
+      kpiTone='red'
+      itemLabelSingular='équipement de sécurité'
+      itemLabelPlural='équipements de sécurité'
+      searchPlaceholder='Rechercher un équipement de sécurité…'
+      getItemId={item => item.id}
+      getItemName={item => item.name ?? ''}
+      searchMatches={(item, q) => (item.name ?? '').toLowerCase().includes(q)}
+      fields={[
+        {
+          name: 'name',
+          label: 'Nom',
+          type: 'text',
+          required: true,
+          placeholder: 'Ex: Détecteur de fumée, Extincteur',
+        },
+      ]}
+      emptyFormData={{ name: '' }}
+      toFormData={item => ({ name: item.name ?? '' })}
+      adapter={adapter}
+    />
   )
 }

--- a/src/app/admin/typeRent/[id]/page.tsx
+++ b/src/app/admin/typeRent/[id]/page.tsx
@@ -2,14 +2,40 @@
 
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState, use } from 'react'
+import { useEffect, useMemo, useState, use } from 'react'
 import Link from 'next/link'
 import { motion } from 'framer-motion'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
+import {
+  Loader2,
+  Home,
+  Hotel,
+  Eye,
+  Edit,
+  Trash2,
+  MapPin,
+  Users,
+  ExternalLink,
+  Shield,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  AlertTriangle,
+  ImageIcon,
+} from 'lucide-react'
+import { ProductValidation } from '@prisma/client'
+
+import { findTypeById, updateTypeRent } from '@/lib/services/typeRent.service'
+import { TypeRentInterface } from '@/lib/interface/typeRentInterface'
+import DeleteTypeModal from '../components/DeleteTypeModal'
+import { toast } from 'sonner'
+
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard } from '@/components/admin/ui/KpiCard'
+import { FilterBar } from '@/components/admin/ui/FilterBar'
+import { DataTable, type DataTableColumn } from '@/components/admin/ui/DataTable'
 import { Button } from '@/components/ui/shadcnui/button'
 import { Input } from '@/components/ui/shadcnui/input'
-import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
-import { Badge } from '@/components/ui/shadcnui/badge'
+import { Label } from '@/components/ui/shadcnui/label'
 import { Checkbox } from '@/components/ui/shadcnui/checkbox'
 import {
   Dialog,
@@ -19,34 +45,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/shadcnui/label'
-import {
-  Loader2,
-  Search,
-  Eye,
-  Home,
-  ArrowLeft,
-  MapPin,
-  Users,
-  Euro,
-  Edit,
-  ExternalLink,
-  Trash2,
-  CheckCircle,
-  Hotel,
-} from 'lucide-react'
-import { findTypeById, updateTypeRent } from '@/lib/services/typeRent.service'
-import { TypeRentInterface } from '@/lib/interface/typeRentInterface'
-import DeleteTypeModal from '../components/DeleteTypeModal'
-import { ProductValidation } from '@prisma/client'
+import { formatCurrency } from '@/lib/utils/formatNumber'
 
-interface Product {
+interface ExtendedProduct {
   id: string
-  title: string | null
-  status: string | null
-}
-
-interface ExtendedProduct extends Product {
   name: string
   address: string
   basePrice: string
@@ -54,24 +56,66 @@ interface ExtendedProduct extends Product {
   validate: string
 }
 
+const VALIDATION_CONFIG: Record<
+  string,
+  { label: string; tone: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  Approve: {
+    label: 'Validé',
+    tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: CheckCircle2,
+  },
+  NotVerified: {
+    label: 'En attente',
+    tone: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: Clock,
+  },
+  Refused: {
+    label: 'Rejeté',
+    tone: 'bg-red-50 text-red-700 ring-red-200',
+    icon: XCircle,
+  },
+  Recheck: {
+    label: 'À revérifier',
+    tone: 'bg-blue-50 text-blue-700 ring-blue-200',
+    icon: AlertTriangle,
+  },
+}
+
+function ValidationPill({ status }: { status: string }) {
+  const config = VALIDATION_CONFIG[status] ?? {
+    label: status,
+    tone: 'bg-slate-50 text-slate-600 ring-slate-200',
+    icon: Clock,
+  }
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.label}
+    </span>
+  )
+}
+
 export default function TypeRentDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)
   const { data: session } = useSession()
   const router = useRouter()
+
   const [typeRent, setTypeRent] = useState<TypeRentInterface | null>(null)
   const [products, setProducts] = useState<ExtendedProduct[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
 
-  // États pour l'édition
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
   const [editTypeName, setEditTypeName] = useState('')
   const [editTypeDescription, setEditTypeDescription] = useState('')
   const [editIsHotelType, setEditIsHotelType] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  // États pour la suppression
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
   const isAdmin = session?.user?.roles === 'ADMIN'
@@ -87,7 +131,6 @@ export default function TypeRentDetailPage({ params }: { params: Promise<{ id: s
 
     const fetchData = async () => {
       try {
-        // Récupérer le type de logement
         const type = await findTypeById(id)
         if (!type) {
           setError('Type de logement introuvable')
@@ -95,7 +138,6 @@ export default function TypeRentDetailPage({ params }: { params: Promise<{ id: s
         }
         setTypeRent(type)
 
-        // Récupérer les produits associés avec plus de détails
         const response = await fetch(`/api/admin/typeRent/${id}/products`)
         if (response.ok) {
           const productsData = await response.json()
@@ -111,13 +153,30 @@ export default function TypeRentDetailPage({ params }: { params: Promise<{ id: s
     fetchData()
   }, [id, isAdmin])
 
+  const filteredProducts = useMemo(() => {
+    const q = searchTerm.trim().toLowerCase()
+    if (!q) return products
+    return products.filter(
+      p =>
+        p.name?.toLowerCase().includes(q) ||
+        p.address?.toLowerCase().includes(q)
+    )
+  }, [products, searchTerm])
+
+  const stats = useMemo(() => {
+    const total = products.length
+    const approved = products.filter(p => p.validate === ProductValidation.Approve).length
+    const pending = products.filter(p => p.validate === ProductValidation.NotVerified).length
+    const refused = products.filter(p => p.validate === ProductValidation.Refused).length
+    return { total, approved, pending, refused }
+  }, [products])
+
   const handleEditType = () => {
-    if (typeRent) {
-      setEditTypeName(typeRent.name || '')
-      setEditTypeDescription(typeRent.description || '')
-      setEditIsHotelType(typeRent.isHotelType || false)
-      setIsEditDialogOpen(true)
-    }
+    if (!typeRent) return
+    setEditTypeName(typeRent.name || '')
+    setEditTypeDescription(typeRent.description || '')
+    setEditIsHotelType(typeRent.isHotelType || false)
+    setIsEditDialogOpen(true)
   }
 
   const handleUpdateType = async () => {
@@ -125,74 +184,105 @@ export default function TypeRentDetailPage({ params }: { params: Promise<{ id: s
 
     setIsSubmitting(true)
     try {
-      const updatedType = await updateTypeRent(
+      const updated = await updateTypeRent(
         typeRent.id,
         editTypeName,
         editTypeDescription,
         editIsHotelType
       )
-
-      if (updatedType) {
-        setTypeRent(updatedType)
+      if (updated) {
+        setTypeRent(updated)
         setIsEditDialogOpen(false)
+        toast.success('Type de logement mis à jour')
       } else {
-        setError('Erreur lors de la modification du type de logement')
+        toast.error('Erreur lors de la modification du type de logement')
       }
     } catch (err) {
       console.error('Erreur lors de la modification:', err)
-      setError('Erreur lors de la modification du type de logement')
+      toast.error('Erreur lors de la modification du type de logement')
     } finally {
       setIsSubmitting(false)
     }
   }
 
-  const handleDeleteSuccess = () => {
-    router.push('/admin/typeRent')
-  }
-
-  const handleDeleteError = (message: string) => {
-    setError(message)
-    setTimeout(() => setError(null), 5000)
-  }
-
-  const filteredProducts = products.filter(
-    product =>
-      product.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      product.address?.toLowerCase().includes(searchTerm.toLowerCase())
-  )
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'Verified':
-        return 'bg-green-50 text-green-700 border-green-200'
-      case 'Rejected':
-        return 'bg-red-50 text-red-700 border-red-200'
-      case 'NotVerified':
-        return 'bg-yellow-50 text-yellow-700 border-yellow-200'
-      default:
-        return 'bg-gray-50 text-gray-700 border-gray-200'
-    }
-  }
-
-  const getStatusLabel = (status: string) => {
-    switch (status) {
-      case 'Verified':
-        return 'Validé'
-      case 'Rejected':
-        return 'Rejeté'
-      case 'NotVerified':
-        return 'En attente'
-      default:
-        return status
-    }
-  }
+  const columns: Array<DataTableColumn<ExtendedProduct>> = [
+    {
+      key: 'name',
+      header: 'Hébergement',
+      sortable: true,
+      sortAccessor: item => (item.name ?? '').toLowerCase(),
+      render: item => (
+        <div className='flex items-center gap-3 min-w-0'>
+          <div className='flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-600'>
+            <Home className='h-4 w-4' />
+          </div>
+          <div className='min-w-0'>
+            <p className='truncate text-sm font-semibold text-slate-900'>
+              {item.name || 'Sans nom'}
+            </p>
+            <p className='flex items-center gap-1 truncate text-xs text-slate-500'>
+              <MapPin className='h-3 w-3 shrink-0' />
+              {item.address || 'Adresse non renseignée'}
+            </p>
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: 'basePrice',
+      header: 'Prix de base',
+      sortable: true,
+      sortAccessor: item => parseFloat(item.basePrice || '0'),
+      align: 'right',
+      render: item => (
+        <p className='text-sm font-semibold tabular-nums text-slate-900'>
+          {formatCurrency(parseFloat(item.basePrice || '0'))}
+        </p>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'capacity',
+      header: 'Capacité',
+      sortable: true,
+      sortAccessor: item => Number(item.maxPeople ?? 0),
+      align: 'right',
+      render: item => (
+        <div className='flex items-center justify-end gap-1 text-sm text-slate-600'>
+          <Users className='h-4 w-4 text-slate-400' />
+          {item.maxPeople ? `${item.maxPeople.toString()} pers.` : '—'}
+        </div>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'validate',
+      header: 'Validation',
+      sortable: true,
+      sortAccessor: item => item.validate,
+      render: item => <ValidationPill status={item.validate} />,
+      cellClassName: 'whitespace-nowrap',
+    },
+  ]
 
   if (loading) {
     return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 p-8 flex items-center justify-center'>
-        <div className='flex items-center gap-3'>
-          <Loader2 className='h-6 w-6 animate-spin text-purple-600' />
-          <p className='text-slate-600 text-lg'>Chargement des données...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
         </div>
       </div>
     )
@@ -200,298 +290,244 @@ export default function TypeRentDetailPage({ params }: { params: Promise<{ id: s
 
   if (error || !typeRent) {
     return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive'>
-            <AlertDescription>{error || 'Type de logement introuvable'}</AlertDescription>
-          </Alert>
-          <Button variant='outline' className='mt-4' asChild>
-            <Link href='/admin/typeRent'>
-              <ArrowLeft className='h-4 w-4 mr-2' />
-              Retour aux types
-            </Link>
-          </Button>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-4xl space-y-8 p-6'>
+          <PageHeader
+            backHref='/admin/typeRent'
+            backLabel='Retour aux types'
+            eyebrow='Espace administrateur'
+            title='Type introuvable'
+            subtitle='Ce type de logement n’existe pas ou a été supprimé.'
+          />
+          <div className='rounded-2xl border border-slate-200/80 bg-white p-12 text-center shadow-sm'>
+            <div className='mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 text-red-600'>
+              <AlertTriangle className='h-8 w-8' />
+            </div>
+            <h2 className='mt-4 text-lg font-bold text-slate-900'>
+              {error || 'Type de logement introuvable'}
+            </h2>
+            <Button className='mt-6' asChild>
+              <Link href='/admin/typeRent'>Retour aux types</Link>
+            </Button>
+          </div>
         </div>
       </div>
     )
   }
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
       <motion.div
-        className='max-w-7xl mx-auto p-6 space-y-8'
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.5 }}
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
       >
-        {/* Header with breadcrumb */}
-        <motion.div
-          className='flex items-center gap-4'
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-        >
-          <Button variant='ghost' size='sm' asChild className='text-slate-600 hover:text-slate-800'>
-            <Link href='/admin/typeRent' className='flex items-center gap-2'>
-              <ArrowLeft className='h-4 w-4' />
-              Retour aux types
-            </Link>
-          </Button>
-        </motion.div>
-
-        {/* Type Info Header */}
-        <motion.div
-          className='bg-white/70 backdrop-blur-sm rounded-2xl p-8 border-0 shadow-lg'
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.1 }}
-        >
-          <div className='flex items-start justify-between'>
-            <div className='space-y-4'>
-              <div className='flex items-center gap-3'>
-                <div className='p-3 bg-purple-100 rounded-xl'>
-                  <Home className='h-8 w-8 text-purple-600' />
-                </div>
-                <div>
-                  <h1 className='text-3xl font-bold text-slate-800'>{typeRent.name}</h1>
-                  <p className='text-slate-600 mt-1'>{typeRent.description}</p>
-                </div>
-              </div>
-              <div className='flex items-center gap-4 flex-wrap'>
-                {typeRent.isHotelType && (
-                  <Badge
-                    variant='secondary'
-                    className='bg-purple-50 text-purple-700 border-purple-200 px-3 py-1'
-                  >
-                    <Hotel className='h-3 w-3 mr-1' />
-                    Type Hôtel
-                  </Badge>
-                )}
-                <Badge variant='secondary' className='bg-blue-50 text-blue-700 px-3 py-1'>
-                  <Home className='h-3 w-3 mr-1' />
-                  {products.length} logement{products.length > 1 ? 's' : ''}
-                </Badge>
-                <Badge variant='secondary' className='bg-green-50 text-green-700 px-3 py-1'>
-                  {products.filter(p => p.validate === ProductValidation.Approve).length} validé
-                  {products.filter(p => p.validate === ProductValidation.Approve).length > 1 ? 's' : ''}
-                </Badge>
-                <Badge variant='secondary' className='bg-yellow-50 text-yellow-700 px-3 py-1'>
-                  {products.filter(p => p.validate === ProductValidation.NotVerified).length} en attente
-                </Badge>
-              </div>
-            </div>
-            <div className='flex gap-2'>
-              <Button variant='outline' onClick={handleEditType}>
-                <Edit className='h-4 w-4 mr-2' />
+        <PageHeader
+          backHref='/admin/typeRent'
+          backLabel='Retour aux types'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title={typeRent.name || 'Type sans nom'}
+          subtitle={typeRent.description || 'Aucune description'}
+          actions={
+            <div className='flex flex-wrap items-center gap-2'>
+              {typeRent.isHotelType && (
+                <span className='inline-flex items-center gap-1 rounded-full bg-purple-50 px-3 py-1 text-xs font-semibold text-purple-700 ring-1 ring-purple-200'>
+                  <Hotel className='h-3 w-3' />
+                  Type hôtel
+                </span>
+              )}
+              {typeRent.coverImage && (
+                <span className='inline-flex items-center gap-1 rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700 ring-1 ring-emerald-200'>
+                  <ImageIcon className='h-3 w-3' />
+                  Image définie
+                </span>
+              )}
+              <Button variant='outline' onClick={handleEditType} className='gap-2'>
+                <Edit className='h-4 w-4' />
                 Modifier
               </Button>
               <Button
                 variant='outline'
-                className='hover:bg-red-50 hover:text-red-600 hover:border-red-200'
                 onClick={() => setIsDeleteModalOpen(true)}
+                className='gap-2 border-red-200 text-red-700 hover:bg-red-50 hover:text-red-700'
               >
-                <Trash2 className='h-4 w-4 mr-2' />
+                <Trash2 className='h-4 w-4' />
                 Supprimer
               </Button>
             </div>
-          </div>
-        </motion.div>
+          }
+        />
 
-        {/* Search bar */}
-        <motion.div
-          className='bg-white/70 backdrop-blur-sm rounded-2xl p-6 border-0 shadow-lg'
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.2 }}
-        >
-          <div className='relative'>
-            <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4' />
-            <Input
-              placeholder='Rechercher un logement par nom ou adresse...'
-              value={searchTerm}
-              onChange={e => setSearchTerm(e.target.value)}
-              className='pl-10 border-slate-200 focus:border-purple-300 focus:ring-purple-200'
-            />
-          </div>
-        </motion.div>
+        {/* KPI row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Hébergements'
+            value={stats.total}
+            hint='utilisant ce type'
+            icon={Home}
+            tone='purple'
+          />
+          <KpiCard
+            label='Validés'
+            value={stats.approved}
+            hint={`sur ${stats.total}`}
+            icon={CheckCircle2}
+            tone='emerald'
+          />
+          <KpiCard
+            label='En attente'
+            value={stats.pending}
+            hint='à valider'
+            icon={Clock}
+            tone='amber'
+          />
+          <KpiCard
+            label='Rejetés'
+            value={stats.refused}
+            hint='non publiés'
+            icon={XCircle}
+            tone='red'
+          />
+        </div>
 
-        {/* Products Grid */}
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.3 }}>
-          {filteredProducts.length === 0 ? (
-            <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm'>
-              <CardContent className='text-center py-12'>
-                <Home className='h-16 w-16 text-slate-300 mx-auto mb-4' />
-                <h3 className='text-xl font-semibold text-slate-600 mb-2'>
-                  {searchTerm ? 'Aucun résultat' : 'Aucun logement'}
-                </h3>
-                <p className='text-slate-500'>
-                  {searchTerm
-                    ? 'Aucun logement ne correspond à votre recherche.'
-                    : `Aucun logement n'utilise ce type "${typeRent.name}".`}
-                </p>
-              </CardContent>
-            </Card>
-          ) : (
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3'>
-              {filteredProducts.map((product, index) => (
-                <motion.div
-                  key={product.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.3 + index * 0.05 }}
+        {/* Search */}
+        <FilterBar
+          searchValue={searchTerm}
+          onSearchChange={setSearchTerm}
+          searchPlaceholder='Rechercher un hébergement par nom ou adresse…'
+        />
+
+        {/* Products table */}
+        <DataTable<ExtendedProduct>
+          columns={columns}
+          rows={filteredProducts}
+          getRowId={item => item.id}
+          loading={false}
+          rowActions={item => (
+            <div className='flex items-center justify-end gap-1'>
+              <Button variant='ghost' size='sm' asChild>
+                <Link
+                  href={`/admin/products/${item.id}`}
+                  className='gap-1 text-slate-600 hover:text-slate-900'
                 >
-                  <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm hover:shadow-xl transition-all duration-300 group h-full'>
-                    <CardHeader className='pb-3'>
-                      <div className='flex items-start justify-between mb-2'>
-                        <CardTitle className='text-lg font-semibold text-slate-800 line-clamp-1'>
-                          {product.name || 'Sans nom'}
-                        </CardTitle>
-                        <Badge className={getStatusColor(product.validate)}>
-                          {getStatusLabel(product.validate)}
-                        </Badge>
-                      </div>
-                      <div className='space-y-2 text-sm text-slate-600'>
-                        <div className='flex items-center gap-2'>
-                          <MapPin className='h-4 w-4 text-slate-400' />
-                          <span className='line-clamp-1'>
-                            {product.address || 'Adresse non renseignée'}
-                          </span>
-                        </div>
-                        <div className='flex items-center gap-4'>
-                          <div className='flex items-center gap-1'>
-                            <Euro className='h-4 w-4 text-slate-400' />
-                            <span className='font-medium'>{product.basePrice || '0'}</span>
-                          </div>
-                          {product.maxPeople && (
-                            <div className='flex items-center gap-1'>
-                              <Users className='h-4 w-4 text-slate-400' />
-                              <span>{product.maxPeople.toString()} pers.</span>
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </CardHeader>
-                    <CardContent className='pt-0'>
-                      <div className='flex items-center gap-2'>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          asChild
-                          className='flex-1 hover:bg-purple-50 hover:text-purple-600'
-                        >
-                          <Link href={`/admin/products/${product.id}`}>
-                            <Eye className='h-4 w-4 mr-2' />
-                            Voir détails
-                          </Link>
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          asChild
-                          className='hover:bg-blue-50 hover:text-blue-600'
-                        >
-                          <Link href={`/host/${product.id}`} target='_blank'>
-                            <ExternalLink className='h-4 w-4' />
-                          </Link>
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </motion.div>
-              ))}
+                  <Eye className='h-4 w-4' />
+                  Détails
+                </Link>
+              </Button>
+              <Button
+                variant='ghost'
+                size='sm'
+                asChild
+                className='text-slate-600 hover:text-blue-600'
+              >
+                <Link href={`/host/${item.id}`} target='_blank'>
+                  <ExternalLink className='h-4 w-4' />
+                </Link>
+              </Button>
             </div>
           )}
-        </motion.div>
-
-        {/* Dialog d'édition */}
-        <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-          <DialogContent className='sm:max-w-[425px]'>
-            <DialogHeader>
-              <DialogTitle className='flex items-center gap-2'>
-                <Edit className='h-5 w-5 text-orange-600' />
-                Modifier le type de logement
-              </DialogTitle>
-              <DialogDescription>
-                Modifiez les informations de ce type de logement.
-              </DialogDescription>
-            </DialogHeader>
-            <div className='space-y-4 py-4'>
-              <div className='space-y-2'>
-                <Label htmlFor='editTypeName'>Nom du type</Label>
-                <Input
-                  id='editTypeName'
-                  placeholder='Ex: Villa, Appartement, Maison...'
-                  value={editTypeName}
-                  onChange={e => setEditTypeName(e.target.value)}
-                />
-              </div>
-              <div className='space-y-2'>
-                <Label htmlFor='editTypeDescription'>Description</Label>
-                <Input
-                  id='editTypeDescription'
-                  placeholder='Description du type de logement...'
-                  value={editTypeDescription}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setEditTypeDescription(e.target.value)
-                  }
-                />
-              </div>
-              <div className='flex items-center space-x-2 pt-2'>
-                <Checkbox
-                  id='editIsHotelType'
-                  checked={editIsHotelType}
-                  onCheckedChange={checked => setEditIsHotelType(checked as boolean)}
-                />
-                <Label
-                  htmlFor='editIsHotelType'
-                  className='text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer'
-                >
-                  <div className='flex items-center gap-2'>
-                    <Hotel className='h-4 w-4 text-orange-600' />
-                    <span>Fonctionne comme un hôtel (gestion multi-chambres)</span>
-                  </div>
-                </Label>
-              </div>
-            </div>
-            <DialogFooter>
-              <Button
-                variant='outline'
-                onClick={() => setIsEditDialogOpen(false)}
-                disabled={isSubmitting}
-              >
-                Annuler
-              </Button>
-              <Button
-                onClick={handleUpdateType}
-                disabled={!editTypeName.trim() || !editTypeDescription.trim() || isSubmitting}
-                className='bg-orange-600 hover:bg-orange-700'
-              >
-                {isSubmitting ? (
-                  <>
-                    <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                    Modification...
-                  </>
-                ) : (
-                  <>
-                    <CheckCircle className='h-4 w-4 mr-2' />
-                    Modifier
-                  </>
-                )}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-
-        {/* Modal de suppression */}
-        <DeleteTypeModal
-          isOpen={isDeleteModalOpen}
-          onClose={() => {
-            setIsDeleteModalOpen(false)
+          emptyState={{
+            icon: Home,
+            title: searchTerm ? 'Aucun résultat' : 'Aucun hébergement',
+            subtitle: searchTerm
+              ? 'Essayez d’ajuster votre recherche.'
+              : `Aucun hébergement n'utilise ce type.`,
           }}
-          typeToDelete={typeRent}
-          onDeleteSuccess={handleDeleteSuccess}
-          onError={handleDeleteError}
         />
       </motion.div>
+
+      {/* Edit dialog */}
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent className='sm:max-w-[520px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 ring-1 ring-blue-100'>
+                <Edit className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>Modifier le type de logement</DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  Mettez à jour les informations de ce type.
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <div className='space-y-4 py-2'>
+            <div className='space-y-1.5'>
+              <Label htmlFor='editTypeName'>
+                Nom <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='editTypeName'
+                value={editTypeName}
+                onChange={e => setEditTypeName(e.target.value)}
+              />
+            </div>
+            <div className='space-y-1.5'>
+              <Label htmlFor='editTypeDescription'>
+                Description <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='editTypeDescription'
+                value={editTypeDescription}
+                onChange={e => setEditTypeDescription(e.target.value)}
+              />
+            </div>
+            <div className='flex items-start gap-3 rounded-xl border border-slate-200 bg-slate-50/60 p-3'>
+              <Checkbox
+                id='editIsHotelType'
+                checked={editIsHotelType}
+                onCheckedChange={checked => setEditIsHotelType(checked === true)}
+              />
+              <Label htmlFor='editIsHotelType' className='cursor-pointer space-y-0.5'>
+                <span className='flex items-center gap-1.5 text-sm font-medium text-slate-900'>
+                  <Hotel className='h-4 w-4 text-purple-600' />
+                  Fonctionne comme un hôtel
+                </span>
+                <span className='text-xs text-slate-500'>
+                  Active la gestion multi-chambres pour ce type.
+                </span>
+              </Label>
+            </div>
+          </div>
+
+          <DialogFooter className='gap-2'>
+            <Button
+              variant='outline'
+              onClick={() => setIsEditDialogOpen(false)}
+              disabled={isSubmitting}
+            >
+              Annuler
+            </Button>
+            <Button
+              onClick={handleUpdateType}
+              disabled={!editTypeName.trim() || !editTypeDescription.trim() || isSubmitting}
+              className='gap-2'
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Mise à jour…
+                </>
+              ) : (
+                'Mettre à jour'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete modal — redirects back to the list on success */}
+      <DeleteTypeModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        typeToDelete={typeRent}
+        onDeleteSuccess={() => router.push('/admin/typeRent')}
+        onError={message => toast.error(message)}
+      />
     </div>
   )
 }

--- a/src/app/admin/typeRent/page.tsx
+++ b/src/app/admin/typeRent/page.tsx
@@ -1,15 +1,38 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+import {
+  Home,
+  Hotel,
+  Plus,
+  Eye,
+  Edit,
+  Trash2,
+  Shield,
+  Loader2,
+  ImageIcon,
+  CheckCircle2,
+} from 'lucide-react'
+
 import { useAuth } from '@/hooks/useAuth'
 import { isAdmin } from '@/hooks/useAdminAuth'
-import Link from 'next/link'
-import { motion, Variants } from 'framer-motion'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
+import { findAllTypeRent, createTypeRent, updateTypeRent } from '@/lib/services/typeRent.service'
+import { TypeRentInterface } from '@/lib/interface/typeRentInterface'
+import DeleteTypeModal from './components/DeleteTypeModal'
+import ImageUpload from './components/ImageUpload'
+
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard } from '@/components/admin/ui/KpiCard'
+import { FilterBar } from '@/components/admin/ui/FilterBar'
+import { DataTable, type DataTableColumn } from '@/components/admin/ui/DataTable'
 import { Button } from '@/components/ui/shadcnui/button'
 import { Input } from '@/components/ui/shadcnui/input'
-import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
+import { Label } from '@/components/ui/shadcnui/label'
+import { Checkbox } from '@/components/ui/shadcnui/checkbox'
 import {
   Dialog,
   DialogContent,
@@ -17,49 +40,10 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/shadcnui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import { Checkbox } from '@/components/ui/shadcnui/checkbox'
-import {
-  Loader2,
-  Search,
-  Eye,
-  Home,
-  Plus,
-  ArrowLeft,
-  CheckCircle,
-  Edit3,
-  Trash2,
-  Hotel,
-} from 'lucide-react'
-import { findAllTypeRent, createTypeRent, updateTypeRent } from '@/lib/services/typeRent.service'
-import { TypeRentInterface } from '@/lib/interface/typeRentInterface'
-import DeleteTypeModal from './components/DeleteTypeModal'
-import ImageUpload from './components/ImageUpload'
 
-const containerVariants: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
-  },
-}
-
-const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: 'tween' as const,
-      duration: 0.5,
-      ease: 'easeOut',
-    },
-  },
+interface TypeRentWithCount extends TypeRentInterface {
+  _count?: { products: number }
 }
 
 export default function TypeRentPage() {
@@ -69,10 +53,12 @@ export default function TypeRentPage() {
     isAuthenticated,
   } = useAuth({ required: true, redirectTo: '/auth' })
   const router = useRouter()
-  const [typeRents, setTypeRents] = useState<TypeRentInterface[]>([])
+
+  const [typeRents, setTypeRents] = useState<TypeRentWithCount[]>([])
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
+
+  // Add dialog state
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
   const [newTypeName, setNewTypeName] = useState('')
   const [newTypeDescription, setNewTypeDescription] = useState('')
@@ -80,15 +66,15 @@ export default function TypeRentPage() {
   const [newCoverImage, setNewCoverImage] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  // États pour l'édition
+  // Edit dialog state
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
-  const [editingType, setEditingType] = useState<TypeRentInterface | null>(null)
+  const [editingType, setEditingType] = useState<TypeRentWithCount | null>(null)
   const [editTypeName, setEditTypeName] = useState('')
   const [editTypeDescription, setEditTypeDescription] = useState('')
   const [editIsHotelType, setEditIsHotelType] = useState(false)
   const [editCoverImage, setEditCoverImage] = useState<string | null>(null)
 
-  // États pour la suppression
+  // Delete modal state
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [deletingType, setDeletingType] = useState<TypeRentInterface | null>(null)
 
@@ -101,13 +87,10 @@ export default function TypeRentPage() {
   useEffect(() => {
     const fetchTypeRents = async () => {
       try {
-        const typeRentData = await findAllTypeRent()
-        if (typeRentData) {
-          setTypeRents(typeRentData)
-        }
-      } catch (err) {
-        setError('Erreur lors du chargement des types de logements')
-        console.error(err)
+        const data = await findAllTypeRent()
+        if (data) setTypeRents(data as TypeRentWithCount[])
+      } catch (error) {
+        console.error('Erreur lors du chargement des types:', error)
       } finally {
         setLoading(false)
       }
@@ -115,11 +98,33 @@ export default function TypeRentPage() {
     fetchTypeRents()
   }, [])
 
-  const filteredTypes = typeRents.filter(
-    type =>
-      type.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      type.description?.toLowerCase().includes(searchTerm.toLowerCase())
-  )
+  const filteredTypes = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase()
+    if (!query) return typeRents
+    return typeRents.filter(
+      type =>
+        type.name?.toLowerCase().includes(query) ||
+        type.description?.toLowerCase().includes(query)
+    )
+  }, [typeRents, searchTerm])
+
+  const stats = useMemo(() => {
+    const total = typeRents.length
+    const hotelCount = typeRents.filter(t => t.isHotelType).length
+    const withImage = typeRents.filter(t => Boolean(t.coverImage)).length
+    const totalUsages = typeRents.reduce(
+      (sum, t) => sum + (t._count?.products ?? 0),
+      0
+    )
+    return { total, hotelCount, withImage, totalUsages }
+  }, [typeRents])
+
+  const resetNewForm = () => {
+    setNewTypeName('')
+    setNewTypeDescription('')
+    setNewIsHotelType(false)
+    setNewCoverImage(null)
+  }
 
   const handleAddType = async () => {
     if (!newTypeName.trim() || !newTypeDescription.trim()) return
@@ -132,26 +137,19 @@ export default function TypeRentPage() {
         newIsHotelType,
         newCoverImage || undefined
       )
-
       if (newType) {
-        setTypeRents([...typeRents, newType])
-        setNewTypeName('')
-        setNewTypeDescription('')
-        setNewIsHotelType(false)
-        setNewCoverImage(null)
+        setTypeRents(prev => [...prev, newType as TypeRentWithCount])
+        resetNewForm()
         setIsAddDialogOpen(false)
-      } else {
-        setError('Erreur lors de la création du type de logement')
       }
-    } catch (err) {
-      console.error('Erreur lors de la création:', err)
-      setError('Erreur lors de la création du type de logement')
+    } catch (error) {
+      console.error('Erreur lors de la création:', error)
     } finally {
       setIsSubmitting(false)
     }
   }
 
-  const handleEditType = (type: TypeRentInterface) => {
+  const handleEditType = (type: TypeRentWithCount) => {
     setEditingType(type)
     setEditTypeName(type.name || '')
     setEditTypeDescription(type.description || '')
@@ -165,418 +163,447 @@ export default function TypeRentPage() {
 
     setIsSubmitting(true)
     try {
-      const updatedType = await updateTypeRent(
+      const updated = await updateTypeRent(
         editingType.id,
         editTypeName,
         editTypeDescription,
         editIsHotelType,
         editCoverImage
       )
-
-      if (updatedType) {
-        setTypeRents(typeRents.map(type => (type.id === editingType.id ? updatedType : type)))
-        setEditTypeName('')
-        setEditTypeDescription('')
-        setEditIsHotelType(false)
-        setEditCoverImage(null)
+      if (updated) {
+        setTypeRents(prev =>
+          prev.map(t =>
+            t.id === editingType.id ? ({ ...updated, _count: t._count } as TypeRentWithCount) : t
+          )
+        )
         setEditingType(null)
         setIsEditDialogOpen(false)
-      } else {
-        setError('Erreur lors de la modification du type de logement')
       }
-    } catch (err) {
-      console.error('Erreur lors de la modification:', err)
-      setError('Erreur lors de la modification du type de logement')
+    } catch (error) {
+      console.error('Erreur lors de la modification:', error)
     } finally {
       setIsSubmitting(false)
     }
   }
 
-  const handleDeleteType = (type: TypeRentInterface) => {
+  const handleDeleteType = (type: TypeRentWithCount) => {
     setDeletingType(type)
     setIsDeleteModalOpen(true)
   }
 
   const handleDeleteSuccess = (typeId: string) => {
-    setTypeRents(typeRents.filter(type => type.id !== typeId))
+    setTypeRents(prev => prev.filter(t => t.id !== typeId))
     setDeletingType(null)
     setIsDeleteModalOpen(false)
   }
 
-  const handleDeleteError = (message: string) => {
-    setError(message)
-    setTimeout(() => setError(null), 5000)
-  }
+  const columns: Array<DataTableColumn<TypeRentWithCount>> = [
+    {
+      key: 'name',
+      header: 'Type de logement',
+      sortable: true,
+      sortAccessor: item => (item.name ?? '').toLowerCase(),
+      render: item => (
+        <div className='flex items-center gap-3 min-w-0'>
+          <div className='relative flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-gradient-to-br from-purple-500 to-indigo-500 text-white shadow-sm'>
+            {item.coverImage ? (
+              <Image
+                src={item.coverImage}
+                alt={item.name || 'Type'}
+                fill
+                className='object-cover'
+                sizes='44px'
+                unoptimized
+              />
+            ) : (
+              <Home className='h-5 w-5' />
+            )}
+          </div>
+          <div className='min-w-0'>
+            <p className='truncate text-sm font-semibold text-slate-900'>
+              {item.name || 'Type sans nom'}
+            </p>
+            <p className='truncate text-xs text-slate-500'>
+              {item.description || 'Aucune description'}
+            </p>
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: 'flags',
+      header: 'Caractéristiques',
+      render: item => (
+        <div className='flex flex-wrap items-center gap-1.5'>
+          {item.isHotelType && (
+            <span className='inline-flex items-center gap-1 rounded-full bg-purple-50 px-2 py-0.5 text-xs font-semibold text-purple-700 ring-1 ring-purple-200'>
+              <Hotel className='h-3 w-3' />
+              Hôtel
+            </span>
+          )}
+          {item.coverImage ? (
+            <span className='inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-700 ring-1 ring-emerald-200'>
+              <ImageIcon className='h-3 w-3' />
+              Image
+            </span>
+          ) : (
+            <span className='inline-flex items-center rounded-full bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-500 ring-1 ring-slate-200'>
+              Sans image
+            </span>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'count',
+      header: 'Produits',
+      sortable: true,
+      sortAccessor: item => item._count?.products ?? 0,
+      align: 'right',
+      render: item => {
+        const count = item._count?.products ?? 0
+        return (
+          <span
+            className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${
+              count > 0
+                ? 'bg-blue-50 text-blue-700 ring-blue-200'
+                : 'bg-slate-50 text-slate-600 ring-slate-200'
+            }`}
+          >
+            {count} produit{count > 1 ? 's' : ''}
+          </span>
+        )
+      },
+      cellClassName: 'whitespace-nowrap',
+    },
+  ]
 
   if (isAuthLoading || loading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
         </div>
       </div>
     )
   }
 
-  if (!session) {
-    return null
-  }
-
-  if (error) {
-    return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive'>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        </div>
-      </div>
-    )
-  }
+  if (!session) return null
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
       <motion.div
-        className='max-w-7xl mx-auto p-6 space-y-8'
-        variants={containerVariants}
-        initial='hidden'
-        animate='visible'
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
       >
-        {/* Header with breadcrumb */}
-        <motion.div className='flex items-center gap-4' variants={itemVariants}>
-          <Button variant='ghost' size='sm' asChild className='text-slate-600 hover:text-slate-800'>
-            <Link href='/admin' className='flex items-center gap-2'>
-              <ArrowLeft className='h-4 w-4' />
-              Retour au panel admin
-            </Link>
-          </Button>
-        </motion.div>
+        <PageHeader
+          backHref='/admin'
+          backLabel='Retour au panel admin'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title='Types de logements'
+          subtitle='Gérez les catégories d’hébergements disponibles sur la plateforme (villa, appartement, hôtel, etc.).'
+          actions={
+            <Button onClick={() => setIsAddDialogOpen(true)} className='gap-2'>
+              <Plus className='h-4 w-4' />
+              Ajouter un type
+            </Button>
+          }
+        />
 
-        {/* Page Header */}
-        <motion.div className='text-center space-y-4' variants={itemVariants}>
-          <div className='inline-flex items-center gap-2 px-4 py-2 bg-purple-100 text-purple-700 rounded-full text-sm font-medium'>
-            <Home className='h-4 w-4' />
-            Types de Logements
-          </div>
-          <h1 className='text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-800 via-purple-700 to-indigo-700'>
-            Gestion des types de logements
-          </h1>
-          <p className='text-slate-600 max-w-2xl mx-auto text-lg'>
-            {typeRents.length} type{typeRents.length > 1 ? 's' : ''} de logement
-            {typeRents.length > 1 ? 's' : ''} enregistré{typeRents.length > 1 ? 's' : ''}
-          </p>
-        </motion.div>
+        {/* KPI row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Types enregistrés'
+            value={stats.total}
+            hint='dans le catalogue'
+            icon={Home}
+            tone='purple'
+          />
+          <KpiCard
+            label='Types hôteliers'
+            value={stats.hotelCount}
+            hint='gestion multi-chambres'
+            icon={Hotel}
+            tone='indigo'
+          />
+          <KpiCard
+            label='Avec image'
+            value={stats.withImage}
+            hint={`sur ${stats.total} au total`}
+            icon={ImageIcon}
+            tone='emerald'
+          />
+          <KpiCard
+            label='Produits catégorisés'
+            value={stats.totalUsages}
+            hint='hébergements concernés'
+            icon={CheckCircle2}
+            tone='blue'
+          />
+        </div>
 
-        {/* Search and Add */}
-        <motion.div variants={itemVariants}>
-          <div className='flex flex-col sm:flex-row gap-4 items-center justify-between bg-white/70 backdrop-blur-sm rounded-2xl p-6 border-0 shadow-lg'>
-            <div className='relative flex-1 max-w-md'>
-              <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4' />
-              <Input
-                placeholder='Rechercher un type de logement...'
-                value={searchTerm}
-                onChange={e => setSearchTerm(e.target.value)}
-                className='pl-10 border-slate-200 focus:border-purple-300 focus:ring-purple-200'
-              />
-            </div>
-            <div className='flex gap-3'>
-              <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-                <DialogTrigger asChild>
-                  <Button className='bg-purple-600 hover:bg-purple-700 text-white shadow-lg'>
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter un type
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Home className='h-5 w-5 text-purple-600' />
-                      Ajouter un type de logement
-                    </DialogTitle>
-                    <DialogDescription>
-                      Créez un nouveau type de logement pour votre plateforme.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='typeName'>Nom du type</Label>
-                      <Input
-                        id='typeName'
-                        placeholder='Ex: Villa, Appartement, Maison...'
-                        value={newTypeName}
-                        onChange={e => setNewTypeName(e.target.value)}
-                      />
-                    </div>
-                    <div className='space-y-2'>
-                      <Label htmlFor='typeDescription'>Description</Label>
-                      <Input
-                        id='typeDescription'
-                        placeholder='Description du type de logement...'
-                        value={newTypeDescription}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                          setNewTypeDescription(e.target.value)
-                        }
-                      />
-                    </div>
-                    <ImageUpload
-                      currentImage={newCoverImage}
-                      onImageChange={setNewCoverImage}
-                      entityType='type-rent'
-                    />
-                    <div className='flex items-center space-x-2 pt-2'>
-                      <Checkbox
-                        id='isHotelType'
-                        checked={newIsHotelType}
-                        onCheckedChange={checked => setNewIsHotelType(checked as boolean)}
-                      />
-                      <Label
-                        htmlFor='isHotelType'
-                        className='text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer'
-                      >
-                        <div className='flex items-center gap-2'>
-                          <Hotel className='h-4 w-4 text-purple-600' />
-                          <span>Fonctionne comme un hôtel (gestion multi-chambres)</span>
-                        </div>
-                      </Label>
-                    </div>
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsAddDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleAddType}
-                      disabled={!newTypeName.trim() || !newTypeDescription.trim() || isSubmitting}
-                      className='bg-purple-600 hover:bg-purple-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Création...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Créer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
+        {/* Search */}
+        <FilterBar
+          searchValue={searchTerm}
+          onSearchChange={setSearchTerm}
+          searchPlaceholder='Rechercher un type de logement…'
+        />
 
-              {/* Dialog d'édition */}
-              <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Edit3 className='h-5 w-5 text-orange-600' />
-                      Modifier le type de logement
-                    </DialogTitle>
-                    <DialogDescription>
-                      Modifiez les informations de ce type de logement.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='editTypeName'>Nom du type</Label>
-                      <Input
-                        id='editTypeName'
-                        placeholder='Ex: Villa, Appartement, Maison...'
-                        value={editTypeName}
-                        onChange={e => setEditTypeName(e.target.value)}
-                      />
-                    </div>
-                    <div className='space-y-2'>
-                      <Label htmlFor='editTypeDescription'>Description</Label>
-                      <Input
-                        id='editTypeDescription'
-                        placeholder='Description du type de logement...'
-                        value={editTypeDescription}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                          setEditTypeDescription(e.target.value)
-                        }
-                      />
-                    </div>
-                    <ImageUpload
-                      currentImage={editCoverImage}
-                      onImageChange={setEditCoverImage}
-                      entityType='type-rent'
-                      entityId={editingType?.id}
-                    />
-                    <div className='flex items-center space-x-2 pt-2'>
-                      <Checkbox
-                        id='editIsHotelType'
-                        checked={editIsHotelType}
-                        onCheckedChange={checked => setEditIsHotelType(checked as boolean)}
-                      />
-                      <Label
-                        htmlFor='editIsHotelType'
-                        className='text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer'
-                      >
-                        <div className='flex items-center gap-2'>
-                          <Hotel className='h-4 w-4 text-orange-600' />
-                          <span>Fonctionne comme un hôtel (gestion multi-chambres)</span>
-                        </div>
-                      </Label>
-                    </div>
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsEditDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleUpdateType}
-                      disabled={!editTypeName.trim() || !editTypeDescription.trim() || isSubmitting}
-                      className='bg-orange-600 hover:bg-orange-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Modification...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Modifier
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Modal de suppression améliorée */}
-              <DeleteTypeModal
-                isOpen={isDeleteModalOpen}
-                onClose={() => {
-                  setIsDeleteModalOpen(false)
-                  setDeletingType(null)
-                }}
-                typeToDelete={deletingType}
-                onDeleteSuccess={handleDeleteSuccess}
-                onError={handleDeleteError}
-              />
-            </div>
-          </div>
-        </motion.div>
-
-        {/* Content */}
-        <motion.div variants={itemVariants}>
-          {filteredTypes.length === 0 ? (
-            <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm'>
-              <CardContent className='text-center py-12'>
-                <Home className='h-16 w-16 text-slate-300 mx-auto mb-4' />
-                <h3 className='text-xl font-semibold text-slate-600 mb-2'>
-                  {searchTerm ? 'Aucun résultat' : 'Aucun type de logement'}
-                </h3>
-                <p className='text-slate-500 mb-6'>
-                  {searchTerm
-                    ? 'Aucun type ne correspond à votre recherche.'
-                    : 'Commencez par ajouter votre premier type de logement.'}
-                </p>
-                {!searchTerm && (
-                  <Button
-                    onClick={() => setIsAddDialogOpen(true)}
-                    className='bg-purple-600 hover:bg-purple-700'
-                  >
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter un type
-                  </Button>
-                )}
-              </CardContent>
-            </Card>
-          ) : (
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 items-stretch'>
-              {filteredTypes.map((type, index) => (
-                <motion.div
-                  key={type.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.05 }}
+        {/* Table */}
+        <DataTable<TypeRentWithCount>
+          columns={columns}
+          rows={filteredTypes}
+          getRowId={item => item.id}
+          loading={loading}
+          rowActions={item => (
+            <div className='flex items-center justify-end gap-1'>
+              <Button variant='ghost' size='sm' asChild>
+                <Link
+                  href={`/admin/typeRent/${item.id}`}
+                  className='gap-1 text-slate-600 hover:text-slate-900'
                 >
-                  <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm hover:shadow-xl transition-all duration-300 group h-full'>
-                    <CardHeader className='pb-3'>
-                      <div className='flex items-start justify-between'>
-                        <div className='flex items-center gap-3'>
-                          <div className='p-2 bg-purple-50 rounded-lg group-hover:bg-purple-100 transition-colors'>
-                            <Home className='h-5 w-5 text-purple-600' />
-                          </div>
-                          <div>
-                            <CardTitle className='text-lg font-semibold text-slate-800'>
-                              {type.name || 'Type sans nom'}
-                            </CardTitle>
-                          </div>
-                        </div>
-                        <div className='flex gap-1'>
-                          {type.isHotelType && (
-                            <Badge
-                              variant='secondary'
-                              className='bg-purple-50 text-purple-700 border-purple-200 flex items-center gap-1'
-                            >
-                              <Hotel className='h-3 w-3' />
-                              Hôtel
-                            </Badge>
-                          )}
-                          <Badge
-                            variant='secondary'
-                            className='bg-green-50 text-green-700 border-green-200'
-                          >
-                            Actif
-                          </Badge>
-                        </div>
-                      </div>
-                    </CardHeader>
-                    <CardContent className='pt-0'>
-                      <p className='text-slate-600 text-sm mb-4 line-clamp-2'>
-                        {type.description || 'Aucune description'}
-                      </p>
-                      <div className='flex items-center gap-2'>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          asChild
-                          className='flex-1 hover:bg-purple-50 hover:text-purple-600'
-                        >
-                          <Link href={`/admin/typeRent/${type.id}`}>
-                            <Eye className='h-4 w-4 mr-2' />
-                            Voir logements
-                          </Link>
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-orange-50 hover:text-orange-600'
-                          onClick={() => handleEditType(type)}
-                        >
-                          <Edit3 className='h-4 w-4' />
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-red-50 hover:text-red-600'
-                          onClick={() => handleDeleteType(type)}
-                        >
-                          <Trash2 className='h-4 w-4' />
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </motion.div>
-              ))}
+                  <Eye className='h-4 w-4' />
+                  Voir
+                </Link>
+              </Button>
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={() => handleEditType(item)}
+                className='text-slate-600 hover:text-slate-900'
+              >
+                <Edit className='h-4 w-4' />
+              </Button>
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={() => handleDeleteType(item)}
+                className='text-red-600 hover:bg-red-50 hover:text-red-700'
+              >
+                <Trash2 className='h-4 w-4' />
+              </Button>
             </div>
           )}
-        </motion.div>
+          emptyState={{
+            icon: Home,
+            title: searchTerm ? 'Aucun résultat' : 'Aucun type de logement',
+            subtitle: searchTerm
+              ? 'Essayez d’ajuster votre recherche.'
+              : 'Commencez par ajouter votre premier type de logement.',
+          }}
+        />
       </motion.div>
+
+      {/* Add dialog */}
+      <Dialog
+        open={isAddDialogOpen}
+        onOpenChange={open => {
+          setIsAddDialogOpen(open)
+          if (!open) resetNewForm()
+        }}
+      >
+        <DialogContent className='sm:max-w-[520px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-purple-50 text-purple-600 ring-1 ring-purple-100'>
+                <Home className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>Ajouter un type de logement</DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  Créez un nouveau type de logement pour votre plateforme.
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <div className='space-y-4 py-2'>
+            <div className='space-y-1.5'>
+              <Label htmlFor='typeName'>
+                Nom <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='typeName'
+                placeholder='Ex: Villa, Appartement, Hôtel'
+                value={newTypeName}
+                onChange={e => setNewTypeName(e.target.value)}
+              />
+            </div>
+            <div className='space-y-1.5'>
+              <Label htmlFor='typeDescription'>
+                Description <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='typeDescription'
+                placeholder='Description du type de logement…'
+                value={newTypeDescription}
+                onChange={e => setNewTypeDescription(e.target.value)}
+              />
+            </div>
+            <ImageUpload
+              currentImage={newCoverImage}
+              onImageChange={setNewCoverImage}
+              entityType='type-rent'
+            />
+            <div className='flex items-start gap-3 rounded-xl border border-slate-200 bg-slate-50/60 p-3'>
+              <Checkbox
+                id='isHotelType'
+                checked={newIsHotelType}
+                onCheckedChange={checked => setNewIsHotelType(checked === true)}
+              />
+              <Label htmlFor='isHotelType' className='cursor-pointer space-y-0.5'>
+                <span className='flex items-center gap-1.5 text-sm font-medium text-slate-900'>
+                  <Hotel className='h-4 w-4 text-purple-600' />
+                  Fonctionne comme un hôtel
+                </span>
+                <span className='text-xs text-slate-500'>
+                  Active la gestion multi-chambres pour ce type.
+                </span>
+              </Label>
+            </div>
+          </div>
+
+          <DialogFooter className='gap-2'>
+            <Button
+              variant='outline'
+              onClick={() => setIsAddDialogOpen(false)}
+              disabled={isSubmitting}
+            >
+              Annuler
+            </Button>
+            <Button
+              onClick={handleAddType}
+              disabled={!newTypeName.trim() || !newTypeDescription.trim() || isSubmitting}
+              className='gap-2'
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Création…
+                </>
+              ) : (
+                'Créer'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit dialog */}
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent className='sm:max-w-[520px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 ring-1 ring-blue-100'>
+                <Edit className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>Modifier le type de logement</DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  Mettez à jour les informations de ce type.
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <div className='space-y-4 py-2'>
+            <div className='space-y-1.5'>
+              <Label htmlFor='editTypeName'>
+                Nom <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='editTypeName'
+                value={editTypeName}
+                onChange={e => setEditTypeName(e.target.value)}
+              />
+            </div>
+            <div className='space-y-1.5'>
+              <Label htmlFor='editTypeDescription'>
+                Description <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='editTypeDescription'
+                value={editTypeDescription}
+                onChange={e => setEditTypeDescription(e.target.value)}
+              />
+            </div>
+            <ImageUpload
+              currentImage={editCoverImage}
+              onImageChange={setEditCoverImage}
+              entityType='type-rent'
+              entityId={editingType?.id}
+            />
+            <div className='flex items-start gap-3 rounded-xl border border-slate-200 bg-slate-50/60 p-3'>
+              <Checkbox
+                id='editIsHotelType'
+                checked={editIsHotelType}
+                onCheckedChange={checked => setEditIsHotelType(checked === true)}
+              />
+              <Label htmlFor='editIsHotelType' className='cursor-pointer space-y-0.5'>
+                <span className='flex items-center gap-1.5 text-sm font-medium text-slate-900'>
+                  <Hotel className='h-4 w-4 text-purple-600' />
+                  Fonctionne comme un hôtel
+                </span>
+                <span className='text-xs text-slate-500'>
+                  Active la gestion multi-chambres pour ce type.
+                </span>
+              </Label>
+            </div>
+          </div>
+
+          <DialogFooter className='gap-2'>
+            <Button
+              variant='outline'
+              onClick={() => setIsEditDialogOpen(false)}
+              disabled={isSubmitting}
+            >
+              Annuler
+            </Button>
+            <Button
+              onClick={handleUpdateType}
+              disabled={!editTypeName.trim() || !editTypeDescription.trim() || isSubmitting}
+              className='gap-2'
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Mise à jour…
+                </>
+              ) : (
+                'Mettre à jour'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete modal (specialised — checks for associated products) */}
+      <DeleteTypeModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => {
+          setIsDeleteModalOpen(false)
+          setDeletingType(null)
+        }}
+        typeToDelete={deletingType}
+        onDeleteSuccess={handleDeleteSuccess}
+        onError={message => console.error(message)}
+      />
     </div>
   )
 }

--- a/src/app/admin/users/[id]/UserDetailsClient.tsx
+++ b/src/app/admin/users/[id]/UserDetailsClient.tsx
@@ -1,16 +1,33 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
+import { motion, Variants } from 'framer-motion'
 import { useAuth } from '@/hooks/useAuth'
-import Link from 'next/link'
-import { motion } from 'framer-motion'
-import { Button } from '@/components/ui/shadcnui/button'
-import { ArrowLeft } from 'lucide-react'
+import { isFullAdmin } from '@/hooks/useAdminAuth'
+import { Shield } from 'lucide-react'
 import type { ExtendedUser } from './types'
 import { LoadingDisplay } from './components/LoadingDisplay'
 import { UserPersonalInfo } from './components/UserPersonalInfo'
 import { UserListingsAndBookings } from './components/UserListingsAndBookings'
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+
+const containerVariants: Variants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.08 },
+  },
+}
+
+const itemVariants: Variants = {
+  hidden: { opacity: 0, y: 12 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { type: 'tween', duration: 0.4, ease: 'easeOut' },
+  },
+}
 
 interface UserDetailsClientProps {
   initialData: ExtendedUser
@@ -23,17 +40,14 @@ export function UserDetailsClient({ initialData }: UserDetailsClientProps) {
     isAuthenticated,
   } = useAuth({ required: true, redirectTo: '/auth' })
   const router = useRouter()
-  const [user] = useState<ExtendedUser>(initialData)
-  const [loading] = useState(false)
 
   useEffect(() => {
-    if (isAuthenticated && (!session?.user?.roles || session.user.roles !== 'ADMIN')) {
+    if (isAuthenticated && (!session?.user?.roles || !isFullAdmin(session.user.roles))) {
       router.push('/')
-      return
     }
   }, [isAuthenticated, session, router])
 
-  if (isAuthLoading || loading) {
+  if (isAuthLoading) {
     return <LoadingDisplay />
   }
 
@@ -42,57 +56,36 @@ export function UserDetailsClient({ initialData }: UserDetailsClientProps) {
   }
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100'>
-      <div className='container mx-auto p-6 space-y-8'>
-        <motion.div
-          className='space-y-6'
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-        >
-          {/* Header avec navigation */}
-          <div className='flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border-0'>
-            <div>
-              <h1 className='text-3xl font-bold bg-gradient-to-r from-gray-900 via-blue-800 to-indigo-800 bg-clip-text text-transparent'>
-                Profil Utilisateur
-              </h1>
-              <p className='text-gray-600 mt-1'>
-                Informations détaillées et activité de l&apos;utilisateur
-              </p>
-            </div>
-            <Button
-              variant='outline'
-              asChild
-              className='rounded-xl border-gray-200 hover:bg-gray-50'
-            >
-              <Link href='/admin/users' className='flex items-center gap-2'>
-                <ArrowLeft className='h-4 w-4' />
-                <span>Retour à la liste</span>
-              </Link>
-            </Button>
-          </div>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        variants={containerVariants}
+        initial='hidden'
+        animate='visible'
+      >
+        <motion.div variants={itemVariants}>
+          <PageHeader
+            backHref='/admin/users'
+            backLabel='Retour à la liste'
+            eyebrow='Espace administrateur'
+            eyebrowIcon={Shield}
+            title='Profil utilisateur'
+            subtitle='Informations détaillées, annonces et réservations de cet utilisateur.'
+          />
+        </motion.div>
 
-          {/* Contenu principal */}
-          <div className='grid grid-cols-1 xl:grid-cols-4 gap-8'>
-            <div className='xl:col-span-1'>
-              <UserPersonalInfo user={user} />
-            </div>
-            <div className='xl:col-span-3'>
-              <UserListingsAndBookings
-                userId={user.id}
-                user={{
-                  id: user.id,
-                  name: user.name,
-                  email: user.email,
-                  role: user.roles,
-                }}
-                posts={[]}
-                bookings={[]}
-              />
-            </div>
+        <motion.div
+          variants={itemVariants}
+          className='grid gap-6 xl:grid-cols-[minmax(0,20rem)_minmax(0,1fr)]'
+        >
+          <div>
+            <UserPersonalInfo user={initialData} />
+          </div>
+          <div>
+            <UserListingsAndBookings user={initialData} />
           </div>
         </motion.div>
-      </div>
+      </motion.div>
     </div>
   )
 }

--- a/src/app/admin/users/[id]/components/UserListingsAndBookings.tsx
+++ b/src/app/admin/users/[id]/components/UserListingsAndBookings.tsx
@@ -1,247 +1,227 @@
 'use client'
 
-import { MapPin, Calendar, Euro, Home } from 'lucide-react'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import { Button } from '@/components/ui/shadcnui/button'
 import Link from 'next/link'
-import Image from 'next/image'
+import { MapPin, Calendar, Home, CalendarClock, ArrowUpRight, Receipt } from 'lucide-react'
+import { KpiCard } from '@/components/admin/ui/KpiCard'
+import type { ExtendedUser, ExtendedRent } from '../types'
+import { Product } from '@prisma/client'
 
 interface UserListingsAndBookingsProps {
-  userId: string
-  user: {
-    id: string
-    name: string | null
-    email: string
-    role: string
-  }
-  posts: Array<{
-    id: string
-    title: string
-    description: string
-    price: number
-    location: string
-    images: string[]
-    status: string
-    createdAt: Date
-    isPromoted?: boolean
-  }>
-  bookings: Array<{
-    id: string
-    product: {
-      id: string
-      title: string
-      price: number
-      location: string
-      images: string[]
-    }
-    totalPrice: number
-    startDate: Date
-    endDate: Date
-    status: string
-    createdAt: Date
-  }>
+  user: ExtendedUser
 }
 
-export function UserListingsAndBookings({ posts, bookings }: UserListingsAndBookingsProps) {
-  // Calculer les statistiques
-  const totalEarnings = bookings
-    .filter(booking => booking.status === 'CONFIRMED')
-    .reduce((sum, booking) => sum + booking.totalPrice, 0)
+const PAYMENT_PAID_STATES = new Set([
+  'CLIENT_PAID',
+  'MID_TRANSFER_REQ',
+  'MID_TRANSFER_DONE',
+  'REST_TRANSFER_REQ',
+  'REST_TRANSFER_DONE',
+  'FULL_TRANSFER_REQ',
+  'FULL_TRANSFER_DONE',
+])
 
-  const activePosts = posts.filter(post => post.status === 'APPROVED').length
-  const totalBookings = bookings.length
+const VALIDATION_LABEL: Record<string, { label: string; tone: string }> = {
+  Approve: { label: 'Validé', tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200' },
+  NotVerified: { label: 'En attente', tone: 'bg-amber-50 text-amber-700 ring-amber-200' },
+  RecheckRequest: {
+    label: 'Révision demandée',
+    tone: 'bg-orange-50 text-orange-700 ring-orange-200',
+  },
+  Refused: { label: 'Refusé', tone: 'bg-red-50 text-red-700 ring-red-200' },
+  ModificationPending: {
+    label: 'Modification en attente',
+    tone: 'bg-purple-50 text-purple-700 ring-purple-200',
+  },
+}
+
+const RENT_STATUS_LABEL: Record<string, { label: string; tone: string }> = {
+  WAITING: { label: 'En attente', tone: 'bg-amber-50 text-amber-700 ring-amber-200' },
+  RESERVED: { label: 'Réservée', tone: 'bg-blue-50 text-blue-700 ring-blue-200' },
+  CHECKIN: { label: 'Check-in', tone: 'bg-indigo-50 text-indigo-700 ring-indigo-200' },
+  CHECKOUT: { label: 'Check-out', tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200' },
+  CANCEL: { label: 'Annulée', tone: 'bg-red-50 text-red-700 ring-red-200' },
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(amount)
+}
+
+export function UserListingsAndBookings({ user }: UserListingsAndBookingsProps) {
+  const products: Product[] = user.Product ?? []
+  const rents: ExtendedRent[] = user.Rent ?? []
+
+  const paidRents = rents.filter(r => PAYMENT_PAID_STATES.has(r.payment as unknown as string))
+  const totalSpent = paidRents.reduce((sum, r) => sum + (r.totalAmount ?? 0), 0)
+
+  const activeListings = products.filter(
+    p => (p as Product).validate === 'Approve' && !(p as Product).isDraft
+  ).length
 
   return (
-    <div className='space-y-8'>
-      {/* Statistiques */}
-      <div className='grid grid-cols-1 md:grid-cols-3 gap-6'>
-        <Card className='border-0 shadow-lg bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-2xl'>
-          <CardContent className='p-6'>
-            <div className='flex items-center justify-between'>
-              <div>
-                <p className='text-blue-100 text-sm font-medium'>Revenus totaux</p>
-                <p className='text-2xl font-bold mt-1'>{totalEarnings}€</p>
-              </div>
-              <div className='bg-white/20 p-3 rounded-full'>
-                <Euro className='h-6 w-6 text-white' />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className='border-0 shadow-lg bg-gradient-to-r from-green-500 to-green-600 text-white rounded-2xl'>
-          <CardContent className='p-6'>
-            <div className='flex items-center justify-between'>
-              <div>
-                <p className='text-green-100 text-sm font-medium'>Annonces actives</p>
-                <p className='text-2xl font-bold mt-1'>{activePosts}</p>
-              </div>
-              <div className='bg-white/20 p-3 rounded-full'>
-                <Home className='h-6 w-6 text-white' />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className='border-0 shadow-lg bg-gradient-to-r from-purple-500 to-purple-600 text-white rounded-2xl'>
-          <CardContent className='p-6'>
-            <div className='flex items-center justify-between'>
-              <div>
-                <p className='text-purple-100 text-sm font-medium'>Réservations</p>
-                <p className='text-2xl font-bold mt-1'>{totalBookings}</p>
-              </div>
-              <div className='bg-white/20 p-3 rounded-full'>
-                <Calendar className='h-6 w-6 text-white' />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+    <div className='space-y-6'>
+      {/* Stats row */}
+      <div className='grid gap-4 md:grid-cols-3'>
+        <KpiCard
+          label='Dépensé total'
+          value={formatCurrency(totalSpent)}
+          hint='sur les réservations payées'
+          icon={Receipt}
+          tone='emerald'
+        />
+        <KpiCard
+          label='Annonces actives'
+          value={activeListings}
+          hint={`${products.length} au total`}
+          icon={Home}
+          tone='blue'
+        />
+        <KpiCard
+          label='Réservations'
+          value={rents.length}
+          hint={`${paidRents.length} payées`}
+          icon={Calendar}
+          tone='purple'
+        />
       </div>
 
-      {/* Annonces de l'utilisateur */}
-      <Card className='border-0 shadow-lg rounded-2xl'>
-        <CardHeader className='pb-4'>
-          <CardTitle className='text-xl font-bold text-gray-900 flex items-center gap-2'>
-            <Home className='h-5 w-5 text-blue-600' />
-            Annonces ({posts.length})
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {posts.length === 0 ? (
-            <div className='text-center py-12'>
-              <Home className='h-12 w-12 text-gray-300 mx-auto mb-4' />
-              <p className='text-gray-500'>Aucune annonce trouvée</p>
-            </div>
-          ) : (
-            <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
-              {posts.map(post => (
-                <div
-                  key={post.id}
-                  className='border border-gray-200 rounded-xl overflow-hidden hover:shadow-md transition-shadow'
-                >
-                  {post.images && post.images.length > 0 && (
-                    <div className='aspect-video bg-gray-100 relative'>
-                      <Image
-                        src={post.images[0]}
-                        alt={post.title}
-                        fill
-                        className='object-cover'
-                        unoptimized
-                      />
-                      {post.isPromoted && (
-                        <Badge className='absolute top-2 right-2 bg-yellow-500 text-white border-0'>
-                          Sponsorisé
-                        </Badge>
-                      )}
-                    </div>
-                  )}
-                  <div className='p-4'>
-                    <h3 className='font-medium text-gray-900 mb-2 line-clamp-2'>{post.title}</h3>
-                    <div className='flex items-center gap-1 text-gray-500 text-sm mb-2'>
-                      <MapPin className='h-4 w-4' />
-                      <span>{post.location}</span>
-                    </div>
-                    <div className='flex items-center justify-between'>
-                      <span className='font-bold text-blue-600'>{post.price}€/nuit</span>
-                      <Badge
-                        variant={
-                          post.status === 'APPROVED'
-                            ? 'default'
-                            : post.status === 'PENDING'
-                              ? 'secondary'
-                              : 'destructive'
-                        }
-                      >
-                        {post.status === 'APPROVED'
-                          ? 'Approuvé'
-                          : post.status === 'PENDING'
-                            ? 'En attente'
-                            : 'Rejeté'}
-                      </Badge>
-                    </div>
-                    <div className='mt-3'>
-                      <Button variant='outline' size='sm' asChild className='w-full'>
-                        <Link href={`/posts/${post.id}`}>Voir l&apos;annonce</Link>
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
+      {/* Listings */}
+      <div className='rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm'>
+        <div className='mb-4 flex items-center justify-between'>
+          <h3 className='text-lg font-semibold text-slate-900'>
+            Annonces possédées{' '}
+            <span className='text-sm font-normal text-slate-500'>({products.length})</span>
+          </h3>
+          {products.length > 0 && (
+            <Link
+              href={`/admin/products?ownerId=${user.id}`}
+              className='text-xs font-medium text-blue-600 hover:underline'
+            >
+              Voir tout
+            </Link>
           )}
-        </CardContent>
-      </Card>
+        </div>
 
-      {/* Réservations de l'utilisateur */}
-      <Card className='border-0 shadow-lg rounded-2xl'>
-        <CardHeader className='pb-4'>
-          <CardTitle className='text-xl font-bold text-gray-900 flex items-center gap-2'>
-            <Calendar className='h-5 w-5 text-purple-600' />
-            Réservations ({bookings.length})
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {bookings.length === 0 ? (
-            <div className='text-center py-12'>
-              <Calendar className='h-12 w-12 text-gray-300 mx-auto mb-4' />
-              <p className='text-gray-500'>Aucune réservation trouvée</p>
+        {products.length === 0 ? (
+          <div className='flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-200 py-10 text-center'>
+            <div className='mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 text-slate-400'>
+              <Home className='h-6 w-6' />
             </div>
-          ) : (
-            <div className='space-y-4'>
-              {bookings.map(booking => (
-                <div
-                  key={booking.id}
-                  className='border border-gray-200 rounded-xl p-4 hover:shadow-md transition-shadow'
+            <p className='text-sm font-semibold text-slate-900'>Aucune annonce</p>
+            <p className='mt-0.5 text-xs text-slate-500'>
+              Cet utilisateur n’a pas encore créé d’annonce.
+            </p>
+          </div>
+        ) : (
+          <div className='space-y-2'>
+            {products.map(product => {
+              const validation =
+                VALIDATION_LABEL[product.validate] ?? {
+                  label: product.validate,
+                  tone: 'bg-slate-100 text-slate-700 ring-slate-200',
+                }
+              return (
+                <Link
+                  key={product.id}
+                  href={`/admin/validation/${product.id}`}
+                  className='group flex items-center gap-4 rounded-xl border border-slate-200 bg-white p-3 transition hover:border-blue-200 hover:bg-blue-50/30'
                 >
-                  <div className='flex items-start gap-4'>
-                    {booking.product.images && booking.product.images.length > 0 && (
-                      <div className='w-20 h-20 bg-gray-100 rounded-lg overflow-hidden flex-shrink-0 relative'>
-                        <Image
-                          src={booking.product.images[0]}
-                          alt={booking.product.title}
-                          fill
-                          className='object-cover'
-                          unoptimized
-                        />
-                      </div>
+                  <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600'>
+                    <Home className='h-5 w-5' />
+                  </div>
+                  <div className='min-w-0 flex-1'>
+                    <p className='truncate text-sm font-semibold text-slate-900 group-hover:text-blue-700'>
+                      {product.name}
+                    </p>
+                    <p className='truncate text-xs text-slate-500'>
+                      <MapPin className='mr-1 inline h-3 w-3' />
+                      {product.address}
+                    </p>
+                  </div>
+                  <div className='flex items-center gap-3'>
+                    <span className='text-sm font-bold text-slate-900 tabular-nums'>
+                      {product.basePrice}€
+                      <span className='text-xs font-normal text-slate-500'>/nuit</span>
+                    </span>
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-semibold ring-1 ${validation.tone}`}
+                    >
+                      {validation.label}
+                    </span>
+                    <ArrowUpRight className='h-4 w-4 text-slate-300 transition group-hover:text-slate-600' />
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Bookings */}
+      <div className='rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm'>
+        <div className='mb-4 flex items-center justify-between'>
+          <h3 className='text-lg font-semibold text-slate-900'>
+            Réservations effectuées{' '}
+            <span className='text-sm font-normal text-slate-500'>({rents.length})</span>
+          </h3>
+        </div>
+
+        {rents.length === 0 ? (
+          <div className='flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-200 py-10 text-center'>
+            <div className='mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 text-slate-400'>
+              <Calendar className='h-6 w-6' />
+            </div>
+            <p className='text-sm font-semibold text-slate-900'>Aucune réservation</p>
+            <p className='mt-0.5 text-xs text-slate-500'>
+              Cet utilisateur n’a effectué aucune réservation.
+            </p>
+          </div>
+        ) : (
+          <div className='space-y-2'>
+            {rents.map(rent => {
+              const status = RENT_STATUS_LABEL[rent.status as unknown as string] ?? {
+                label: rent.status,
+                tone: 'bg-slate-100 text-slate-700 ring-slate-200',
+              }
+              return (
+                <div
+                  key={rent.id}
+                  className='flex items-center gap-4 rounded-xl border border-slate-200 bg-white p-3'
+                >
+                  <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-purple-50 text-purple-600'>
+                    <CalendarClock className='h-5 w-5' />
+                  </div>
+                  <div className='min-w-0 flex-1'>
+                    <p className='truncate text-sm font-semibold text-slate-900'>
+                      Réservation #{rent.id.slice(-6)}
+                    </p>
+                    <p className='truncate text-xs text-slate-500'>
+                      <Calendar className='mr-1 inline h-3 w-3' />
+                      {new Date(rent.arrivingDate).toLocaleDateString('fr-FR')} →{' '}
+                      {new Date(rent.leavingDate).toLocaleDateString('fr-FR')}
+                    </p>
+                  </div>
+                  <div className='flex items-center gap-3'>
+                    {rent.totalAmount != null && (
+                      <span className='text-sm font-bold text-slate-900 tabular-nums'>
+                        {formatCurrency(rent.totalAmount)}
+                      </span>
                     )}
-                    <div className='flex-1 min-w-0'>
-                      <h3 className='font-medium text-gray-900 mb-1'>{booking.product.title}</h3>
-                      <div className='flex items-center gap-1 text-gray-500 text-sm mb-2'>
-                        <MapPin className='h-4 w-4' />
-                        <span>{booking.product.location}</span>
-                      </div>
-                      <div className='text-sm text-gray-600 mb-2'>
-                        {new Date(booking.startDate).toLocaleDateString('fr-FR')} -{' '}
-                        {new Date(booking.endDate).toLocaleDateString('fr-FR')}
-                      </div>
-                      <div className='flex items-center justify-between'>
-                        <span className='font-bold text-green-600'>{booking.totalPrice}€</span>
-                        <Badge
-                          variant={
-                            booking.status === 'CONFIRMED'
-                              ? 'default'
-                              : booking.status === 'PENDING'
-                                ? 'secondary'
-                                : 'destructive'
-                          }
-                        >
-                          {booking.status === 'CONFIRMED'
-                            ? 'Confirmé'
-                            : booking.status === 'PENDING'
-                              ? 'En attente'
-                              : 'Annulé'}
-                        </Badge>
-                      </div>
-                    </div>
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-semibold ring-1 ${status.tone}`}
+                    >
+                      {status.label}
+                    </span>
                   </div>
                 </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+              )
+            })}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/app/admin/users/[id]/components/UserPersonalInfo.tsx
+++ b/src/app/admin/users/[id]/components/UserPersonalInfo.tsx
@@ -1,123 +1,162 @@
 'use client'
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/shadcnui/avatar'
-import { Button } from '@/components/ui/shadcnui/button'
-import { User as UserIcon, Mail, Calendar, Shield, Edit3 } from 'lucide-react'
+import {
+  User as UserIcon,
+  Mail,
+  Calendar,
+  ShieldCheck,
+  MailCheck,
+  MailX,
+  BadgeCheck,
+  Phone,
+} from 'lucide-react'
 import type { ExtendedUser } from '../types'
-import { RoleBadge } from '@/components/ui/RoleBadge'
+import { getUserAvatarUrl } from '@/lib/utils/userAvatar'
+
+/**
+ * Ordered list of roles with Lucide icons and accent tones.
+ * Kept in sync with the list page `RolePill`.
+ */
+const ROLE_CONFIG: Record<
+  string,
+  { label: string; accent: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  ADMIN: {
+    label: 'Administrateur',
+    accent: 'bg-purple-50 text-purple-700 ring-purple-200',
+    icon: ShieldCheck,
+  },
+  HOST_MANAGER: {
+    label: 'Gestionnaire Hôtes',
+    accent: 'bg-indigo-50 text-indigo-700 ring-indigo-200',
+    icon: ShieldCheck,
+  },
+  BLOGWRITER: {
+    label: 'Rédacteur Blog',
+    accent: 'bg-blue-50 text-blue-700 ring-blue-200',
+    icon: BadgeCheck,
+  },
+  HOST_VERIFIED: {
+    label: 'Hôte Vérifié',
+    accent: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: BadgeCheck,
+  },
+  HOST: {
+    label: 'Hôte',
+    accent: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: UserIcon,
+  },
+  USER: {
+    label: 'Utilisateur',
+    accent: 'bg-slate-100 text-slate-700 ring-slate-200',
+    icon: UserIcon,
+  },
+}
+
+interface InfoRowProps {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  value: React.ReactNode
+  tone?: 'slate' | 'emerald' | 'amber'
+}
+
+function InfoRow({ icon: Icon, label, value, tone = 'slate' }: InfoRowProps) {
+  const toneClass: Record<NonNullable<InfoRowProps['tone']>, string> = {
+    slate: 'bg-slate-100 text-slate-600',
+    emerald: 'bg-emerald-50 text-emerald-600',
+    amber: 'bg-amber-50 text-amber-600',
+  }
+  return (
+    <div className='flex items-start gap-3'>
+      <div
+        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${toneClass[tone]}`}
+      >
+        <Icon className='h-4 w-4' />
+      </div>
+      <div className='min-w-0 flex-1'>
+        <p className='text-xs font-medium uppercase tracking-wide text-slate-400'>{label}</p>
+        <div className='mt-0.5 text-sm font-medium text-slate-900'>{value}</div>
+      </div>
+    </div>
+  )
+}
 
 interface UserPersonalInfoProps {
   user: ExtendedUser
 }
 
 export function UserPersonalInfo({ user }: UserPersonalInfoProps) {
+  const displayName =
+    user.name || user.lastname
+      ? `${user.name || ''} ${user.lastname || ''}`.trim()
+      : 'Utilisateur sans nom'
+
+  const role = ROLE_CONFIG[user.roles] ?? ROLE_CONFIG.USER
+  const RoleIcon = role.icon
+
   return (
-    <div className='space-y-6'>
-      {/* Photo de profil et informations principales */}
-      <Card className='border-0 shadow-xl bg-white rounded-2xl overflow-hidden'>
-        <div className='relative h-24 bg-gradient-to-r from-blue-500 via-purple-500 to-indigo-600'>
+    <div className='space-y-4'>
+      {/* Profile header card */}
+      <div className='overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm'>
+        <div className='relative h-24 bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500'>
           <div className='absolute inset-0 bg-black/10' />
         </div>
-        <CardContent className='p-4 -mt-12 relative'>
-          <div className='flex flex-col items-center text-center space-y-3'>
-            <Avatar className='h-20 w-20 border-4 border-white shadow-lg'>
-              <AvatarImage
-                src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${user.email}`}
-                className='object-cover'
-              />
-              <AvatarFallback className='bg-gradient-to-r from-blue-500 to-indigo-600 text-white text-xl font-bold'>
-                {(user.name?.[0] || user.email[0]).toUpperCase()}
-              </AvatarFallback>
-            </Avatar>
-
-            <div className='space-y-1'>
-              <h2 className='text-xl font-bold text-gray-900'>
-                {user.name || user.lastname
-                  ? `${user.name || ''} ${user.lastname || ''}`.trim()
-                  : 'Utilisateur sans nom'}
-              </h2>
-              <p className='text-gray-500 text-sm flex items-center justify-center gap-1'>
-                <Mail className='h-3 w-3' />
-                {user.email}
-              </p>
-            </div>
-
-            <RoleBadge role={user.roles} size='sm' />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Informations détaillées */}
-      <Card className='border-0 shadow-lg bg-white rounded-2xl'>
-        <CardHeader className='pb-3'>
-          <CardTitle className='flex items-center gap-2 text-lg'>
-            <UserIcon className='h-4 w-4 text-blue-600' />
-            Informations
-          </CardTitle>
-        </CardHeader>
-        <CardContent className='space-y-4'>
-          <div className='space-y-3'>
-            <div className='flex items-center gap-3 p-3 bg-gray-50 rounded-lg'>
-              <div className='p-1.5 bg-blue-100 rounded-lg'>
-                <Calendar className='h-3.5 w-3.5 text-blue-600' />
-              </div>
-              <div className='flex-1 min-w-0'>
-                <p className='text-xs text-gray-500'>Inscription</p>
-                <p className='text-sm font-medium text-gray-900 truncate'>
-                  {new Date(user.createdAt).toLocaleDateString('fr-FR', {
-                    year: 'numeric',
-                    month: 'short',
-                    day: 'numeric',
-                  })}
-                </p>
-              </div>
-            </div>
-
-            <div className='flex items-center gap-3 p-3 bg-gray-50 rounded-lg'>
-              <div className='p-1.5 bg-green-100 rounded-lg'>
-                <Shield className='h-3.5 w-3.5 text-green-600' />
-              </div>
-              <div className='flex-1 min-w-0'>
-                <p className='text-xs text-gray-500'>Email</p>
-                <div className='flex items-center gap-2'>
-                  <span className='text-sm font-medium text-gray-900'>
-                    {user.emailVerified ? 'Vérifié' : 'Non vérifié'}
-                  </span>
-                  <div
-                    className={`h-1.5 w-1.5 rounded-full ${user.emailVerified ? 'bg-green-500' : 'bg-orange-500'}`}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Actions rapides */}
-      <Card className='border-0 shadow-lg bg-white rounded-2xl'>
-        <CardHeader className='pb-3'>
-          <CardTitle className='text-lg'>Actions</CardTitle>
-        </CardHeader>
-        <CardContent className='space-y-2'>
-          <Button variant='outline' size='sm' className='w-full justify-start rounded-lg text-sm'>
-            <Edit3 className='h-3.5 w-3.5 mr-2' />
-            Modifier
-          </Button>
-          <Button variant='outline' size='sm' className='w-full justify-start rounded-lg text-sm'>
-            <Mail className='h-3.5 w-3.5 mr-2' />
-            Email
-          </Button>
-          <Button
-            variant='outline'
-            size='sm'
-            className='w-full justify-start rounded-lg text-sm text-red-600 hover:text-red-700 hover:bg-red-50'
+        <div className='relative -mt-12 flex flex-col items-center px-6 pb-6 text-center'>
+          <Avatar className='h-24 w-24 border-4 border-white shadow-lg'>
+            <AvatarImage src={getUserAvatarUrl(user)} alt={displayName} />
+            <AvatarFallback className='bg-gradient-to-br from-indigo-500 to-purple-500 text-2xl font-bold text-white'>
+              {(user.name?.[0] || user.email[0]).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <h2 className='mt-4 text-xl font-bold text-slate-900'>{displayName}</h2>
+          <p className='mt-0.5 flex items-center gap-1.5 text-sm text-slate-500'>
+            <Mail className='h-3.5 w-3.5' />
+            <span className='truncate max-w-[220px]'>{user.email}</span>
+          </p>
+          <span
+            className={`mt-3 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold ring-1 ${role.accent}`}
           >
-            <Shield className='h-3.5 w-3.5 mr-2' />
-            Suspendre
-          </Button>
-        </CardContent>
-      </Card>
+            <RoleIcon className='h-3 w-3' />
+            {role.label}
+          </span>
+        </div>
+      </div>
+
+      {/* Info card */}
+      <div className='rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm'>
+        <h3 className='mb-4 text-sm font-semibold uppercase tracking-wide text-slate-500'>
+          Informations
+        </h3>
+        <div className='space-y-4'>
+          <InfoRow
+            icon={Calendar}
+            label='Inscrit le'
+            value={new Date(user.createdAt).toLocaleDateString('fr-FR', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          />
+          <InfoRow
+            icon={user.emailVerified ? MailCheck : MailX}
+            label='Email'
+            tone={user.emailVerified ? 'emerald' : 'amber'}
+            value={
+              <span
+                className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-semibold ${
+                  user.emailVerified
+                    ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
+                    : 'bg-amber-50 text-amber-700 ring-1 ring-amber-200'
+                }`}
+              >
+                {user.emailVerified ? 'Vérifié' : 'Non vérifié'}
+              </span>
+            }
+          />
+          {user.info && <InfoRow icon={Phone} label='Bio' value={user.info} />}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/app/admin/users/components/ConfirmDeleteUserDialog.tsx
+++ b/src/app/admin/users/components/ConfirmDeleteUserDialog.tsx
@@ -9,7 +9,15 @@ import {
   DialogTitle,
 } from '@/components/ui/shadcnui/dialog'
 import { Button } from '@/components/ui/shadcnui/button'
-import { Loader2, Trash2, AlertTriangle, Package, CalendarDays } from 'lucide-react'
+import {
+  Loader2,
+  Trash2,
+  AlertTriangle,
+  Package,
+  CalendarDays,
+  ShieldAlert,
+  CalendarClock,
+} from 'lucide-react'
 
 interface ActiveRent {
   id: string
@@ -40,10 +48,30 @@ interface ConfirmDeleteUserDialogProps {
 function formatStatus(status: string) {
   const labels: Record<string, string> = {
     WAITING: 'En attente',
-    RESERVED: 'Reservee',
+    RESERVED: 'Réservée',
     CHECKIN: 'Check-in',
+    CHECKOUT: 'Check-out',
+    CANCEL: 'Annulée',
   }
   return labels[status] || status
+}
+
+function ActiveRentRow({ rent, showGuest }: { rent: ActiveRent; showGuest?: boolean }) {
+  return (
+    <li className='flex items-start gap-3 rounded-xl border border-red-100 bg-red-50/60 p-3'>
+      <div className='mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-white text-red-600 shadow-sm'>
+        <CalendarClock className='h-3.5 w-3.5' />
+      </div>
+      <div className='min-w-0 flex-1'>
+        <p className='truncate text-sm font-semibold text-slate-900'>{rent.product.name}</p>
+        <p className='text-xs text-slate-600'>
+          {formatStatus(rent.status)} · {new Date(rent.arrivingDate).toLocaleDateString('fr-FR')}{' '}
+          → {new Date(rent.leavingDate).toLocaleDateString('fr-FR')}
+          {showGuest && rent.user && ` · ${rent.user.name || rent.user.email}`}
+        </p>
+      </div>
+    </li>
+  )
 }
 
 export function ConfirmDeleteUserDialog({
@@ -55,79 +83,101 @@ export function ConfirmDeleteUserDialog({
 }: ConfirmDeleteUserDialogProps) {
   if (!deletionInfo) return null
 
-  const { user, ownedProductCount, rentCount, activeRentsAsGuest, activeRentsAsHost, hasActiveReservations } = deletionInfo
+  const {
+    user,
+    ownedProductCount,
+    rentCount,
+    activeRentsAsGuest,
+    activeRentsAsHost,
+    hasActiveReservations,
+  } = deletionInfo
   const displayName = [user.name, user.lastname].filter(Boolean).join(' ') || user.email
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className='sm:max-w-[520px]'>
+      <DialogContent className='sm:max-w-[560px]'>
         <DialogHeader>
-          <DialogTitle className='flex items-center gap-2'>
-            <AlertTriangle className='h-5 w-5 text-red-600' />
-            Supprimer l&apos;utilisateur
-          </DialogTitle>
-          <DialogDescription>
-            {hasActiveReservations
-              ? `Impossible de supprimer "${displayName}" car il a des reservations actives.`
-              : `Etes-vous sur de vouloir supprimer definitivement "${displayName}" ? Cette action est irreversible.`}
-          </DialogDescription>
+          <div className='flex items-start gap-3'>
+            <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-red-50 text-red-600 ring-1 ring-red-100'>
+              <AlertTriangle className='h-5 w-5' />
+            </div>
+            <div className='min-w-0 flex-1 space-y-1'>
+              <DialogTitle className='text-lg'>
+                {hasActiveReservations
+                  ? 'Suppression impossible'
+                  : "Supprimer l'utilisateur"}
+              </DialogTitle>
+              <DialogDescription className='text-sm text-slate-600'>
+                {hasActiveReservations ? (
+                  <>
+                    <span className='font-semibold text-slate-900'>{displayName}</span> a des
+                    réservations actives et ne peut pas être supprimé pour le moment.
+                  </>
+                ) : (
+                  <>
+                    Cette action supprimera définitivement{' '}
+                    <span className='font-semibold text-slate-900'>{displayName}</span> et toutes
+                    ses données associées. Elle est <strong>irréversible</strong>.
+                  </>
+                )}
+              </DialogDescription>
+            </div>
+          </div>
         </DialogHeader>
 
+        {/* Impact summary */}
         <div className='space-y-4 py-2'>
-          <div className='flex gap-4 text-sm text-gray-600'>
-            <div className='flex items-center gap-1.5'>
-              <Package className='h-4 w-4' />
-              <span>{ownedProductCount} hebergement{ownedProductCount > 1 ? 's' : ''}</span>
+          <div className='grid grid-cols-2 gap-3'>
+            <div className='flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50/60 px-3 py-2.5'>
+              <div className='flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600'>
+                <Package className='h-4 w-4' />
+              </div>
+              <div className='min-w-0'>
+                <p className='text-xs text-slate-500'>Hébergements</p>
+                <p className='text-sm font-semibold text-slate-900'>
+                  {ownedProductCount} possédé{ownedProductCount > 1 ? 's' : ''}
+                </p>
+              </div>
             </div>
-            <div className='flex items-center gap-1.5'>
-              <CalendarDays className='h-4 w-4' />
-              <span>{rentCount} reservation{rentCount > 1 ? 's' : ''} (total)</span>
+            <div className='flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50/60 px-3 py-2.5'>
+              <div className='flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-purple-50 text-purple-600'>
+                <CalendarDays className='h-4 w-4' />
+              </div>
+              <div className='min-w-0'>
+                <p className='text-xs text-slate-500'>Réservations</p>
+                <p className='text-sm font-semibold text-slate-900'>
+                  {rentCount} au total
+                </p>
+              </div>
             </div>
           </div>
 
           {hasActiveReservations && (
-            <div className='space-y-3'>
+            <div className='space-y-3 rounded-xl border border-red-200 bg-red-50/40 p-4'>
+              <div className='flex items-center gap-2 text-sm font-semibold text-red-700'>
+                <ShieldAlert className='h-4 w-4' />
+                Réservations actives bloquantes
+              </div>
               {activeRentsAsGuest.length > 0 && (
-                <div>
-                  <p className='text-sm font-medium text-gray-900 mb-2'>
-                    Reservations actives (en tant que voyageur) :
+                <div className='space-y-2'>
+                  <p className='text-xs font-medium uppercase tracking-wide text-slate-500'>
+                    En tant que voyageur ({activeRentsAsGuest.length})
                   </p>
-                  <ul className='space-y-1.5'>
+                  <ul className='space-y-2'>
                     {activeRentsAsGuest.map(rent => (
-                      <li
-                        key={rent.id}
-                        className='text-sm bg-red-50 border border-red-100 rounded-lg px-3 py-2'
-                      >
-                        <span className='font-medium'>{rent.product.name}</span>
-                        <span className='text-gray-500'>
-                          {' '}&mdash; {formatStatus(rent.status)} &mdash;{' '}
-                          {new Date(rent.arrivingDate).toLocaleDateString('fr-FR')} au{' '}
-                          {new Date(rent.leavingDate).toLocaleDateString('fr-FR')}
-                        </span>
-                      </li>
+                      <ActiveRentRow key={rent.id} rent={rent} />
                     ))}
                   </ul>
                 </div>
               )}
               {activeRentsAsHost.length > 0 && (
-                <div>
-                  <p className='text-sm font-medium text-gray-900 mb-2'>
-                    Reservations actives (en tant qu&apos;hote) :
+                <div className='space-y-2'>
+                  <p className='text-xs font-medium uppercase tracking-wide text-slate-500'>
+                    En tant qu’hôte ({activeRentsAsHost.length})
                   </p>
-                  <ul className='space-y-1.5'>
+                  <ul className='space-y-2'>
                     {activeRentsAsHost.map(rent => (
-                      <li
-                        key={rent.id}
-                        className='text-sm bg-red-50 border border-red-100 rounded-lg px-3 py-2'
-                      >
-                        <span className='font-medium'>{rent.product.name}</span>
-                        <span className='text-gray-500'>
-                          {' '}&mdash; {formatStatus(rent.status)} &mdash;{' '}
-                          {new Date(rent.arrivingDate).toLocaleDateString('fr-FR')} au{' '}
-                          {new Date(rent.leavingDate).toLocaleDateString('fr-FR')}
-                          {rent.user && ` (${rent.user.name || rent.user.email})`}
-                        </span>
-                      </li>
+                      <ActiveRentRow key={rent.id} rent={rent} showGuest />
                     ))}
                   </ul>
                 </div>
@@ -136,10 +186,14 @@ export function ConfirmDeleteUserDialog({
           )}
 
           {!hasActiveReservations && ownedProductCount > 0 && (
-            <p className='text-sm text-amber-700 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2'>
-              Attention : les {ownedProductCount} hebergement{ownedProductCount > 1 ? 's' : ''} de
-              cet utilisateur seront egalement supprimes.
-            </p>
+            <div className='flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50/60 p-3 text-sm'>
+              <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0 text-amber-600' />
+              <p className='text-amber-800'>
+                Les <strong>{ownedProductCount}</strong> hébergement
+                {ownedProductCount > 1 ? 's' : ''} de cet utilisateur seront également supprimé
+                {ownedProductCount > 1 ? 's' : ''}.
+              </p>
+            </div>
           )}
         </div>
 
@@ -148,16 +202,21 @@ export function ConfirmDeleteUserDialog({
             {hasActiveReservations ? 'Fermer' : 'Annuler'}
           </Button>
           {!hasActiveReservations && (
-            <Button variant='destructive' onClick={onConfirm} disabled={isLoading}>
+            <Button
+              variant='destructive'
+              onClick={onConfirm}
+              disabled={isLoading}
+              className='gap-2'
+            >
               {isLoading ? (
                 <>
                   <Loader2 className='h-4 w-4 animate-spin' />
-                  Suppression...
+                  Suppression…
                 </>
               ) : (
                 <>
                   <Trash2 className='h-4 w-4' />
-                  Supprimer
+                  Supprimer définitivement
                 </>
               )}
             </Button>

--- a/src/app/admin/users/components/EmailVerificationPanel.tsx
+++ b/src/app/admin/users/components/EmailVerificationPanel.tsx
@@ -12,7 +12,6 @@ import {
   DialogTrigger,
 } from '@/components/ui/shadcnui/dialog'
 import { Button } from '@/components/ui/shadcnui/button'
-import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
 import {
   Select,
   SelectContent,
@@ -21,7 +20,20 @@ import {
   SelectValue,
 } from '@/components/ui/shadcnui/select'
 import { Checkbox } from '@/components/ui/checkbox'
-import { Mail, Loader2, CheckCircle, XCircle, Users, User as UserIcon } from 'lucide-react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/shadcnui/avatar'
+import {
+  Mail,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  Users as UsersIcon,
+  User as UserIcon,
+  MailX,
+  MailCheck,
+  Send,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { getUserAvatarUrl } from '@/lib/utils/userAvatar'
 
 interface EmailVerificationPanelProps {
   users: User[]
@@ -35,9 +47,11 @@ interface SendResult {
   error?: string
 }
 
+type SendMode = 'all' | 'selected' | 'single'
+
 export function EmailVerificationPanel({ users, refreshUsers }: EmailVerificationPanelProps) {
   const [isOpen, setIsOpen] = useState(false)
-  const [mode, setMode] = useState<'all' | 'selected' | 'single'>('all')
+  const [mode, setMode] = useState<SendMode>('all')
   const [selectedUsers, setSelectedUsers] = useState<string[]>([])
   const [singleUser, setSingleUser] = useState<string>('')
   const [isLoading, setIsLoading] = useState(false)
@@ -48,87 +62,55 @@ export function EmailVerificationPanel({ users, refreshUsers }: EmailVerificatio
     failures: number
   } | null>(null)
 
-  // Filtrer les utilisateurs non vérifiés
-  const unverifiedUsers = users.filter(user => !user.emailVerified)
+  const unverifiedUsers = users.filter(u => !u.emailVerified)
 
-  const handleUserSelection = (userId: string, checked: boolean) => {
-    if (checked) {
-      setSelectedUsers([...selectedUsers, userId])
-    } else {
-      setSelectedUsers(selectedUsers.filter(id => id !== userId))
-    }
+  const toggleUser = (userId: string, checked: boolean) => {
+    setSelectedUsers(prev =>
+      checked ? [...prev, userId] : prev.filter(id => id !== userId)
+    )
   }
 
-  const handleSelectAll = (checked: boolean) => {
-    if (checked) {
-      setSelectedUsers(unverifiedUsers.map(user => user.id))
-    } else {
-      setSelectedUsers([])
-    }
+  const toggleAll = (checked: boolean) => {
+    setSelectedUsers(checked ? unverifiedUsers.map(u => u.id) : [])
   }
 
-  const handleSendEmails = async () => {
+  const handleSend = async () => {
     setIsLoading(true)
     setResults([])
     setSummary(null)
 
     try {
       let userIds: string[] = []
-
-      if (mode === 'all') {
-        userIds = unverifiedUsers.map(user => user.id)
-      } else if (mode === 'selected') {
-        userIds = selectedUsers
-      } else if (mode === 'single') {
-        userIds = [singleUser]
-      }
+      if (mode === 'all') userIds = unverifiedUsers.map(u => u.id)
+      else if (mode === 'selected') userIds = selectedUsers
+      else if (mode === 'single' && singleUser) userIds = [singleUser]
 
       if (userIds.length === 0) {
-        console.error('Aucun utilisateur sélectionné')
+        toast.error('Aucun utilisateur sélectionné')
         return
       }
 
       const response = await fetch('/api/admin/users/send-verification', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          userIds,
-          mode,
-        }),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userIds, mode }),
       })
 
       const data = await response.json()
-
       if (response.ok) {
         setResults(data.results || [])
         setSummary(data.summary || null)
-
-        // Afficher un toast de succès
         const successCount = data.summary?.success || 0
-        const failureCount = data.summary?.failures || 0
-
         if (successCount > 0) {
-          console.log(`${successCount} email(s) envoyé(s) avec succès`)
+          toast.success(`${successCount} email${successCount > 1 ? 's' : ''} envoyé${successCount > 1 ? 's' : ''}`)
         }
-        if (failureCount > 0) {
-          console.warn(`${failureCount} échec(s) lors de l'envoi`)
-        }
-
-        // Rafraîchir la liste des utilisateurs après envoi
-        setTimeout(() => {
-          refreshUsers()
-        }, 1000)
+        setTimeout(() => refreshUsers(), 1000)
       } else {
-        console.error('Erreur:', data.error)
-        // Afficher un toast d'erreur
-        console.error("Erreur lors de l'envoi des emails")
+        toast.error(data.error || "Erreur lors de l'envoi des emails")
       }
     } catch (error) {
-      console.error("Erreur lors de l'envoi des emails:", error)
-      // Afficher un toast d'erreur
-      console.error("Erreur de connexion lors de l'envoi des emails")
+      console.error("Erreur lors de l'envoi:", error)
+      toast.error('Erreur technique lors de l’envoi')
     } finally {
       setIsLoading(false)
     }
@@ -147,115 +129,173 @@ export function EmailVerificationPanel({ users, refreshUsers }: EmailVerificatio
     resetForm()
   }
 
+  const canSubmit =
+    !isLoading &&
+    ((mode === 'all' && unverifiedUsers.length > 0) ||
+      (mode === 'selected' && selectedUsers.length > 0) ||
+      (mode === 'single' && !!singleUser))
+
+  const selectedCount =
+    mode === 'all'
+      ? unverifiedUsers.length
+      : mode === 'selected'
+        ? selectedUsers.length
+        : singleUser
+          ? 1
+          : 0
+
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
-        <Button variant='outline' className='gap-2' disabled={unverifiedUsers.length === 0}>
+        <Button
+          variant='outline'
+          className='gap-2 border-slate-200 bg-white/80 text-slate-700 shadow-sm hover:bg-slate-50'
+          disabled={unverifiedUsers.length === 0}
+        >
           <Mail className='h-4 w-4' />
           Renvoyer emails de vérification
           {unverifiedUsers.length > 0 && (
-            <span className='ml-1 px-2 py-1 text-xs bg-orange-100 text-orange-800 rounded-full'>
+            <span className='ml-1 inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800'>
               {unverifiedUsers.length}
             </span>
           )}
         </Button>
       </DialogTrigger>
 
-      <DialogContent className='max-w-2xl max-h-[80vh] overflow-y-auto'>
+      <DialogContent className='max-h-[85vh] overflow-y-auto sm:max-w-2xl'>
         <DialogHeader>
-          <DialogTitle>Renvoyer les emails de vérification</DialogTitle>
-          <DialogDescription>
-            Choisissez les utilisateurs à qui renvoyer l&apos;email de vérification de compte. Seuls
-            les comptes non vérifiés sont concernés ({unverifiedUsers.length} comptes).
-          </DialogDescription>
+          <div className='flex items-start gap-3'>
+            <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 ring-1 ring-blue-100'>
+              <Mail className='h-5 w-5' />
+            </div>
+            <div className='min-w-0 flex-1 space-y-1'>
+              <DialogTitle className='text-lg'>Renvoyer les emails de vérification</DialogTitle>
+              <DialogDescription className='text-sm text-slate-600'>
+                Seuls les comptes non vérifiés sont concernés.{' '}
+                <strong>{unverifiedUsers.length}</strong> compte
+                {unverifiedUsers.length > 1 ? 's' : ''} en attente.
+              </DialogDescription>
+            </div>
+          </div>
         </DialogHeader>
 
-        <div className='space-y-4'>
-          {/* Mode de sélection */}
-          <div>
-            <label className='text-sm font-medium'>Mode d&apos;envoi</label>
-            <Select
-              value={mode}
-              onValueChange={(value: 'all' | 'selected' | 'single') => setMode(value)}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value='all'>
-                  <div className='flex items-center gap-2'>
-                    <Users className='h-4 w-4' />
-                    Tous les comptes non vérifiés ({unverifiedUsers.length})
+        <div className='space-y-5 py-2'>
+          {/* Mode selection as icon cards */}
+          <div className='grid gap-2 sm:grid-cols-3'>
+            {[
+              {
+                value: 'all' as SendMode,
+                icon: UsersIcon,
+                title: 'Tous les non vérifiés',
+                subtitle: `${unverifiedUsers.length} compte${unverifiedUsers.length > 1 ? 's' : ''}`,
+              },
+              {
+                value: 'selected' as SendMode,
+                icon: UsersIcon,
+                title: 'Sélection',
+                subtitle: 'Choix manuel',
+              },
+              {
+                value: 'single' as SendMode,
+                icon: UserIcon,
+                title: 'Un utilisateur',
+                subtitle: 'Compte unique',
+              },
+            ].map(opt => {
+              const Icon = opt.icon
+              const active = mode === opt.value
+              return (
+                <button
+                  key={opt.value}
+                  type='button'
+                  onClick={() => setMode(opt.value)}
+                  className={`flex flex-col items-start gap-1 rounded-xl border p-3 text-left transition ${
+                    active
+                      ? 'border-blue-300 bg-blue-50/60 ring-2 ring-blue-100'
+                      : 'border-slate-200 bg-white hover:border-slate-300'
+                  }`}
+                >
+                  <div
+                    className={`flex h-8 w-8 items-center justify-center rounded-lg ${
+                      active ? 'bg-blue-100 text-blue-600' : 'bg-slate-100 text-slate-600'
+                    }`}
+                  >
+                    <Icon className='h-4 w-4' />
                   </div>
-                </SelectItem>
-                <SelectItem value='selected'>
-                  <div className='flex items-center gap-2'>
-                    <Users className='h-4 w-4' />
-                    Comptes sélectionnés
-                  </div>
-                </SelectItem>
-                <SelectItem value='single'>
-                  <div className='flex items-center gap-2'>
-                    <UserIcon className='h-4 w-4' />
-                    Un seul compte
-                  </div>
-                </SelectItem>
-              </SelectContent>
-            </Select>
+                  <p className='text-sm font-semibold text-slate-900'>{opt.title}</p>
+                  <p className='text-xs text-slate-500'>{opt.subtitle}</p>
+                </button>
+              )
+            })}
           </div>
 
-          {/* Sélection multiple */}
+          {/* Mode: selected — checkbox list */}
           {mode === 'selected' && (
-            <div className='space-y-3'>
-              <div className='flex items-center gap-2'>
-                <Checkbox
-                  checked={selectedUsers.length === unverifiedUsers.length}
-                  onCheckedChange={handleSelectAll}
-                />
-                <label className='text-sm'>Sélectionner tout</label>
+            <div className='space-y-3 rounded-xl border border-slate-200 bg-slate-50/40 p-3'>
+              <div className='flex items-center justify-between gap-3 border-b border-slate-200 pb-3'>
+                <label className='flex items-center gap-2 text-sm font-medium text-slate-700'>
+                  <Checkbox
+                    checked={
+                      selectedUsers.length === unverifiedUsers.length &&
+                      unverifiedUsers.length > 0
+                    }
+                    onCheckedChange={toggleAll}
+                  />
+                  Tout sélectionner
+                </label>
+                <span className='text-xs text-slate-500'>
+                  {selectedUsers.length} / {unverifiedUsers.length}
+                </span>
               </div>
-
-              <div className='max-h-48 overflow-y-auto border rounded p-3 space-y-2'>
-                {unverifiedUsers.map(user => (
-                  <div key={user.id} className='flex items-center gap-2'>
-                    <Checkbox
-                      checked={selectedUsers.includes(user.id)}
-                      onCheckedChange={(checked: boolean) => handleUserSelection(user.id, checked)}
-                    />
-                    <div className='flex-1'>
-                      <div className='text-sm font-medium'>
-                        {user.name} {user.lastname}
+              <div className='max-h-60 space-y-1.5 overflow-y-auto'>
+                {unverifiedUsers.map(user => {
+                  const isChecked = selectedUsers.includes(user.id)
+                  return (
+                    <label
+                      key={user.id}
+                      className={`flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2 transition ${
+                        isChecked ? 'bg-blue-50/80' : 'hover:bg-white'
+                      }`}
+                    >
+                      <Checkbox
+                        checked={isChecked}
+                        onCheckedChange={(checked: boolean) => toggleUser(user.id, checked)}
+                      />
+                      <Avatar className='h-8 w-8 shrink-0'>
+                        <AvatarImage src={getUserAvatarUrl(user)} alt={user.name || user.email} />
+                        <AvatarFallback className='bg-gradient-to-br from-indigo-500 to-purple-500 text-[10px] font-semibold text-white'>
+                          {(user.name?.[0] || user.email[0]).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className='min-w-0 flex-1'>
+                        <p className='truncate text-sm font-medium text-slate-900'>
+                          {[user.name, user.lastname].filter(Boolean).join(' ') || 'Sans nom'}
+                        </p>
+                        <p className='truncate text-xs text-slate-500'>{user.email}</p>
                       </div>
-                      <div className='text-xs text-gray-500'>{user.email}</div>
-                    </div>
-                  </div>
-                ))}
+                    </label>
+                  )
+                })}
               </div>
-
-              {selectedUsers.length > 0 && (
-                <div className='text-sm text-blue-600'>
-                  {selectedUsers.length} compte(s) sélectionné(s)
-                </div>
-              )}
             </div>
           )}
 
-          {/* Sélection unique */}
+          {/* Mode: single — select */}
           {mode === 'single' && (
-            <div>
-              <label className='text-sm font-medium'>Utilisateur</label>
+            <div className='space-y-2'>
+              <label className='text-sm font-medium text-slate-700'>Utilisateur</label>
               <Select value={singleUser} onValueChange={setSingleUser}>
                 <SelectTrigger>
-                  <SelectValue placeholder='Choisir un utilisateur' />
+                  <SelectValue placeholder='Choisir un utilisateur…' />
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent className='max-h-72'>
                   {unverifiedUsers.map(user => (
                     <SelectItem key={user.id} value={user.id}>
-                      <div>
-                        <div className='font-medium'>
-                          {user.name} {user.lastname}
-                        </div>
-                        <div className='text-xs text-gray-500'>{user.email}</div>
+                      <div className='flex flex-col'>
+                        <span className='font-medium'>
+                          {[user.name, user.lastname].filter(Boolean).join(' ') || user.email}
+                        </span>
+                        <span className='text-xs text-slate-500'>{user.email}</span>
                       </div>
                     </SelectItem>
                   ))}
@@ -264,33 +304,52 @@ export function EmailVerificationPanel({ users, refreshUsers }: EmailVerificatio
             </div>
           )}
 
-          {/* Résultats */}
+          {/* Results summary */}
           {summary && (
-            <Alert>
-              <CheckCircle className='h-4 w-4' />
-              <AlertDescription>
-                <div className='font-medium'>Envoi terminé</div>
-                <div className='text-sm'>
-                  {summary.success} emails envoyés avec succès, {summary.failures} échecs sur{' '}
-                  {summary.total} total
+            <div className='rounded-xl border border-slate-200 bg-white p-4'>
+              <div className='mb-3 flex items-center justify-between'>
+                <p className='text-sm font-semibold text-slate-900'>Résultat de l’envoi</p>
+                <span className='text-xs text-slate-500'>
+                  {summary.total} email{summary.total > 1 ? 's' : ''} traité
+                  {summary.total > 1 ? 's' : ''}
+                </span>
+              </div>
+              <div className='grid grid-cols-2 gap-3'>
+                <div className='flex items-center gap-2 rounded-lg bg-emerald-50 px-3 py-2 text-emerald-700 ring-1 ring-emerald-100'>
+                  <MailCheck className='h-4 w-4' />
+                  <span className='text-sm font-semibold tabular-nums'>{summary.success}</span>
+                  <span className='text-xs'>envoyés</span>
                 </div>
-              </AlertDescription>
-            </Alert>
+                <div className='flex items-center gap-2 rounded-lg bg-red-50 px-3 py-2 text-red-700 ring-1 ring-red-100'>
+                  <MailX className='h-4 w-4' />
+                  <span className='text-sm font-semibold tabular-nums'>{summary.failures}</span>
+                  <span className='text-xs'>échecs</span>
+                </div>
+              </div>
+            </div>
           )}
 
+          {/* Per-email result list */}
           {results.length > 0 && (
             <div className='space-y-2'>
-              <h4 className='text-sm font-medium'>Détails des envois :</h4>
-              <div className='max-h-32 overflow-y-auto space-y-1'>
+              <h4 className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                Détails
+              </h4>
+              <div className='max-h-40 space-y-1 overflow-y-auto rounded-xl border border-slate-200 bg-white p-2'>
                 {results.map((result, index) => (
-                  <div key={index} className='flex items-center gap-2 text-xs'>
+                  <div
+                    key={`${result.userId}-${index}`}
+                    className='flex items-center gap-2 rounded-md px-2 py-1.5 text-xs'
+                  >
                     {result.success ? (
-                      <CheckCircle className='h-3 w-3 text-green-500' />
+                      <CheckCircle2 className='h-3.5 w-3.5 shrink-0 text-emerald-500' />
                     ) : (
-                      <XCircle className='h-3 w-3 text-red-500' />
+                      <XCircle className='h-3.5 w-3.5 shrink-0 text-red-500' />
                     )}
-                    <span className='flex-1'>{result.email}</span>
-                    {!result.success && <span className='text-red-500'>{result.error}</span>}
+                    <span className='flex-1 truncate text-slate-700'>{result.email}</span>
+                    {!result.success && result.error && (
+                      <span className='truncate text-red-500'>{result.error}</span>
+                    )}
                   </div>
                 ))}
               </div>
@@ -298,24 +357,19 @@ export function EmailVerificationPanel({ users, refreshUsers }: EmailVerificatio
           )}
         </div>
 
-        <DialogFooter>
-          <Button variant='outline' onClick={handleClose}>
+        <DialogFooter className='gap-2'>
+          <Button variant='outline' onClick={handleClose} disabled={isLoading}>
             Fermer
           </Button>
           <Button
-            onClick={handleSendEmails}
-            disabled={
-              isLoading ||
-              (mode === 'selected' && selectedUsers.length === 0) ||
-              (mode === 'single' && !singleUser)
-            }
+            onClick={handleSend}
+            disabled={!canSubmit}
+            className='gap-2 bg-blue-600 text-white hover:bg-blue-700'
           >
-            {isLoading ? (
-              <Loader2 className='h-4 w-4 animate-spin mr-2' />
-            ) : (
-              <Mail className='h-4 w-4 mr-2' />
-            )}
-            {isLoading ? 'Envoi en cours...' : 'Envoyer les emails'}
+            {isLoading ? <Loader2 className='h-4 w-4 animate-spin' /> : <Send className='h-4 w-4' />}
+            {isLoading
+              ? 'Envoi…'
+              : `Envoyer ${selectedCount > 0 ? `(${selectedCount})` : ''}`.trim()}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,36 +1,40 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+import { User } from '@prisma/client'
 import { useAuth } from '@/hooks/useAuth'
 import { isFullAdmin } from '@/hooks/useAdminAuth'
 import { createUser } from '@/lib/services/user.service'
-import { User } from '@prisma/client'
 import { useAdminUsersPaginated } from '@/hooks/useAdminPaginated'
 import Pagination from '@/components/ui/Pagination'
-import Link from 'next/link'
-import { motion, Variants } from 'framer-motion'
-import { Card, CardContent, CardHeader } from '@/components/ui/shadcnui/card'
 import { Button } from '@/components/ui/shadcnui/button'
 import { Input } from '@/components/ui/shadcnui/input'
 import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/shadcnui/avatar'
 import {
   Loader2,
-  Search,
-  User as UserIcon,
   Calendar,
   Mail,
   Eye,
-  CheckCircle,
+  CheckCircle2,
   Edit3,
-  Users,
-  Filter,
-  MoreVertical,
+  Users as UsersIcon,
   UserPlus,
   Shield,
   Trash2,
   ShieldCheck,
+  UserCheck,
+  UserCog,
+  Crown,
+  Home,
+  PenLine,
+  UserCircle2,
+  MoreHorizontal,
+  MailCheck,
+  MailX,
 } from 'lucide-react'
 import {
   Dialog,
@@ -57,30 +61,67 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/shadcnui/dropdown-menu'
-import { RoleBadge, RoleIcon } from '@/components/ui/RoleBadge'
 import { EmailVerificationPanel } from './components/EmailVerificationPanel'
 import { ConfirmDeleteUserDialog } from './components/ConfirmDeleteUserDialog'
 import { toast } from 'sonner'
 
-const containerVariants: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
-  },
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard, KpiMetric, type KpiTone } from '@/components/admin/ui/KpiCard'
+import { FilterBar } from '@/components/admin/ui/FilterBar'
+import { DataTable, type DataTableColumn, type DataTableSort } from '@/components/admin/ui/DataTable'
+
+/**
+ * Ordered list of roles known to the admin panel.
+ * The order determines how they appear in the role-filter buttons and the role <Select>.
+ */
+const ROLES: Array<{
+  value: string
+  label: string
+  short: string
+  icon: React.ComponentType<{ className?: string }>
+  tone: KpiTone
+}> = [
+  { value: 'ADMIN', label: 'Administrateurs', short: 'Admin', icon: Crown, tone: 'purple' },
+  { value: 'HOST_MANAGER', label: 'Gestionnaires Hôtes', short: 'Gestionnaire', icon: ShieldCheck, tone: 'indigo' },
+  { value: 'BLOGWRITER', label: 'Rédacteurs Blog', short: 'Rédacteur', icon: PenLine, tone: 'blue' },
+  { value: 'HOST_VERIFIED', label: 'Hôtes Vérifiés', short: 'Hôte vérifié', icon: UserCheck, tone: 'emerald' },
+  { value: 'HOST', label: 'Hôtes', short: 'Hôte', icon: Home, tone: 'amber' },
+  { value: 'USER', label: 'Utilisateurs', short: 'Utilisateur', icon: UserCircle2, tone: 'slate' },
+]
+
+function getRoleConfig(role: string) {
+  return ROLES.find(r => r.value === role)
 }
 
-const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.5,
-    },
-  },
+function RolePill({ role }: { role: string }) {
+  const config = getRoleConfig(role)
+  if (!config) {
+    return (
+      <span className='inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200'>
+        <UserCog className='h-3 w-3' />
+        {role}
+      </span>
+    )
+  }
+  const Icon = config.icon
+  const toneClass: Record<KpiTone, string> = {
+    slate: 'bg-slate-100 text-slate-700 ring-slate-200',
+    blue: 'bg-blue-50 text-blue-700 ring-blue-200',
+    indigo: 'bg-indigo-50 text-indigo-700 ring-indigo-200',
+    emerald: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    amber: 'bg-amber-50 text-amber-700 ring-amber-200',
+    orange: 'bg-orange-50 text-orange-700 ring-orange-200',
+    red: 'bg-red-50 text-red-700 ring-red-200',
+    purple: 'bg-purple-50 text-purple-700 ring-purple-200',
+  }
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ring-1 ${toneClass[config.tone]}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.short}
+    </span>
+  )
 }
 
 export default function UsersPage() {
@@ -91,7 +132,6 @@ export default function UsersPage() {
   } = useAuth({ required: true, redirectTo: '/auth' })
   const router = useRouter()
 
-  // Use optimized pagination hook
   const {
     users,
     pagination,
@@ -106,37 +146,44 @@ export default function UsersPage() {
   } = useAdminUsersPaginated()
 
   const [error, setError] = useState<string | null>(null)
+  const [sort, setSort] = useState<DataTableSort | null>({ key: 'createdAt', direction: 'desc' })
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
 
+  // Add-user dialog
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
   const [newUserName, setNewUserName] = useState('')
-  const [newUserSurname, setnewUserSurname] = useState('')
-  const [newUserEmail, setnewUserEmail] = useState('')
-  const [newUserPassword, setnewUserPassword] = useState('')
+  const [newUserSurname, setNewUserSurname] = useState('')
+  const [newUserEmail, setNewUserEmail] = useState('')
+  const [newUserPassword, setNewUserPassword] = useState('')
 
-  // États pour la modification des rôles
+  // Edit-role dialog
   const [isEditRoleDialogOpen, setIsEditRoleDialogOpen] = useState(false)
   const [editingUser, setEditingUser] = useState<User | null>(null)
   const [newRole, setNewRole] = useState('')
   const [isUpdatingRole, setIsUpdatingRole] = useState(false)
 
-  // États pour la suppression d'utilisateur
+  // Delete dialog
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [deletionInfo, setDeletionInfo] = useState<unknown>(null)
   const [isDeleting, setIsDeleting] = useState(false)
 
-  const handleAddOption = async () => {
-    if (
-      !newUserName.trim() &&
-      !newUserSurname.trim() &&
-      !newUserEmail.trim() &&
-      !newUserPassword.trim()
-    )
-      return
+  useEffect(() => {
+    if (isAuthenticated && (!session?.user?.roles || !isFullAdmin(session.user.roles))) {
+      router.push('/')
+    }
+  }, [isAuthenticated, session, router])
 
+  // Reset selection when page / filter changes
+  useEffect(() => {
+    setSelectedIds(new Set())
+  }, [pagination.currentPage, searchTerm, roleFilter])
+
+  const handleAddUser = async () => {
+    if (!newUserName.trim() || !newUserEmail.trim() || !newUserPassword.trim()) return
     setIsSubmitting(true)
     try {
-      const newOption = await createUser(
+      const result = await createUser(
         {
           email: newUserEmail,
           password: newUserPassword,
@@ -145,21 +192,20 @@ export default function UsersPage() {
         },
         true
       )
-
-      if (newOption) {
-        // Refresh the paginated data instead of manually updating state
+      if (result) {
         await refetch()
         setNewUserName('')
-        setnewUserEmail('')
-        setnewUserSurname('')
-        setnewUserPassword('')
+        setNewUserEmail('')
+        setNewUserSurname('')
+        setNewUserPassword('')
         setIsAddDialogOpen(false)
+        toast.success('Utilisateur créé avec succès')
       } else {
         setError("Erreur lors de la création de l'utilisateur")
       }
     } catch (err) {
       console.error('Erreur lors de la création:', err)
-      setError("Erreur lors de la création de l'utilisateurs")
+      setError("Erreur lors de la création de l'utilisateur")
     } finally {
       setIsSubmitting(false)
     }
@@ -173,39 +219,30 @@ export default function UsersPage() {
 
   const handleUpdateRole = async () => {
     if (!editingUser || !newRole || editingUser.roles === newRole) return
-
     setIsUpdatingRole(true)
     try {
       const response = await fetch(`/api/admin/users/${editingUser.id}/role`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ role: newRole }),
       })
-
       if (response.ok) {
-        // Refresh the paginated data instead of manually updating state
         await refetch()
         setIsEditRoleDialogOpen(false)
         setEditingUser(null)
         setNewRole('')
-
-        // Notification toast de succès
-        toast.success('Rôle mis à jour avec succès !', {
-          description: `Un email de notification a été envoyé à ${editingUser.name || editingUser.email} pour l'informer du changement de rôle.`,
+        toast.success('Rôle mis à jour avec succès', {
+          description: `Un email de notification a été envoyé à ${editingUser.name || editingUser.email}.`,
           duration: 5000,
         })
       } else {
         const errorData = await response.json()
-        setError(errorData.error || 'Erreur lors de la modification du rôle')
         toast.error('Erreur lors de la modification du rôle', {
           description: errorData.error || 'Une erreur est survenue',
         })
       }
     } catch (err) {
       console.error('Erreur lors de la modification du rôle:', err)
-      setError('Erreur lors de la modification du rôle')
       toast.error('Erreur lors de la modification du rôle', {
         description: 'Une erreur technique est survenue',
       })
@@ -218,27 +255,25 @@ export default function UsersPage() {
     try {
       const response = await fetch(`/api/admin/users/${user.id}`)
       if (!response.ok) {
-        toast.error('Erreur lors de la recuperation des informations')
+        toast.error('Erreur lors de la récupération des informations')
         return
       }
       const info = await response.json()
       setDeletionInfo(info)
       setDeleteDialogOpen(true)
     } catch {
-      toast.error('Erreur lors de la recuperation des informations')
+      toast.error('Erreur lors de la récupération des informations')
     }
   }
 
   const handleDeleteConfirm = async () => {
     const info = deletionInfo as { user: { id: string } } | null
     if (!info) return
-
     setIsDeleting(true)
     try {
       const response = await fetch(`/api/admin/users/${info.user.id}`, { method: 'DELETE' })
-
       if (response.ok) {
-        toast.success('Utilisateur supprime avec succes')
+        toast.success('Utilisateur supprimé avec succès')
         setDeleteDialogOpen(false)
         setDeletionInfo(null)
         await refetch()
@@ -256,468 +291,485 @@ export default function UsersPage() {
   const handleForceVerifyEmail = async (user: User) => {
     try {
       const response = await fetch(`/api/admin/users/${user.id}`, { method: 'PATCH' })
-
       if (response.ok) {
-        toast.success(`Email de ${user.name || user.email} verifie avec succes`)
+        toast.success(`Email de ${user.name || user.email} vérifié avec succès`)
         await refetch()
       } else {
         const data = await response.json()
-        toast.error(data.error || 'Erreur lors de la verification')
+        toast.error(data.error || 'Erreur lors de la vérification')
       }
     } catch {
-      toast.error('Erreur technique lors de la verification')
+      toast.error('Erreur technique lors de la vérification')
     }
   }
 
-  const getRoleDisplayName = (role: string) => {
-    const roleNames: { [key: string]: string } = {
-      ADMIN: 'Administrateur',
-      HOST_MANAGER: 'Gestionnaire Hôtes',
-      BLOGWRITER: 'Rédacteur Blog',
-      HOST: 'Hôte',
-      HOST_VERIFIED: 'Hôte Vérifié',
-      USER: 'Utilisateur',
+  // Count users per role on the current page (display-only, not precise totals).
+  const rolesCountOnPage = useMemo(() => {
+    const acc: Record<string, number> = {}
+    for (const u of users) {
+      acc[u.roles] = (acc[u.roles] || 0) + 1
     }
-    return roleNames[role] || role
-  }
+    return acc
+  }, [users])
 
-  useEffect(() => {
-    if (isAuthenticated && (!session?.user?.roles || !isFullAdmin(session.user.roles))) {
-      router.push('/')
-    }
-  }, [isAuthenticated, session, router])
+  const unverifiedCount = useMemo(
+    () => users.filter(u => !u.emailVerified).length,
+    [users]
+  )
 
-  // Remove manual data fetching - handled by hook now
+  const columns: DataTableColumn<User>[] = [
+    {
+      key: 'user',
+      header: 'Utilisateur',
+      sortable: true,
+      sortAccessor: u => (u.name || u.email).toLowerCase(),
+      render: user => (
+        <div className='flex min-w-0 items-center gap-3'>
+          <Avatar className='h-9 w-9 shrink-0 border-2 border-white shadow-sm'>
+            <AvatarImage
+              src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${user.email}`}
+              alt={user.name || user.email}
+            />
+            <AvatarFallback className='bg-gradient-to-br from-indigo-500 to-purple-500 text-xs font-semibold text-white'>
+              {(user.name?.[0] || user.email[0]).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <div className='min-w-0'>
+            <div className='flex items-center gap-2'>
+              <span className='truncate text-sm font-semibold text-slate-900'>
+                {user.name || user.lastname
+                  ? `${user.name || ''} ${user.lastname || ''}`.trim()
+                  : 'Sans nom'}
+              </span>
+              {user.emailVerified ? (
+                <MailCheck className='h-3.5 w-3.5 shrink-0 text-emerald-500' />
+              ) : (
+                <MailX className='h-3.5 w-3.5 shrink-0 text-amber-500' />
+              )}
+            </div>
+            <p className='truncate text-xs text-slate-500'>
+              <Mail className='mr-1 inline h-3 w-3' />
+              {user.email}
+            </p>
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: 'role',
+      header: 'Rôle',
+      sortable: true,
+      sortAccessor: u => u.roles,
+      render: user => <RolePill role={user.roles} />,
+    },
+    {
+      key: 'createdAt',
+      header: 'Inscrit le',
+      sortable: true,
+      sortAccessor: u => new Date(u.createdAt),
+      render: user => (
+        <div className='flex items-center gap-1.5 text-xs text-slate-500'>
+          <Calendar className='h-3 w-3' />
+          {new Date(user.createdAt).toLocaleDateString('fr-FR')}
+        </div>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+  ]
 
-  if (isAuthLoading || loading) {
+  if (isAuthLoading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-16 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
+          <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
         </div>
       </div>
     )
   }
 
-  if (!session) {
-    return null
-  }
+  if (!session) return null
 
-  if (error || hookError) {
-    return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive' className='rounded-2xl'>
+  return (
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        {/* Header */}
+        <PageHeader
+          backHref='/admin'
+          backLabel='Retour au panel admin'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title='Gestion des utilisateurs'
+          subtitle='Consultez les comptes, modifiez les rôles et gérez les vérifications d’email depuis cet espace.'
+          actions={
+            <div className='flex items-center gap-2'>
+              <EmailVerificationPanel users={users} refreshUsers={refetch} />
+              <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+                <DialogTrigger asChild>
+                  <Button className='gap-2 bg-gradient-to-r from-blue-600 to-indigo-600 text-white shadow-sm hover:from-blue-700 hover:to-indigo-700'>
+                    <UserPlus className='h-4 w-4' />
+                    Ajouter
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className='sm:max-w-md'>
+                  <DialogHeader>
+                    <DialogTitle className='flex items-center gap-2'>
+                      <UserPlus className='h-5 w-5 text-blue-600' />
+                      Nouvel utilisateur
+                    </DialogTitle>
+                    <DialogDescription>
+                      Créez un compte utilisateur avec les informations ci-dessous.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <div className='space-y-4 py-4'>
+                    <div className='grid grid-cols-2 gap-4'>
+                      <div className='space-y-2'>
+                        <Label htmlFor='userName'>Nom</Label>
+                        <Input
+                          id='userName'
+                          placeholder='Dupont'
+                          value={newUserName}
+                          onChange={e => setNewUserName(e.target.value)}
+                        />
+                      </div>
+                      <div className='space-y-2'>
+                        <Label htmlFor='userSurname'>Prénom</Label>
+                        <Input
+                          id='userSurname'
+                          placeholder='Jean'
+                          value={newUserSurname}
+                          onChange={e => setNewUserSurname(e.target.value)}
+                        />
+                      </div>
+                    </div>
+                    <div className='space-y-2'>
+                      <Label htmlFor='userEmail'>Email</Label>
+                      <Input
+                        id='userEmail'
+                        type='email'
+                        placeholder='jean.dupont@email.com'
+                        value={newUserEmail}
+                        onChange={e => setNewUserEmail(e.target.value)}
+                      />
+                    </div>
+                    <div className='space-y-2'>
+                      <Label htmlFor='userPassword'>Mot de passe</Label>
+                      <Input
+                        id='userPassword'
+                        type='password'
+                        placeholder='••••••••'
+                        value={newUserPassword}
+                        onChange={e => setNewUserPassword(e.target.value)}
+                      />
+                    </div>
+                  </div>
+                  <DialogFooter>
+                    <Button
+                      variant='outline'
+                      onClick={() => setIsAddDialogOpen(false)}
+                      disabled={isSubmitting}
+                    >
+                      Annuler
+                    </Button>
+                    <Button
+                      onClick={handleAddUser}
+                      disabled={
+                        !newUserName.trim() ||
+                        !newUserEmail.trim() ||
+                        !newUserPassword.trim() ||
+                        isSubmitting
+                      }
+                      className='gap-2 bg-blue-600 text-white hover:bg-blue-700'
+                    >
+                      {isSubmitting ? (
+                        <Loader2 className='h-4 w-4 animate-spin' />
+                      ) : (
+                        <CheckCircle2 className='h-4 w-4' />
+                      )}
+                      Créer
+                    </Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
+            </div>
+          }
+        />
+
+        {/* Error */}
+        {(error || hookError) && (
+          <Alert variant='destructive'>
             <AlertDescription>
               {error || hookError?.message || 'Erreur lors du chargement'}
             </AlertDescription>
           </Alert>
+        )}
+
+        {/* KPI row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Utilisateurs'
+            value={pagination.totalItems}
+            hint='au total sur la plateforme'
+            icon={UsersIcon}
+            tone='blue'
+            loading={loading}
+          />
+          <KpiCard
+            label='Administrateurs'
+            value={rolesCountOnPage['ADMIN'] ?? 0}
+            hint='sur cette page'
+            icon={Crown}
+            tone='purple'
+            loading={loading}
+          />
+          <KpiCard
+            label='Hôtes'
+            value={(rolesCountOnPage['HOST'] ?? 0) + (rolesCountOnPage['HOST_VERIFIED'] ?? 0)}
+            hint='vérifiés et non vérifiés'
+            icon={Home}
+            tone='amber'
+            loading={loading}
+          />
+          <KpiCard
+            label='Non vérifiés'
+            value={unverifiedCount}
+            hint='emails en attente de vérification'
+            icon={MailX}
+            tone='red'
+            loading={loading}
+          />
         </div>
-      </div>
-    )
-  }
 
-  return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100'>
-      <div className='container mx-auto p-6 space-y-8'>
-        {/* Header Section */}
-        <motion.div
-          className='text-center space-y-4'
-          variants={containerVariants}
-          initial='hidden'
-          animate='visible'
-        >
-          <motion.div
-            variants={itemVariants}
-            className='inline-flex items-center justify-center w-16 h-16 rounded-full bg-gradient-to-r from-blue-500 to-indigo-600 shadow-lg mb-4'
+        {/* Role filter chips */}
+        <div className='flex flex-wrap items-center gap-2'>
+          <button
+            onClick={() => handleRoleFilter('')}
+            className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+              roleFilter === ''
+                ? 'bg-slate-900 text-white shadow-sm'
+                : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50'
+            }`}
           >
-            <Users className='w-8 h-8 text-white' />
-          </motion.div>
-          <motion.h1
-            variants={itemVariants}
-            className='text-4xl font-bold bg-gradient-to-r from-gray-900 via-blue-800 to-indigo-800 bg-clip-text text-transparent'
-          >
-            Gestion des Utilisateurs
-          </motion.h1>
-          <motion.p variants={itemVariants} className='text-gray-600 text-lg max-w-2xl mx-auto'>
-            Gérez les comptes utilisateurs, leurs rôles et permissions depuis ce panneau
-            d&apos;administration
-          </motion.p>
-        </motion.div>
-
-        {/* Stats Cards */}
-        <motion.div
-          variants={containerVariants}
-          initial='hidden'
-          animate='visible'
-          className='grid grid-cols-1 md:grid-cols-4 gap-6 mb-8'
-        >
-          <motion.div variants={itemVariants}>
-            <Card className='border-0 shadow-lg bg-gradient-to-r from-blue-500 to-blue-600 text-white'>
-              <CardContent className='p-6'>
-                <div className='flex items-center justify-between'>
-                  <div>
-                    <p className='text-blue-100 text-sm font-medium'>Total Utilisateurs</p>
-                    <p className='text-3xl font-bold'>{pagination.totalItems}</p>
-                  </div>
-                  <Users className='h-8 w-8 text-blue-200' />
-                </div>
-              </CardContent>
-            </Card>
-          </motion.div>
-
-          {['ADMIN', 'HOST_MANAGER', 'HOST_VERIFIED', 'HOST', 'USER'].map(role => {
-            const count = users.filter(user => user.roles === role).length
+            Tous
+          </button>
+          {ROLES.map(role => {
+            const active = roleFilter === role.value
+            const Icon = role.icon
             return (
-              <motion.div key={role} variants={itemVariants}>
-                <Card
-                  className='border-0 shadow-lg hover:shadow-xl transition-all duration-300 bg-white/80 backdrop-blur-sm cursor-pointer'
-                  onClick={() => handleRoleFilter(roleFilter === role ? '' : role)}
-                >
-                  <CardContent className='p-6'>
-                    <div className='flex items-center justify-between'>
-                      <div>
-                        <p className='text-gray-600 text-sm font-medium'>
-                          {role === 'ADMIN'
-                            ? 'Administrateurs'
-                            : role === 'HOST_MANAGER'
-                              ? 'Gestionnaires Hôtes'
-                              : role === 'HOST_VERIFIED'
-                                ? 'Hôtes Vérifiés'
-                                : role === 'HOST'
-                                  ? 'Hôtes'
-                                  : 'Utilisateurs'}
-                          {roleFilter === role && ' (Filtré)'}
-                        </p>
-                        <p className='text-2xl font-bold text-gray-900'>
-                          {roleFilter === role ? pagination.totalItems : count}
-                        </p>
-                      </div>
-                      <RoleIcon role={role} size='md' />
-                    </div>
-                  </CardContent>
-                </Card>
-              </motion.div>
+              <button
+                key={role.value}
+                onClick={() => handleRoleFilter(active ? '' : role.value)}
+                className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+                  active
+                    ? 'bg-slate-900 text-white shadow-sm'
+                    : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50'
+                }`}
+              >
+                <Icon className='h-3 w-3' />
+                {role.short}
+              </button>
             )
           })}
-        </motion.div>
+        </div>
 
-        {/* Search and Actions */}
-        <motion.div
-          variants={containerVariants}
-          initial='hidden'
-          animate='visible'
-          className='flex flex-col sm:flex-row gap-4 items-center justify-between bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border-0'
-        >
-          <motion.div variants={itemVariants} className='flex items-center gap-4 w-full sm:w-auto'>
-            <div className='relative flex-1 sm:min-w-[300px]'>
-              <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4' />
-              <Input
-                type='text'
-                placeholder='Rechercher par nom, email...'
-                value={searchTerm}
-                onChange={e => handleSearch(e.target.value)}
-                className='pl-10 py-3 border-0 bg-gray-50 focus:bg-white transition-colors rounded-xl'
-              />
-            </div>
-          </motion.div>
-
-          <motion.div variants={itemVariants} className='flex gap-3'>
-            <Button variant='outline' className='rounded-xl border-gray-200 hover:bg-gray-50'>
-              <Filter className='h-4 w-4 mr-2' />
-              Filtrer
-            </Button>
-            <EmailVerificationPanel users={users} refreshUsers={refetch} />
-            <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-              <DialogTrigger asChild>
-                <Button className='bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white rounded-xl shadow-lg'>
-                  <UserPlus className='h-4 w-4 mr-2' />
-                  Ajouter un utilisateur
+        {/* Filter bar */}
+        <FilterBar
+          searchValue={searchTerm}
+          onSearchChange={handleSearch}
+          searchPlaceholder='Rechercher par nom, email…'
+          belowSlot={
+            selectedIds.size > 0 ? (
+              <div className='flex items-center justify-between'>
+                <span className='text-sm font-medium text-slate-600'>
+                  {selectedIds.size} utilisateur
+                  {selectedIds.size > 1 ? 's' : ''} sélectionné{selectedIds.size > 1 ? 's' : ''}
+                </span>
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  onClick={() => setSelectedIds(new Set())}
+                  className='text-slate-500 hover:text-slate-900'
+                >
+                  Tout désélectionner
                 </Button>
-              </DialogTrigger>
-              <DialogContent className='sm:max-w-md rounded-2xl'>
-                <DialogHeader>
-                  <DialogTitle className='flex items-center gap-2 text-xl'>
-                    <UserPlus className='h-5 w-5 text-blue-600' />
-                    Ajouter un utilisateur
-                  </DialogTitle>
-                  <DialogDescription>
-                    Créez un nouveau compte utilisateur avec les informations ci-dessous.
-                  </DialogDescription>
-                </DialogHeader>
-                <div className='space-y-4 py-4'>
-                  <div className='grid grid-cols-2 gap-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='userName'>Nom</Label>
-                      <Input
-                        id='userName'
-                        placeholder='Dupont'
-                        value={newUserName}
-                        onChange={e => setNewUserName(e.target.value)}
-                        className='rounded-xl'
-                      />
-                    </div>
-                    <div className='space-y-2'>
-                      <Label htmlFor='userSurname'>Prénom</Label>
-                      <Input
-                        id='userSurname'
-                        placeholder='Jean'
-                        value={newUserSurname}
-                        onChange={e => setnewUserSurname(e.target.value)}
-                        className='rounded-xl'
-                      />
-                    </div>
-                  </div>
-                  <div className='space-y-2'>
-                    <Label htmlFor='userEmail'>Email</Label>
-                    <Input
-                      id='userEmail'
-                      type='email'
-                      placeholder='jean.dupont@email.com'
-                      value={newUserEmail}
-                      onChange={e => setnewUserEmail(e.target.value)}
-                      className='rounded-xl'
-                    />
-                  </div>
-                  <div className='space-y-2'>
-                    <Label htmlFor='userPassword'>Mot de passe</Label>
-                    <Input
-                      id='userPassword'
-                      type='password'
-                      placeholder='••••••••'
-                      value={newUserPassword}
-                      onChange={e => setnewUserPassword(e.target.value)}
-                      className='rounded-xl'
-                    />
-                  </div>
-                </div>
-                <DialogFooter>
-                  <Button
-                    variant='outline'
-                    onClick={() => setIsAddDialogOpen(false)}
-                    disabled={isSubmitting}
-                    className='rounded-xl'
-                  >
-                    Annuler
-                  </Button>
-                  <Button
-                    onClick={handleAddOption}
-                    disabled={!newUserName.trim() || isSubmitting}
-                    className='bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 rounded-xl'
-                  >
-                    {isSubmitting ? (
-                      <>
-                        <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                        Création...
-                      </>
-                    ) : (
-                      <>
-                        <CheckCircle className='h-4 w-4 mr-2' />
-                        Créer
-                      </>
-                    )}
-                  </Button>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
-          </motion.div>
-        </motion.div>
+              </div>
+            ) : null
+          }
+        />
 
-        {/* Users Grid */}
-        <motion.div
-          variants={containerVariants}
-          initial='hidden'
-          animate='visible'
-          className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'
-        >
-          {users.map((user, index) => (
-            <motion.div key={user.id} variants={itemVariants} transition={{ delay: index * 0.1 }}>
-              <Card className='group hover:shadow-2xl transition-all duration-300 border-0 bg-white/80 backdrop-blur-sm rounded-2xl overflow-hidden'>
-                <CardHeader className='pb-4'>
-                  <div className='flex items-start justify-between'>
-                    <div className='flex items-center gap-4'>
-                      <Avatar className='h-12 w-12 border-2 border-white shadow-lg'>
-                        <AvatarImage
-                          src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${user.email}`}
-                        />
-                        <AvatarFallback className='bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-semibold'>
-                          {(user.name?.[0] || user.email[0]).toUpperCase()}
-                        </AvatarFallback>
-                      </Avatar>
-                      <div className='flex-1'>
-                        <h3 className='font-semibold text-lg text-gray-900 group-hover:text-blue-600 transition-colors'>
-                          {user.name || user.lastname
-                            ? `${user.name || ''} ${user.lastname || ''}`.trim()
-                            : 'Sans nom'}
-                        </h3>
-                        <p className='text-gray-500 text-sm flex items-center gap-1'>
-                          <Mail className='h-3 w-3' />
-                          {user.email}
-                        </p>
-                      </div>
-                    </div>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='h-8 w-8 p-0 opacity-0 group-hover:opacity-100 transition-opacity'
-                        >
-                          <MoreVertical className='h-4 w-4' />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align='end' className='rounded-xl'>
-                        <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem asChild>
-                          <Link
-                            href={`/admin/users/${user.id}`}
-                            className='flex items-center gap-2'
-                          >
-                            <Eye className='h-4 w-4' />
-                            Voir le profil
-                          </Link>
-                        </DropdownMenuItem>
-                        {session?.user?.id !== user.id && (
-                          <DropdownMenuItem
-                            onClick={() => handleEditRole(user)}
-                            className='flex items-center gap-2'
-                          >
-                            <Edit3 className='h-4 w-4' />
-                            Modifier le rôle
-                          </DropdownMenuItem>
-                        )}
-                        {!user.emailVerified && (
-                          <DropdownMenuItem
-                            onClick={() => handleForceVerifyEmail(user)}
-                            className='flex items-center gap-2'
-                          >
-                            <ShieldCheck className='h-4 w-4' />
-                            Vérifier l&apos;email
-                          </DropdownMenuItem>
-                        )}
-                        {session?.user?.id !== user.id && (
-                          <>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                              onClick={() => handleDeleteClick(user)}
-                              className='flex items-center gap-2 text-red-600 focus:text-red-600'
-                            >
-                              <Trash2 className='h-4 w-4' />
-                              Supprimer
-                            </DropdownMenuItem>
-                          </>
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
-                </CardHeader>
-                <CardContent className='pt-0'>
-                  <div className='space-y-4'>
-                    <div className='flex items-center justify-between'>
-                      <RoleBadge role={user.roles} size='sm' />
-                      {session?.user?.id !== user.id && (
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          onClick={() => handleEditRole(user)}
-                          className='h-8 w-8 p-0 rounded-full hover:bg-blue-50 hover:text-blue-600'
-                          title='Modifier le rôle'
-                        >
-                          <Edit3 className='h-3 w-3' />
-                        </Button>
-                      )}
-                    </div>
-                    <div className='flex items-center gap-2 text-sm text-gray-500'>
-                      <Calendar className='h-4 w-4' />
-                      <span>Inscrit le {new Date(user.createdAt).toLocaleDateString('fr-FR')}</span>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-          ))}
-        </motion.div>
+        {/* Data table */}
+        <DataTable<User>
+          columns={columns}
+          rows={users}
+          getRowId={u => u.id}
+          loading={loading}
+          sort={sort}
+          onSortChange={setSort}
+          selection={{
+            selectedIds,
+            onSelectionChange: setSelectedIds,
+          }}
+          rowActions={user => (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  className='h-8 w-8 p-0'
+                  aria-label='Actions utilisateur'
+                >
+                  <MoreHorizontal className='h-4 w-4' />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align='end'>
+                <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                  <Link href={`/admin/users/${user.id}`} className='flex items-center gap-2'>
+                    <Eye className='h-4 w-4' />
+                    Voir le profil
+                  </Link>
+                </DropdownMenuItem>
+                {session?.user?.id !== user.id && (
+                  <DropdownMenuItem
+                    onClick={() => handleEditRole(user)}
+                    className='flex items-center gap-2'
+                  >
+                    <Edit3 className='h-4 w-4' />
+                    Modifier le rôle
+                  </DropdownMenuItem>
+                )}
+                {!user.emailVerified && (
+                  <DropdownMenuItem
+                    onClick={() => handleForceVerifyEmail(user)}
+                    className='flex items-center gap-2'
+                  >
+                    <ShieldCheck className='h-4 w-4' />
+                    Vérifier l’email
+                  </DropdownMenuItem>
+                )}
+                {session?.user?.id !== user.id && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onClick={() => handleDeleteClick(user)}
+                      className='flex items-center gap-2 text-red-600 focus:text-red-600'
+                    >
+                      <Trash2 className='h-4 w-4' />
+                      Supprimer
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+          emptyState={{
+            icon: UsersIcon,
+            title: 'Aucun utilisateur trouvé',
+            subtitle:
+              searchTerm || roleFilter
+                ? 'Essayez d’ajuster votre recherche ou vos filtres.'
+                : 'Ajoutez votre premier utilisateur avec le bouton en haut à droite.',
+          }}
+        />
 
-        {users.length === 0 && !loading && (
-          <motion.div variants={itemVariants} className='text-center py-12'>
-            <UserIcon className='h-12 w-12 text-gray-400 mx-auto mb-4' />
-            <h3 className='text-lg font-medium text-gray-900 mb-2'>Aucun utilisateur trouvé</h3>
-            <p className='text-gray-500'>
-              Essayez de modifier votre recherche ou ajoutez un nouvel utilisateur.
+        {/* Footer: summary + pagination */}
+        {!loading && users.length > 0 && (
+          <div className='flex flex-col items-center gap-3 md:flex-row md:justify-between'>
+            <p className='text-sm text-slate-500'>
+              <KpiMetric
+                label='utilisateurs affichés'
+                value={`${(pagination.currentPage - 1) * pagination.itemsPerPage + 1}–${Math.min(
+                  pagination.currentPage * pagination.itemsPerPage,
+                  pagination.totalItems
+                )} / ${pagination.totalItems}`}
+                icon={UsersIcon}
+                tone='slate'
+              />
             </p>
-          </motion.div>
-        )}
-
-        {/* Pagination */}
-        {pagination.totalPages > 1 && (
-          <div className='mt-8 flex justify-center'>
-            <Pagination
-              currentPage={pagination.currentPage}
-              totalPages={pagination.totalPages}
-              onPageChange={goToPage}
-              showPrevNext={true}
-              showNumbers={true}
-              maxVisiblePages={5}
-            />
+            {pagination.totalPages > 1 && (
+              <Pagination
+                currentPage={pagination.currentPage}
+                totalPages={pagination.totalPages}
+                onPageChange={goToPage}
+                showPrevNext={true}
+                showNumbers={true}
+                maxVisiblePages={5}
+              />
+            )}
           </div>
         )}
 
-        {/* Results summary */}
-        {users.length > 0 && (
-          <div className='mt-4 text-center text-sm text-gray-500'>
-            Affichage de {(pagination.currentPage - 1) * pagination.itemsPerPage + 1} à{' '}
-            {Math.min(pagination.currentPage * pagination.itemsPerPage, pagination.totalItems)} sur{' '}
-            {pagination.totalItems} utilisateurs
-          </div>
-        )}
-
-        {/* Modal de modification des rôles */}
+        {/* Edit role dialog */}
         <Dialog open={isEditRoleDialogOpen} onOpenChange={setIsEditRoleDialogOpen}>
-          <DialogContent className='sm:max-w-md rounded-2xl'>
+          <DialogContent className='sm:max-w-md'>
             <DialogHeader>
-              <DialogTitle className='flex items-center gap-2 text-xl'>
+              <DialogTitle className='flex items-center gap-2'>
                 <Shield className='h-5 w-5 text-blue-600' />
-                Modifier le rôle utilisateur
+                Modifier le rôle
               </DialogTitle>
               <DialogDescription>
                 Modifiez le rôle de{' '}
-                <span className='font-semibold'>{editingUser?.name || editingUser?.email}</span>
+                <span className='font-semibold'>{editingUser?.name || editingUser?.email}</span>.
+                Un email de notification sera envoyé.
               </DialogDescription>
             </DialogHeader>
             <div className='space-y-6 py-4'>
-              <div className='text-center'>
-                <div className='inline-flex items-center gap-3 p-4 bg-gray-50 rounded-xl'>
-                  <Avatar className='h-10 w-10'>
-                    <AvatarImage
-                      src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${editingUser?.email}`}
-                    />
-                    <AvatarFallback className='bg-gradient-to-r from-blue-500 to-indigo-600 text-white'>
-                      {(editingUser?.name?.[0] || editingUser?.email?.[0] || 'U').toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className='text-left'>
-                    <p className='font-medium'>{editingUser?.name || editingUser?.email}</p>
-                    <p className='text-sm text-gray-500'>
-                      Rôle actuel: {getRoleDisplayName(editingUser?.roles || '')}
-                    </p>
-                  </div>
+              <div className='flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 p-4'>
+                <Avatar className='h-10 w-10'>
+                  <AvatarImage
+                    src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${editingUser?.email}`}
+                  />
+                  <AvatarFallback className='bg-gradient-to-br from-indigo-500 to-purple-500 text-sm font-semibold text-white'>
+                    {(editingUser?.name?.[0] || editingUser?.email?.[0] || 'U').toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <div className='min-w-0 flex-1'>
+                  <p className='truncate font-medium text-slate-900'>
+                    {editingUser?.name || editingUser?.email}
+                  </p>
+                  <p className='truncate text-xs text-slate-500'>{editingUser?.email}</p>
                 </div>
+                {editingUser && <RolePill role={editingUser.roles} />}
               </div>
               <div className='space-y-2'>
                 <Label htmlFor='userRole'>Nouveau rôle</Label>
                 <Select value={newRole} onValueChange={setNewRole}>
-                  <SelectTrigger className='rounded-xl'>
+                  <SelectTrigger>
                     <SelectValue placeholder='Sélectionner un rôle' />
                   </SelectTrigger>
-                  <SelectContent className='rounded-xl'>
-                    <SelectItem value='USER'>👤 Utilisateur</SelectItem>
-                    <SelectItem value='HOST'>🏠 Hôte</SelectItem>
-                    <SelectItem value='HOST_VERIFIED'>✅ Hôte Vérifié</SelectItem>
-                    <SelectItem value='BLOGWRITER'>✍️ Rédacteur Blog</SelectItem>
-                    <SelectItem value='HOST_MANAGER'>🎯 Gestionnaire Hôtes</SelectItem>
-                    <SelectItem value='ADMIN'>👑 Administrateur</SelectItem>
+                  <SelectContent>
+                    {ROLES.slice()
+                      .reverse()
+                      .map(role => {
+                        const Icon = role.icon
+                        return (
+                          <SelectItem key={role.value} value={role.value}>
+                            <span className='inline-flex items-center gap-2'>
+                              <Icon className='h-4 w-4' />
+                              {role.label}
+                            </span>
+                          </SelectItem>
+                        )
+                      })}
                   </SelectContent>
                 </Select>
               </div>
@@ -731,32 +783,26 @@ export default function UsersPage() {
                   setNewRole('')
                 }}
                 disabled={isUpdatingRole}
-                className='rounded-xl'
               >
                 Annuler
               </Button>
               <Button
                 onClick={handleUpdateRole}
                 disabled={!newRole || isUpdatingRole || editingUser?.roles === newRole}
-                className='bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 rounded-xl'
+                className='gap-2 bg-blue-600 text-white hover:bg-blue-700'
               >
                 {isUpdatingRole ? (
-                  <>
-                    <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                    Modification...
-                  </>
+                  <Loader2 className='h-4 w-4 animate-spin' />
                 ) : (
-                  <>
-                    <CheckCircle className='h-4 w-4 mr-2' />
-                    Modifier
-                  </>
+                  <CheckCircle2 className='h-4 w-4' />
                 )}
+                Mettre à jour
               </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
 
-        {/* Modal de confirmation de suppression */}
+        {/* Delete dialog */}
         <ConfirmDeleteUserDialog
           open={deleteDialogOpen}
           onClose={() => {
@@ -767,7 +813,7 @@ export default function UsersPage() {
           deletionInfo={deletionInfo as Parameters<typeof ConfirmDeleteUserDialog>[0]['deletionInfo']}
           isLoading={isDeleting}
         />
-      </div>
+      </motion.div>
     </div>
   )
 }

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -69,6 +69,7 @@ import { PageHeader } from '@/components/admin/ui/PageHeader'
 import { KpiCard, KpiMetric, type KpiTone } from '@/components/admin/ui/KpiCard'
 import { FilterBar } from '@/components/admin/ui/FilterBar'
 import { DataTable, type DataTableColumn, type DataTableSort } from '@/components/admin/ui/DataTable'
+import { getUserAvatarUrl } from '@/lib/utils/userAvatar'
 
 /**
  * Ordered list of roles known to the admin panel.
@@ -326,10 +327,7 @@ export default function UsersPage() {
       render: user => (
         <div className='flex min-w-0 items-center gap-3'>
           <Avatar className='h-9 w-9 shrink-0 border-2 border-white shadow-sm'>
-            <AvatarImage
-              src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${user.email}`}
-              alt={user.name || user.email}
-            />
+            <AvatarImage src={getUserAvatarUrl(user)} alt={user.name || user.email} />
             <AvatarFallback className='bg-gradient-to-br from-indigo-500 to-purple-500 text-xs font-semibold text-white'>
               {(user.name?.[0] || user.email[0]).toUpperCase()}
             </AvatarFallback>
@@ -735,9 +733,7 @@ export default function UsersPage() {
             <div className='space-y-6 py-4'>
               <div className='flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 p-4'>
                 <Avatar className='h-10 w-10'>
-                  <AvatarImage
-                    src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${editingUser?.email}`}
-                  />
+                  {editingUser && <AvatarImage src={getUserAvatarUrl(editingUser)} />}
                   <AvatarFallback className='bg-gradient-to-br from-indigo-500 to-purple-500 text-sm font-semibold text-white'>
                     {(editingUser?.name?.[0] || editingUser?.email?.[0] || 'U').toUpperCase()}
                   </AvatarFallback>

--- a/src/app/admin/validation/components/ProductValidationCard.tsx
+++ b/src/app/admin/validation/components/ProductValidationCard.tsx
@@ -4,10 +4,17 @@ import React, { useState, useMemo, useCallback } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { ProductValidation } from '@prisma/client'
-import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import { CheckCircle, XCircle, Eye, MapPin, Home, User, Loader2 } from 'lucide-react'
+import {
+  CheckCircle2,
+  XCircle,
+  Eye,
+  MapPin,
+  Home,
+  Loader2,
+  UserCircle2,
+} from 'lucide-react'
+import { toPlainTextPreview } from '@/lib/utils/contentFormat'
 import { approveProduct, rejectProduct } from '../actions'
 
 interface Product {
@@ -25,7 +32,6 @@ interface Product {
     email: string
     image?: string | null
   }
-  // Nouvelles métadonnées pour le contexte de validation
   isRecentlyModified?: boolean
   wasRecheckRequested?: boolean
 }
@@ -36,49 +42,65 @@ interface ProductValidationCardProps {
   onUpdate: () => void
 }
 
+type StatusAccent = {
+  label: string
+  badgeClass: string
+  borderClass: string
+}
+
+function getStatusAccent(
+  validate: ProductValidation,
+  isRecentlyModified?: boolean
+): StatusAccent {
+  switch (validate) {
+    case ProductValidation.NotVerified:
+      if (isRecentlyModified) {
+        return {
+          label: 'Modifié · à revalider',
+          badgeClass: 'bg-blue-100 text-blue-800 ring-1 ring-blue-200',
+          borderClass: 'before:bg-blue-500',
+        }
+      }
+      return {
+        label: 'En attente',
+        badgeClass: 'bg-amber-100 text-amber-800 ring-1 ring-amber-200',
+        borderClass: 'before:bg-amber-500',
+      }
+    case ProductValidation.RecheckRequest:
+      return {
+        label: 'Révision demandée',
+        badgeClass: 'bg-orange-100 text-orange-800 ring-1 ring-orange-200',
+        borderClass: 'before:bg-orange-500',
+      }
+    case ProductValidation.Approve:
+      return {
+        label: 'Validé',
+        badgeClass: 'bg-emerald-100 text-emerald-800 ring-1 ring-emerald-200',
+        borderClass: 'before:bg-emerald-500',
+      }
+    case ProductValidation.Refused:
+      return {
+        label: 'Refusé',
+        badgeClass: 'bg-red-100 text-red-800 ring-1 ring-red-200',
+        borderClass: 'before:bg-red-500',
+      }
+    default:
+      return {
+        label: 'Inconnu',
+        badgeClass: 'bg-slate-100 text-slate-700 ring-1 ring-slate-200',
+        borderClass: 'before:bg-slate-400',
+      }
+  }
+}
+
 function ProductValidationCard({ product, currentUserId, onUpdate }: ProductValidationCardProps) {
   const [loading, setLoading] = useState(false)
 
-  // Memoize the validation badge to prevent recreation on every render
-  const validationBadge = useMemo(() => {
-    switch (product.validate) {
-      case ProductValidation.NotVerified:
-        if (product.isRecentlyModified) {
-          return (
-            <Badge variant='secondary' className='bg-blue-100 text-blue-800 border-blue-300'>
-              Modifié - À revalider
-            </Badge>
-          )
-        }
-        return (
-          <Badge variant='secondary' className='bg-yellow-100 text-yellow-800'>
-            En attente
-          </Badge>
-        )
-      case ProductValidation.RecheckRequest:
-        return (
-          <Badge variant='secondary' className='bg-orange-100 text-orange-800'>
-            Révision demandée
-          </Badge>
-        )
-      case ProductValidation.Approve:
-        return (
-          <Badge variant='default' className='bg-green-100 text-green-800'>
-            Validé
-          </Badge>
-        )
-      case ProductValidation.Refused:
-        return (
-          <Badge variant='destructive' className='bg-red-100 text-red-800'>
-            Refusé
-          </Badge>
-        )
-      default:
-        return <Badge variant='outline'>Inconnu</Badge>
-    }
-  }, [product.validate, product.isRecentlyModified])
+  const statusAccent = useMemo(
+    () => getStatusAccent(product.validate, product.isRecentlyModified),
+    [product.validate, product.isRecentlyModified]
+  )
 
-  // Memoize user display name to prevent recalculation
   const userDisplayName = useMemo(() => {
     const user = product.owner
     if (user?.name && user?.lastname) {
@@ -87,7 +109,15 @@ function ProductValidationCard({ product, currentUserId, onUpdate }: ProductVali
     return user?.email || 'Utilisateur inconnu'
   }, [product.owner])
 
-  // Memoize whether validation actions should be shown
+  const initials = useMemo(() => {
+    const name = userDisplayName
+    const parts = name.split(/\s+/).filter(Boolean)
+    if (parts.length >= 2) {
+      return (parts[0][0] + parts[1][0]).toUpperCase()
+    }
+    return (parts[0]?.[0] || '?').toUpperCase()
+  }, [userDisplayName])
+
   const showValidationActions = useMemo(() => {
     return (
       product.validate === ProductValidation.NotVerified ||
@@ -95,26 +125,27 @@ function ProductValidationCard({ product, currentUserId, onUpdate }: ProductVali
     )
   }, [product.validate])
 
-  // Memoize first image URL
   const firstImageUrl = useMemo(() => {
     return product.img && product.img.length > 0 ? product.img[0].img : null
   }, [product.img])
 
-  // Memoized validation action handler to prevent recreation
+  const descriptionPreview = useMemo(
+    () => toPlainTextPreview(product.description),
+    [product.description]
+  )
+
   const handleValidationAction = useCallback(
     async (action: 'approve' | 'reject') => {
       setLoading(true)
       try {
-        let result
-        if (action === 'approve') {
-          result = await approveProduct(product.id, currentUserId, 'Approuvé par admin')
-        } else {
-          result = await rejectProduct(
-            product.id,
-            currentUserId,
-            "Produit rejeté par l'administrateur"
-          )
-        }
+        const result =
+          action === 'approve'
+            ? await approveProduct(product.id, currentUserId, 'Approuvé par admin')
+            : await rejectProduct(
+                product.id,
+                currentUserId,
+                "Produit rejeté par l'administrateur"
+              )
 
         if (result.success) {
           onUpdate()
@@ -133,141 +164,173 @@ function ProductValidationCard({ product, currentUserId, onUpdate }: ProductVali
     [product.id, currentUserId, onUpdate]
   )
 
-  // Memoized click handlers to prevent recreation
   const handleApprove = useCallback(
     () => handleValidationAction('approve'),
     [handleValidationAction]
   )
-  const handleReject = useCallback(() => handleValidationAction('reject'), [handleValidationAction])
+  const handleReject = useCallback(
+    () => handleValidationAction('reject'),
+    [handleValidationAction]
+  )
 
   return (
-    <Card className='overflow-hidden hover:shadow-lg transition-all duration-300'>
-      {/* Product Image */}
-      <div className='relative h-48 w-full'>
+    <article
+      className={`group relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg before:absolute before:left-0 before:top-0 before:h-full before:w-1.5 ${statusAccent.borderClass}`}
+    >
+      {/* Image + status badge overlay */}
+      <div className='relative h-56 w-full overflow-hidden bg-slate-100'>
         {firstImageUrl ? (
-          <Image src={firstImageUrl} alt={product.name} fill className='object-cover' />
+          <Image
+            src={firstImageUrl}
+            alt={product.name}
+            fill
+            className='object-cover transition-transform duration-500 group-hover:scale-[1.03]'
+            sizes='(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw'
+          />
         ) : (
-          <div className='w-full h-full bg-gray-200 flex items-center justify-center'>
-            <Home className='h-12 w-12 text-gray-400' />
+          <div className='flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200'>
+            <Home className='h-12 w-12 text-slate-400' />
           </div>
         )}
-        <div className='absolute top-4 right-4'>{validationBadge}</div>
+
+        <div className='absolute left-4 top-4'>
+          <span
+            className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${statusAccent.badgeClass}`}
+          >
+            {statusAccent.label}
+          </span>
+        </div>
+
+        <div className='absolute right-4 top-4'>
+          <span className='inline-flex items-center gap-1 rounded-full bg-black/60 px-3 py-1 text-xs font-semibold text-white backdrop-blur-sm'>
+            {product.basePrice}€
+            <span className='font-normal opacity-80'>/nuit</span>
+          </span>
+        </div>
       </div>
 
-      <CardContent className='p-4'>
-        <div className='space-y-3'>
-          {/* Product Title */}
-          <div>
-            <h3 className='font-semibold text-lg text-gray-900 line-clamp-1'>{product.name}</h3>
-            <p className='text-gray-600 text-sm line-clamp-2 mt-1'>{product.description}</p>
-          </div>
-
-          {/* Location and Price */}
-          <div className='flex items-center justify-between'>
-            <div className='flex items-center gap-1 text-gray-600'>
-              <MapPin className='h-4 w-4' />
-              <span className='text-sm line-clamp-1'>{product.address}</span>
+      {/* Body */}
+      <div className='flex flex-1 flex-col gap-4 p-5'>
+        {/* Host row */}
+        <div className='flex items-center gap-3 border-b border-slate-100 pb-4'>
+          {product.owner.image ? (
+            <Image
+              src={product.owner.image}
+              alt={userDisplayName}
+              width={36}
+              height={36}
+              className='h-9 w-9 rounded-full object-cover ring-2 ring-white'
+            />
+          ) : (
+            <div className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-purple-500 text-xs font-semibold text-white ring-2 ring-white'>
+              {initials}
             </div>
-            <div className='text-lg font-bold text-primary'>{product.basePrice}€</div>
-          </div>
-
-          {/* Host Info */}
-          <div className='flex items-center gap-2 text-sm text-gray-600'>
-            <User className='h-4 w-4' />
-            <span>{userDisplayName}</span>
-          </div>
-
-          {/* Actions */}
-          <div className='flex gap-2 pt-2'>
-            <Button variant='outline' size='sm' asChild className='flex-1'>
-              <Link href={`/admin/validation/${product.id}`}>
-                <Eye className='h-4 w-4 mr-1' />
-                Détails
-              </Link>
-            </Button>
-
-            {showValidationActions && (
-              <>
-                <Button
-                  size='sm'
-                  onClick={handleApprove}
-                  className='bg-green-600 hover:bg-green-700'
-                  disabled={loading}
-                >
-                  {loading ? (
-                    <Loader2 className='h-4 w-4 animate-spin' />
-                  ) : (
-                    <CheckCircle className='h-4 w-4' />
-                  )}
-                </Button>
-                <Button variant='destructive' size='sm' onClick={handleReject} disabled={loading}>
-                  {loading ? (
-                    <Loader2 className='h-4 w-4 animate-spin' />
-                  ) : (
-                    <XCircle className='h-4 w-4' />
-                  )}
-                </Button>
-              </>
-            )}
+          )}
+          <div className='min-w-0 flex-1'>
+            <p className='truncate text-sm font-medium text-slate-900'>{userDisplayName}</p>
+            <p className='truncate text-xs text-slate-500'>
+              <UserCircle2 className='inline h-3 w-3 align-text-bottom' /> {product.owner.email}
+            </p>
           </div>
         </div>
-      </CardContent>
-    </Card>
+
+        {/* Title + description */}
+        <div className='space-y-2'>
+          <h3 className='line-clamp-1 text-lg font-semibold text-slate-900'>{product.name}</h3>
+          <p className='line-clamp-2 text-sm text-slate-600'>
+            {descriptionPreview || 'Aucune description'}
+          </p>
+        </div>
+
+        {/* Location */}
+        <div className='flex items-start gap-2 text-sm text-slate-500'>
+          <MapPin className='mt-0.5 h-4 w-4 shrink-0' />
+          <span className='line-clamp-1'>{product.address}</span>
+        </div>
+
+        {/* Actions */}
+        <div className='mt-auto flex flex-wrap items-center gap-2 pt-2'>
+          <Button variant='outline' size='sm' asChild className='flex-1 min-w-[110px]'>
+            <Link href={`/admin/validation/${product.id}`}>
+              <Eye className='mr-1 h-4 w-4' />
+              Détails
+            </Link>
+          </Button>
+
+          {showValidationActions && (
+            <div className='flex gap-2'>
+              <Button
+                size='sm'
+                onClick={handleApprove}
+                className='bg-emerald-600 text-white hover:bg-emerald-700'
+                disabled={loading}
+                aria-label='Approuver l’annonce'
+                title='Approuver'
+              >
+                {loading ? (
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                ) : (
+                  <CheckCircle2 className='h-4 w-4' />
+                )}
+              </Button>
+              <Button
+                size='sm'
+                variant='destructive'
+                onClick={handleReject}
+                disabled={loading}
+                aria-label='Refuser l’annonce'
+                title='Refuser'
+              >
+                {loading ? (
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                ) : (
+                  <XCircle className='h-4 w-4' />
+                )}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
   )
 }
 
-// Custom comparison function for React.memo to prevent unnecessary re-renders
 const arePropsEqual = (
   prevProps: ProductValidationCardProps,
   nextProps: ProductValidationCardProps
 ) => {
-  // Check if currentUserId changed
-  if (prevProps.currentUserId !== nextProps.currentUserId) {
-    return false
-  }
+  if (prevProps.currentUserId !== nextProps.currentUserId) return false
+  if (prevProps.onUpdate !== nextProps.onUpdate) return false
 
-  // Check if onUpdate function reference changed
-  if (prevProps.onUpdate !== nextProps.onUpdate) {
-    return false
-  }
-
-  // Check if product has changed (deep comparison of key fields)
-  const prevProduct = prevProps.product
-  const nextProduct = nextProps.product
+  const p = prevProps.product
+  const n = nextProps.product
 
   if (
-    prevProduct.id !== nextProduct.id ||
-    prevProduct.name !== nextProduct.name ||
-    prevProduct.description !== nextProduct.description ||
-    prevProduct.address !== nextProduct.address ||
-    prevProduct.basePrice !== nextProduct.basePrice ||
-    prevProduct.validate !== nextProduct.validate ||
-    prevProduct.isRecentlyModified !== nextProduct.isRecentlyModified ||
-    prevProduct.wasRecheckRequested !== nextProduct.wasRecheckRequested
+    p.id !== n.id ||
+    p.name !== n.name ||
+    p.description !== n.description ||
+    p.address !== n.address ||
+    p.basePrice !== n.basePrice ||
+    p.validate !== n.validate ||
+    p.isRecentlyModified !== n.isRecentlyModified ||
+    p.wasRecheckRequested !== n.wasRecheckRequested
   ) {
     return false
   }
 
-  // Check if images changed (shallow comparison)
-  if (prevProduct.img?.length !== nextProduct.img?.length) {
-    return false
+  if (p.img?.length !== n.img?.length) return false
+  if (p.img && n.img && p.img.length > 0) {
+    if (p.img[0].img !== n.img[0].img) return false
   }
 
-  if (prevProduct.img && nextProduct.img && prevProduct.img.length > 0) {
-    if (prevProduct.img[0].img !== nextProduct.img[0].img) {
-      return false
-    }
-  }
-
-  // Check if user data changed
-  const prevUser = prevProduct.owner
-  const nextUser = nextProduct.owner
-
+  const pu = p.owner
+  const nu = n.owner
   if (
-    prevUser?.id !== nextUser?.id ||
-    prevUser?.name !== nextUser?.name ||
-    prevUser?.lastname !== nextUser?.lastname ||
-    prevUser?.email !== nextUser?.email
+    pu?.id !== nu?.id ||
+    pu?.name !== nu?.name ||
+    pu?.lastname !== nu?.lastname ||
+    pu?.email !== nu?.email ||
+    pu?.image !== nu?.image
   ) {
     return false
   }

--- a/src/app/admin/validation/components/ValidationStatsCards.tsx
+++ b/src/app/admin/validation/components/ValidationStatsCards.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { CheckCircle, XCircle, Clock, Home, Edit, FileText } from 'lucide-react'
+import { Clock, Edit3, FileText, CheckCircle2, XCircle, LayoutGrid } from 'lucide-react'
 
 interface ValidationStats {
   pending: number
@@ -17,76 +16,131 @@ interface ValidationStatsCardsProps {
   stats: ValidationStats
 }
 
-export function ValidationStatsCards({ stats }: ValidationStatsCardsProps) {
+interface PrimaryCardProps {
+  label: string
+  value: number
+  hint: string
+  icon: React.ReactNode
+  accent: {
+    bg: string
+    text: string
+    ring: string
+    iconBg: string
+  }
+}
+
+function PrimaryStatCard({ label, value, hint, icon, accent }: PrimaryCardProps) {
   return (
-    <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4 mb-8'>
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <CardTitle className='text-sm font-medium'>Total</CardTitle>
-          <Home className='h-4 w-4 text-muted-foreground' />
-        </CardHeader>
-        <CardContent>
-          <div className='text-2xl font-bold'>{stats.total}</div>
-          <p className='text-xs text-muted-foreground'>annonces au total</p>
-        </CardContent>
-      </Card>
+    <div
+      className={`relative overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm ring-1 ring-transparent transition hover:shadow-md hover:${accent.ring}`}
+    >
+      <div className='flex items-start justify-between gap-4'>
+        <div className='space-y-1'>
+          <p className='text-sm font-medium text-slate-500'>{label}</p>
+          <p className={`text-4xl font-bold tracking-tight ${accent.text}`}>{value}</p>
+          <p className='text-xs text-slate-500'>{hint}</p>
+        </div>
+        <div
+          className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-xl ${accent.bg} ${accent.text}`}
+        >
+          {icon}
+        </div>
+      </div>
+    </div>
+  )
+}
 
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <CardTitle className='text-sm font-medium'>En attente</CardTitle>
-          <Clock className='h-4 w-4 text-yellow-600' />
-        </CardHeader>
-        <CardContent>
-          <div className='text-2xl font-bold text-yellow-600'>{stats.pending}</div>
-          <p className='text-xs text-muted-foreground'>nouvelles</p>
-        </CardContent>
-      </Card>
+interface SecondaryMetricProps {
+  label: string
+  value: number
+  icon: React.ReactNode
+  tone: 'slate' | 'green' | 'red'
+}
 
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <CardTitle className='text-sm font-medium'>Révisions</CardTitle>
-          <Edit className='h-4 w-4 text-blue-600' />
-        </CardHeader>
-        <CardContent>
-          <div className='text-2xl font-bold text-blue-600'>{stats.recheckRequest}</div>
-          <p className='text-xs text-muted-foreground'>à corriger</p>
-        </CardContent>
-      </Card>
+function SecondaryMetric({ label, value, icon, tone }: SecondaryMetricProps) {
+  const tones = {
+    slate: 'text-slate-600',
+    green: 'text-emerald-600',
+    red: 'text-red-600',
+  } as const
+  return (
+    <div className='flex items-center gap-3 rounded-xl border border-slate-200/80 bg-white/60 px-4 py-3 backdrop-blur-sm'>
+      <div className={`${tones[tone]}`}>{icon}</div>
+      <div className='flex items-baseline gap-2'>
+        <span className={`text-2xl font-semibold tabular-nums ${tones[tone]}`}>{value}</span>
+        <span className='text-sm font-medium text-slate-600'>{label}</span>
+      </div>
+    </div>
+  )
+}
 
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <CardTitle className='text-sm font-medium'>Modifications</CardTitle>
-          <FileText className='h-4 w-4 text-purple-600' />
-        </CardHeader>
-        <CardContent>
-          <div className='text-2xl font-bold text-purple-600'>
-            {stats.modificationPending + stats.drafts}
-          </div>
-          <p className='text-xs text-muted-foreground'>en attente</p>
-        </CardContent>
-      </Card>
+export function ValidationStatsCards({ stats }: ValidationStatsCardsProps) {
+  const actionable = stats.pending + stats.recheckRequest
+  const modifications = stats.modificationPending + stats.drafts
 
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <CardTitle className='text-sm font-medium'>Validées</CardTitle>
-          <CheckCircle className='h-4 w-4 text-green-600' />
-        </CardHeader>
-        <CardContent>
-          <div className='text-2xl font-bold text-green-600'>{stats.approved}</div>
-          <p className='text-xs text-muted-foreground'>approuvées</p>
-        </CardContent>
-      </Card>
+  return (
+    <div className='space-y-4'>
+      {/* Primary — actionable items */}
+      <div className='grid gap-4 md:grid-cols-3'>
+        <PrimaryStatCard
+          label='À traiter'
+          value={actionable}
+          hint={actionable === 0 ? 'Rien en attente' : 'annonces en attente d’action'}
+          icon={<Clock className='h-6 w-6' />}
+          accent={{
+            bg: 'bg-amber-50',
+            text: 'text-amber-600',
+            ring: 'ring-amber-200',
+            iconBg: 'bg-amber-50',
+          }}
+        />
+        <PrimaryStatCard
+          label='Révisions demandées'
+          value={stats.recheckRequest}
+          hint='à corriger par l’hôte'
+          icon={<Edit3 className='h-6 w-6' />}
+          accent={{
+            bg: 'bg-blue-50',
+            text: 'text-blue-600',
+            ring: 'ring-blue-200',
+            iconBg: 'bg-blue-50',
+          }}
+        />
+        <PrimaryStatCard
+          label='Modifications'
+          value={modifications}
+          hint='changements en attente de revue'
+          icon={<FileText className='h-6 w-6' />}
+          accent={{
+            bg: 'bg-purple-50',
+            text: 'text-purple-600',
+            ring: 'ring-purple-200',
+            iconBg: 'bg-purple-50',
+          }}
+        />
+      </div>
 
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <CardTitle className='text-sm font-medium'>Refusées</CardTitle>
-          <XCircle className='h-4 w-4 text-red-600' />
-        </CardHeader>
-        <CardContent>
-          <div className='text-2xl font-bold text-red-600'>{stats.rejected}</div>
-          <p className='text-xs text-muted-foreground'>rejetées</p>
-        </CardContent>
-      </Card>
+      {/* Secondary — resolved / total metrics */}
+      <div className='grid gap-3 sm:grid-cols-3'>
+        <SecondaryMetric
+          label='annonces au total'
+          value={stats.total}
+          icon={<LayoutGrid className='h-5 w-5' />}
+          tone='slate'
+        />
+        <SecondaryMetric
+          label='validées'
+          value={stats.approved}
+          icon={<CheckCircle2 className='h-5 w-5' />}
+          tone='green'
+        />
+        <SecondaryMetric
+          label='refusées'
+          value={stats.rejected}
+          icon={<XCircle className='h-5 w-5' />}
+          tone='red'
+        />
+      </div>
     </div>
   )
 }

--- a/src/app/admin/validation/components/ValidationTabs.tsx
+++ b/src/app/admin/validation/components/ValidationTabs.tsx
@@ -1,10 +1,17 @@
 'use client'
 
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { ProductValidation } from '@prisma/client'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Card, CardContent } from '@/components/ui/card'
-import { Home, Loader2 } from 'lucide-react'
+import {
+  Bell,
+  CheckCircle2,
+  ClipboardList,
+  Home,
+  LayoutGrid,
+  PenLine,
+  XCircle,
+} from 'lucide-react'
 import { motion } from 'framer-motion'
 import ProductValidationCard from './ProductValidationCard'
 import { RejectedProductsTab } from './RejectedProductsTab'
@@ -55,26 +62,29 @@ interface ValidationTabsProps {
 
 const ITEMS_PER_PAGE = 20
 
-const TAB_STATUS_MAP: Record<string, { status?: ProductValidation; statuses?: ProductValidation[] }> = {
+const TAB_STATUS_MAP: Record<
+  string,
+  { status?: ProductValidation; statuses?: ProductValidation[] }
+> = {
   all: {},
-  pending: { statuses: [ProductValidation.NotVerified, ProductValidation.RecheckRequest] },
+  pending: {
+    statuses: [ProductValidation.NotVerified, ProductValidation.RecheckRequest],
+  },
   new: { status: ProductValidation.NotVerified },
   resubmitted: { status: ProductValidation.RecheckRequest },
   approved: { status: ProductValidation.Approve },
   rejected: { status: ProductValidation.Refused },
 }
 
-const itemVariants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: 'tween' as const,
-      duration: 0.5,
-      ease: 'easeOut' as const,
-    },
-  },
+interface TabDefinition {
+  key: string
+  label: string
+  icon: React.ReactNode
+  count: number
+  badgeClass: string
+  activeClass: string
+  emptyTitle: string
+  emptySubtitle: string
 }
 
 interface TabState {
@@ -88,6 +98,46 @@ const initialTabState = (): TabState => ({
   pagination: null,
   loading: false,
 })
+
+function SkeletonCard() {
+  return (
+    <div className='relative overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm'>
+      <div className='h-56 w-full animate-pulse bg-slate-200' />
+      <div className='space-y-4 p-5'>
+        <div className='flex items-center gap-3 border-b border-slate-100 pb-4'>
+          <div className='h-9 w-9 animate-pulse rounded-full bg-slate-200' />
+          <div className='flex-1 space-y-2'>
+            <div className='h-3 w-24 animate-pulse rounded bg-slate-200' />
+            <div className='h-3 w-32 animate-pulse rounded bg-slate-200' />
+          </div>
+        </div>
+        <div className='space-y-2'>
+          <div className='h-5 w-3/4 animate-pulse rounded bg-slate-200' />
+          <div className='h-3 w-full animate-pulse rounded bg-slate-200' />
+          <div className='h-3 w-5/6 animate-pulse rounded bg-slate-200' />
+        </div>
+        <div className='h-3 w-2/3 animate-pulse rounded bg-slate-200' />
+        <div className='flex gap-2 pt-2'>
+          <div className='h-9 flex-1 animate-pulse rounded-md bg-slate-200' />
+          <div className='h-9 w-9 animate-pulse rounded-md bg-slate-200' />
+          <div className='h-9 w-9 animate-pulse rounded-md bg-slate-200' />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function EmptyState({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div className='flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-white/60 py-16 px-6 text-center'>
+      <div className='mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-slate-100'>
+        <Home className='h-8 w-8 text-slate-400' />
+      </div>
+      <h3 className='mb-1 text-lg font-semibold text-slate-900'>{title}</h3>
+      <p className='max-w-md text-sm text-slate-500'>{subtitle}</p>
+    </div>
+  )
+}
 
 function ValidationTabs({ stats, currentUserId, onUpdate }: ValidationTabsProps) {
   const [activeTab, setActiveTab] = useState('all')
@@ -108,42 +158,38 @@ function ValidationTabs({ stats, currentUserId, onUpdate }: ValidationTabsProps)
     rejected: initialTabState(),
   })
 
-  const fetchTab = useCallback(
-    async (tab: string, page: number) => {
+  const fetchTab = useCallback(async (tab: string, page: number) => {
+    setTabStates(prev => ({
+      ...prev,
+      [tab]: { ...prev[tab], loading: true },
+    }))
+
+    const { status, statuses } = TAB_STATUS_MAP[tab]
+
+    const result = await getValidationProductsByStatus({
+      status,
+      statuses,
+      page,
+      limit: ITEMS_PER_PAGE,
+    })
+
+    if (result.success && result.data) {
+      const products = result.data as Product[]
       setTabStates(prev => ({
         ...prev,
-        [tab]: { ...prev[tab], loading: true },
+        [tab]: {
+          products,
+          pagination: result.pagination ?? null,
+          loading: false,
+        },
       }))
-
-      const { status, statuses } = TAB_STATUS_MAP[tab]
-
-      const result = await getValidationProductsByStatus({
-        status,
-        statuses,
-        page,
-        limit: ITEMS_PER_PAGE,
-      })
-
-      if (result.success && result.data) {
-        const products = result.data as Product[]
-
-        setTabStates(prev => ({
-          ...prev,
-          [tab]: {
-            products,
-            pagination: result.pagination ?? null,
-            loading: false,
-          },
-        }))
-      } else {
-        setTabStates(prev => ({
-          ...prev,
-          [tab]: { ...prev[tab], loading: false },
-        }))
-      }
-    },
-    []
-  )
+    } else {
+      setTabStates(prev => ({
+        ...prev,
+        [tab]: { ...prev[tab], loading: false },
+      }))
+    }
+  }, [])
 
   useEffect(() => {
     fetchTab(activeTab, pages[activeTab])
@@ -163,41 +209,131 @@ function ValidationTabs({ stats, currentUserId, onUpdate }: ValidationTabsProps)
 
   const handleUpdate = useCallback(() => {
     onUpdate()
-    // Re-fetch current tab after a mutation
     fetchTab(activeTab, pages[activeTab])
   }, [onUpdate, fetchTab, activeTab, pages])
 
+  const tabDefinitions: TabDefinition[] = useMemo(
+    () => [
+      {
+        key: 'all',
+        label: 'Toutes',
+        icon: <LayoutGrid className='h-4 w-4' />,
+        count: stats.total,
+        badgeClass: 'bg-slate-100 text-slate-700',
+        activeClass:
+          'data-[state=active]:border-slate-900 data-[state=active]:text-slate-900',
+        emptyTitle: 'Aucune annonce',
+        emptySubtitle: 'Il n’y a pas encore d’annonces créées sur la plateforme.',
+      },
+      {
+        key: 'pending',
+        label: 'À traiter',
+        icon: <ClipboardList className='h-4 w-4' />,
+        count: stats.pending + stats.recheckRequest,
+        badgeClass: 'bg-amber-100 text-amber-800',
+        activeClass:
+          'data-[state=active]:border-amber-500 data-[state=active]:text-amber-700',
+        emptyTitle: 'Tout est à jour',
+        emptySubtitle: 'Aucune annonce en attente d’action. Bon travail !',
+      },
+      {
+        key: 'new',
+        label: 'Nouvelles',
+        icon: <Bell className='h-4 w-4' />,
+        count: stats.pending,
+        badgeClass: 'bg-yellow-100 text-yellow-800',
+        activeClass:
+          'data-[state=active]:border-yellow-500 data-[state=active]:text-yellow-700',
+        emptyTitle: 'Aucune nouvelle annonce',
+        emptySubtitle:
+          'Les nouvelles annonces soumises par les hôtes apparaîtront ici.',
+      },
+      {
+        key: 'resubmitted',
+        label: 'Modifiées',
+        icon: <PenLine className='h-4 w-4' />,
+        count: stats.recheckRequest,
+        badgeClass: 'bg-orange-100 text-orange-800',
+        activeClass:
+          'data-[state=active]:border-orange-500 data-[state=active]:text-orange-700',
+        emptyTitle: 'Aucune révision en cours',
+        emptySubtitle:
+          'Les annonces renvoyées après une demande de révision apparaîtront ici.',
+      },
+      {
+        key: 'approved',
+        label: 'Validées',
+        icon: <CheckCircle2 className='h-4 w-4' />,
+        count: stats.approved,
+        badgeClass: 'bg-emerald-100 text-emerald-800',
+        activeClass:
+          'data-[state=active]:border-emerald-500 data-[state=active]:text-emerald-700',
+        emptyTitle: 'Aucune annonce validée',
+        emptySubtitle: 'Les annonces que vous validez apparaîtront ici.',
+      },
+      {
+        key: 'rejected',
+        label: 'Rejetées',
+        icon: <XCircle className='h-4 w-4' />,
+        count: stats.rejected,
+        badgeClass: 'bg-red-100 text-red-800',
+        activeClass:
+          'data-[state=active]:border-red-500 data-[state=active]:text-red-700',
+        emptyTitle: 'Aucune annonce refusée',
+        emptySubtitle: 'Les annonces que vous refusez apparaîtront ici.',
+      },
+    ],
+    [stats]
+  )
+
   const renderTabContent = useCallback(
-    (tab: string) => {
-      const { products, pagination, loading } = tabStates[tab]
+    (tab: TabDefinition) => {
+      const { products, pagination, loading } = tabStates[tab.key]
 
       if (loading) {
         return (
-          <div className='flex items-center justify-center py-16'>
-            <Loader2 className='h-8 w-8 text-blue-500 animate-spin' />
+          <div className='grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3'>
+            {Array.from({ length: 6 }).map((_, i) => (
+              <SkeletonCard key={i} />
+            ))}
           </div>
         )
       }
 
       if (products.length === 0) {
-        return (
-          <Card>
-            <CardContent className='flex flex-col items-center justify-center py-12'>
-              <Home className='h-12 w-12 text-gray-400 mb-4' />
-              <h3 className='text-lg font-medium text-gray-900 mb-2'>Aucune annonce trouvée</h3>
-              <p className='text-gray-500 text-center'>
-                Aucune annonce dans cet onglet pour le moment.
-              </p>
-            </CardContent>
-          </Card>
-        )
+        return <EmptyState title={tab.emptyTitle} subtitle={tab.emptySubtitle} />
       }
 
       return (
-        <div className='space-y-6'>
-          <div className='grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6'>
-            {products.map((product, index) => (
-              <motion.div key={product.id} variants={itemVariants} transition={{ delay: index * 0.05 }}>
+        <div className='space-y-8'>
+          {/* Re-key the grid on activeTab + page so framer-motion remounts the subtree
+              when data changes and the stagger orchestration runs with the children
+              already present. Same pattern as the host dashboard fix. */}
+          <motion.div
+            key={`grid-${tab.key}-${pagination?.page ?? 1}-${products.length}`}
+            className='grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3'
+            initial='hidden'
+            animate='visible'
+            variants={{
+              hidden: { opacity: 0 },
+              visible: {
+                opacity: 1,
+                transition: { staggerChildren: 0.06 },
+              },
+            }}
+          >
+            {products.map(product => (
+              <motion.div
+                key={product.id}
+                variants={{
+                  hidden: { opacity: 0, y: 16 },
+                  visible: {
+                    opacity: 1,
+                    y: 0,
+                    transition: { type: 'tween', duration: 0.4, ease: 'easeOut' },
+                  },
+                }}
+              >
                 <ProductValidationCard
                   product={product}
                   currentUserId={currentUserId}
@@ -205,10 +341,10 @@ function ValidationTabs({ stats, currentUserId, onUpdate }: ValidationTabsProps)
                 />
               </motion.div>
             ))}
-          </div>
+          </motion.div>
 
           {pagination && pagination.totalPages > 1 && (
-            <div className='flex flex-col items-center gap-2'>
+            <div className='flex flex-col items-center gap-2 pt-4'>
               <Pagination
                 currentPage={pagination.page}
                 totalPages={pagination.totalPages}
@@ -217,7 +353,7 @@ function ValidationTabs({ stats, currentUserId, onUpdate }: ValidationTabsProps)
                 showNumbers={true}
                 maxVisiblePages={5}
               />
-              <p className='text-sm text-gray-500'>
+              <p className='text-xs text-slate-500'>
                 Affichage de {(pagination.page - 1) * pagination.limit + 1} à{' '}
                 {Math.min(pagination.page * pagination.limit, pagination.total)} sur{' '}
                 {pagination.total} annonces
@@ -232,51 +368,42 @@ function ValidationTabs({ stats, currentUserId, onUpdate }: ValidationTabsProps)
 
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} className='w-full'>
-      <TabsList className='grid w-full grid-cols-6'>
-        <TabsTrigger value='all'>Toutes ({stats.total})</TabsTrigger>
-        <TabsTrigger value='pending'>
-          À traiter ({stats.pending + stats.recheckRequest})
-        </TabsTrigger>
-        <TabsTrigger value='new'>Nouvelles ({stats.pending})</TabsTrigger>
-        <TabsTrigger value='resubmitted' className='text-orange-600'>
-          Modifiées ({stats.recheckRequest})
-        </TabsTrigger>
-        <TabsTrigger value='approved'>Validées ({stats.approved})</TabsTrigger>
-        <TabsTrigger value='rejected' className='text-red-600'>
-          Rejetées ({stats.rejected})
-        </TabsTrigger>
+      <TabsList className='flex h-auto w-full flex-wrap gap-1 rounded-xl border border-slate-200/80 bg-white/60 p-1.5 backdrop-blur-sm'>
+        {tabDefinitions.map(tab => (
+          <TabsTrigger
+            key={tab.key}
+            value={tab.key}
+            className={`flex flex-1 items-center justify-center gap-2 rounded-lg border-b-2 border-transparent px-4 py-2.5 text-sm font-medium text-slate-600 transition data-[state=active]:bg-slate-50 data-[state=active]:shadow-sm ${tab.activeClass}`}
+          >
+            {tab.icon}
+            <span>{tab.label}</span>
+            <span
+              className={`inline-flex min-w-[1.5rem] items-center justify-center rounded-full px-1.5 py-0.5 text-xs font-semibold tabular-nums ${tab.badgeClass}`}
+            >
+              {tab.count}
+            </span>
+          </TabsTrigger>
+        ))}
       </TabsList>
 
-      <TabsContent value='all' className='mt-6'>
-        {renderTabContent('all')}
-      </TabsContent>
-
-      <TabsContent value='pending' className='mt-6'>
-        {renderTabContent('pending')}
-      </TabsContent>
-
-      <TabsContent value='new' className='mt-6'>
-        {renderTabContent('new')}
-      </TabsContent>
-
-      <TabsContent value='resubmitted' className='mt-6'>
-        {renderTabContent('resubmitted')}
-      </TabsContent>
-
-      <TabsContent value='approved' className='mt-6'>
-        {renderTabContent('approved')}
-      </TabsContent>
-
-      <TabsContent value='rejected' className='mt-6'>
-        <RejectedProductsTab
-          products={tabStates['rejected'].products}
-          loading={tabStates['rejected'].loading}
-          pagination={tabStates['rejected'].pagination}
-          currentUserId={currentUserId}
-          onUpdate={handleUpdate}
-          onPageChange={handlePageChange}
-        />
-      </TabsContent>
+      {tabDefinitions.map(tab =>
+        tab.key === 'rejected' ? (
+          <TabsContent key={tab.key} value={tab.key} className='mt-6'>
+            <RejectedProductsTab
+              products={tabStates['rejected'].products}
+              loading={tabStates['rejected'].loading}
+              pagination={tabStates['rejected'].pagination}
+              currentUserId={currentUserId}
+              onUpdate={handleUpdate}
+              onPageChange={handlePageChange}
+            />
+          </TabsContent>
+        ) : (
+          <TabsContent key={tab.key} value={tab.key} className='mt-6'>
+            {renderTabContent(tab)}
+          </TabsContent>
+        )
+      )}
     </Tabs>
   )
 }

--- a/src/app/admin/validation/page.tsx
+++ b/src/app/admin/validation/page.tsx
@@ -7,7 +7,7 @@ import { isAdmin } from '@/hooks/useAdminAuth'
 import { motion, Variants } from 'framer-motion'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { XCircle, ArrowLeft } from 'lucide-react'
+import { XCircle, ArrowLeft, RefreshCw, ShieldCheck, Loader2 } from 'lucide-react'
 import { getValidationStats } from './actions'
 import { ValidationStatsCards } from './components/ValidationStatsCards'
 import ValidationTabs from './components/ValidationTabs'
@@ -53,6 +53,7 @@ export default function ValidationPage() {
   } = useAuth({ required: true, redirectTo: '/auth' })
   const router = useRouter()
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [stats, setStats] = useState<ValidationStats>({
     pending: 0,
@@ -80,9 +81,14 @@ export default function ValidationPage() {
     }
   }, [isAuthenticated, session, router])
 
-  const fetchData = async () => {
+  const fetchData = async (opts?: { silent?: boolean }) => {
+    const silent = opts?.silent ?? false
     try {
-      setLoading(true)
+      if (silent) {
+        setRefreshing(true)
+      } else {
+        setLoading(true)
+      }
       const statsResult = await getValidationStats()
       if (statsResult.success && statsResult.data) {
         setStats(statsResult.data)
@@ -93,16 +99,45 @@ export default function ValidationPage() {
       console.error('Erreur lors du chargement des données:', err)
       setError('Erreur lors du chargement des données')
     } finally {
-      setLoading(false)
+      if (silent) {
+        setRefreshing(false)
+      } else {
+        setLoading(false)
+      }
     }
+  }
+
+  const handleRefresh = () => {
+    setError(null)
+    fetchData({ silent: true })
   }
 
   if (isAuthLoading || loading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='container mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-3'>
+            {[0, 1, 2].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-14 animate-pulse rounded-xl border border-slate-200/80 bg-white' />
+          <div className='grid gap-6 lg:grid-cols-2 xl:grid-cols-3'>
+            {[0, 1, 2].map(i => (
+              <div
+                key={i}
+                className='h-[30rem] animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
         </div>
       </div>
     )
@@ -112,54 +147,87 @@ export default function ValidationPage() {
     return null
   }
 
-  if (error) {
-    return (
-      <div className='container mx-auto p-6 max-w-4xl'>
-        <Alert className='border-red-200 bg-red-50'>
-          <XCircle className='h-4 w-4 text-red-600' />
-          <AlertDescription className='text-red-800'>{error}</AlertDescription>
-        </Alert>
-      </div>
-    )
-  }
-
   return (
-    <motion.div
-      className='container mx-auto p-6 max-w-7xl'
-      variants={containerVariants}
-      initial='hidden'
-      animate='visible'
-    >
-      {/* Header */}
-      <motion.div className='flex items-center gap-4 mb-8' variants={itemVariants}>
-        <Button
-          variant='ghost'
-          size='sm'
-          onClick={() => router.push('/admin')}
-          className='flex items-center gap-2'
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='container mx-auto max-w-7xl space-y-8 p-6'
+        variants={containerVariants}
+        initial='hidden'
+        animate='visible'
+      >
+        {/* Breadcrumb / back link */}
+        <motion.div variants={itemVariants}>
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={() => router.push('/admin')}
+            className='text-slate-600 hover:text-slate-900'
+          >
+            <ArrowLeft className='mr-2 h-4 w-4' />
+            Retour au panel admin
+          </Button>
+        </motion.div>
+
+        {/* Header */}
+        <motion.div
+          variants={itemVariants}
+          className='flex flex-col gap-4 md:flex-row md:items-start md:justify-between'
         >
-          <ArrowLeft className='h-4 w-4' />
-          Retour au dashboard
-        </Button>
-        <div>
-          <h1 className='text-3xl font-bold text-gray-900'>Validation des annonces</h1>
-          <p className='text-gray-600 mt-1'>Gérer et valider les annonces soumises par les hôtes</p>
-        </div>
-      </motion.div>
+          <div className='space-y-3'>
+            <span className='inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700'>
+              <ShieldCheck className='h-3.5 w-3.5' />
+              Espace administrateur
+            </span>
+            <h1 className='bg-gradient-to-r from-slate-900 via-blue-800 to-indigo-800 bg-clip-text text-4xl font-bold tracking-tight text-transparent md:text-5xl'>
+              Validation des annonces
+            </h1>
+            <p className='max-w-2xl text-base text-slate-600'>
+              Passez en revue, validez ou refusez les annonces soumises par les hôtes.
+              Les annonces en attente d’action sont mises en avant en haut de la liste.
+            </p>
+          </div>
 
-      {/* Statistics Cards */}
-      <motion.div variants={itemVariants}>
-        <ValidationStatsCards stats={stats} />
-      </motion.div>
+          <div className='shrink-0'>
+            <Button
+              onClick={handleRefresh}
+              disabled={refreshing}
+              variant='outline'
+              className='gap-2 border-slate-200 bg-white/80 text-slate-700 shadow-sm hover:bg-slate-50'
+            >
+              {refreshing ? (
+                <Loader2 className='h-4 w-4 animate-spin' />
+              ) : (
+                <RefreshCw className='h-4 w-4' />
+              )}
+              {refreshing ? 'Actualisation…' : 'Actualiser'}
+            </Button>
+          </div>
+        </motion.div>
 
-      {/* Validation Tabs */}
-      <motion.div variants={itemVariants}>
-        <ValidationTabs
-          stats={stats}
-          currentUserId={session?.user?.id || ''}
-          onUpdate={fetchData}
-        />
+        {/* Error */}
+        {error && (
+          <motion.div variants={itemVariants}>
+            <Alert className='border-red-200 bg-red-50'>
+              <XCircle className='h-4 w-4 text-red-600' />
+              <AlertDescription className='text-red-800'>{error}</AlertDescription>
+            </Alert>
+          </motion.div>
+        )}
+
+        {/* Statistics */}
+        <motion.div variants={itemVariants}>
+          <ValidationStatsCards stats={stats} />
+        </motion.div>
+
+        {/* Validation Tabs */}
+        <motion.div variants={itemVariants}>
+          <ValidationTabs
+            stats={stats}
+            currentUserId={session?.user?.id || ''}
+            onUpdate={() => fetchData({ silent: true })}
+          />
+        </motion.div>
       </motion.div>
-    </motion.div>
+    </div>
   )
 }

--- a/src/app/admin/withdrawals/page.tsx
+++ b/src/app/admin/withdrawals/page.tsx
@@ -1,19 +1,19 @@
 'use client'
 
 /**
- * Page Admin - Gestion des retraits
- * /admin/withdrawals
+ * Admin page — Withdrawal requests management.
  *
- * Permet aux admin/host_manager de :
- * - Voir toutes les demandes de retrait
- * - Approuver/rejeter des demandes
- * - Marquer comme payé
- * - Valider des comptes de paiement
- * - Créer des demandes pour les hôtes
+ * Allows ADMIN and HOST_MANAGER to:
+ *  - View all withdrawal requests with filters
+ *  - Approve / reject pending requests
+ *  - Mark approved requests as paid
+ *  - Validate payment accounts
+ *  - Create a new withdrawal request on behalf of a host
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
+import { motion } from 'framer-motion'
 import { useAuth } from '@/hooks/useAuth'
 import { toast } from 'sonner'
 import {
@@ -23,19 +23,62 @@ import {
   type PaymentAccount,
 } from '@prisma/client'
 
-// Type étendu avec les relations
+import { Button } from '@/components/ui/shadcnui/button'
+import { Input } from '@/components/ui/shadcnui/input'
+import { Label } from '@/components/ui/shadcnui/label'
+import { Textarea } from '@/components/ui/shadcnui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/shadcnui/select'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/shadcnui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/shadcnui/dropdown-menu'
+import {
+  Wallet,
+  Clock,
+  CheckCircle2,
+  Banknote,
+  XCircle,
+  ShieldCheck,
+  Shield,
+  MoreHorizontal,
+  Loader2,
+  UserPlus,
+  ArrowRight,
+  TrendingUp,
+  ShieldAlert,
+} from 'lucide-react'
+
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard, KpiMetric } from '@/components/admin/ui/KpiCard'
+import { FilterBar } from '@/components/admin/ui/FilterBar'
+import {
+  DataTable,
+  type DataTableColumn,
+  type DataTableSort,
+} from '@/components/admin/ui/DataTable'
+
 type WithdrawalRequest = PrismaWithdrawalRequest & {
-  user: {
-    id: string
-    name: string | null
-    email: string
-  }
+  user: { id: string; name: string | null; email: string }
   paymentAccount: PaymentAccount | null
-  processor: {
-    id: string
-    name: string | null
-    email: string
-  } | null
+  processor: { id: string; name: string | null; email: string } | null
 }
 
 type Host = {
@@ -54,6 +97,75 @@ type HostBalance = {
   amount100Percent: number
 }
 
+const STATUS_CONFIG: Record<
+  WithdrawalStatus,
+  { label: string; tone: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  PENDING: { label: 'En attente', tone: 'bg-amber-50 text-amber-700 ring-amber-200', icon: Clock },
+  ACCOUNT_VALIDATION: {
+    label: 'Validation compte',
+    tone: 'bg-orange-50 text-orange-700 ring-orange-200',
+    icon: ShieldAlert,
+  },
+  APPROVED: {
+    label: 'Approuvée',
+    tone: 'bg-blue-50 text-blue-700 ring-blue-200',
+    icon: CheckCircle2,
+  },
+  PAID: { label: 'Payée', tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200', icon: Banknote },
+  REJECTED: { label: 'Rejetée', tone: 'bg-red-50 text-red-700 ring-red-200', icon: XCircle },
+  CANCELLED: {
+    label: 'Annulée',
+    tone: 'bg-slate-100 text-slate-700 ring-slate-200',
+    icon: XCircle,
+  },
+}
+
+const STATUS_FILTERS: Array<{
+  value: WithdrawalStatus | 'ALL'
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}> = [
+  { value: 'ALL', label: 'Toutes', icon: Wallet },
+  { value: 'PENDING', label: 'En attente', icon: Clock },
+  { value: 'ACCOUNT_VALIDATION', label: 'Validation compte', icon: ShieldAlert },
+  { value: 'APPROVED', label: 'Approuvées', icon: CheckCircle2 },
+  { value: 'PAID', label: 'Payées', icon: Banknote },
+  { value: 'REJECTED', label: 'Rejetées', icon: XCircle },
+]
+
+const PAYMENT_METHOD_LABEL: Record<PaymentMethod, string> = {
+  SEPA_VIREMENT: 'SEPA',
+  PRIPEO: 'Pripeo',
+  MOBILE_MONEY: 'Mobile Money',
+  PAYPAL: 'PayPal',
+  MONEYGRAM: 'MoneyGram',
+  TAPTAP: 'TapTap',
+  INTERNATIONAL: 'International',
+  OTHER: 'Autre',
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 2,
+  }).format(amount)
+}
+
+function StatusPill({ status }: { status: WithdrawalStatus }) {
+  const config = STATUS_CONFIG[status]
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.label}
+    </span>
+  )
+}
+
 export default function AdminWithdrawalsPage() {
   const {
     session,
@@ -65,20 +177,22 @@ export default function AdminWithdrawalsPage() {
   const [requests, setRequests] = useState<WithdrawalRequest[]>([])
   const [hosts, setHosts] = useState<Host[]>([])
   const [loading, setLoading] = useState(true)
-  const [filter, setFilter] = useState<WithdrawalStatus | 'ALL'>('ALL')
+  const [searchValue, setSearchValue] = useState('')
+  const [statusFilter, setStatusFilter] = useState<WithdrawalStatus | 'ALL'>('ALL')
+  const [sort, setSort] = useState<DataTableSort | null>({ key: 'createdAt', direction: 'desc' })
+
+  // Create-withdrawal modal state
+  const [showCreateModal, setShowCreateModal] = useState(false)
   const [selectedHost, setSelectedHost] = useState<string>('')
   const [hostBalance, setHostBalance] = useState<HostBalance | null>(null)
-  const [showCreateModal, setShowCreateModal] = useState(false)
+  const [isCreating, setIsCreating] = useState(false)
 
-  // Form state for withdrawal creation
   const [withdrawalForm, setWithdrawalForm] = useState({
     amount: '',
     withdrawalType: 'PARTIAL_50' as 'PARTIAL_50' | 'FULL_100',
     paymentMethod: 'SEPA_VIREMENT' as PaymentMethod,
     notes: '',
   })
-
-  // Payment details for each method
   const [paymentDetails, setPaymentDetails] = useState({
     accountHolderName: '',
     iban: '',
@@ -93,70 +207,41 @@ export default function AdminWithdrawalsPage() {
     moneygramPhone: '',
   })
 
-  useEffect(() => {
-    if (isAuthenticated) {
-      // Vérifier les permissions
-      if (!session?.user.roles || !['ADMIN', 'HOST_MANAGER'].includes(session.user.roles)) {
-        toast.error('Accès non autorisé')
-        router.push('/dashboard')
-        return
-      }
+  const canManage =
+    session?.user.roles && ['ADMIN', 'HOST_MANAGER'].includes(session.user.roles as string)
 
-      fetchRequests()
-      fetchHosts()
+  useEffect(() => {
+    if (isAuthenticated && !canManage) {
+      toast.error('Accès non autorisé')
+      router.push('/')
     }
-  }, [isAuthenticated, router, session])
+  }, [isAuthenticated, canManage, router])
 
   const fetchRequests = async () => {
-    console.log('🔄 [fetchRequests] Début du chargement des demandes')
-    console.log('📊 [fetchRequests] Filtre actuel:', filter)
-    console.log('📋 [fetchRequests] Nombre de demandes avant:', requests.length)
-
     try {
       setLoading(true)
       const url =
-        filter === 'ALL' ? '/api/admin/withdrawals' : `/api/admin/withdrawals?status=${filter}`
-
-      console.log('🌐 [fetchRequests] URL appelée:', url)
-
-      const response = await fetch(url, {
-        cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      })
-
-      console.log('📡 [fetchRequests] Réponse reçue, status:', response.status)
-
+        statusFilter === 'ALL'
+          ? '/api/admin/withdrawals'
+          : `/api/admin/withdrawals?status=${statusFilter}`
+      const response = await fetch(url, { cache: 'no-store' })
       if (response.ok) {
         const data = await response.json()
-        console.log('✅ [fetchRequests] Données reçues:', data.requests.length, 'demandes')
-        console.log(
-          '📝 [fetchRequests] Détails des demandes:',
-          data.requests.map((r: WithdrawalRequest) => ({ id: r.id, status: r.status }))
-        )
         setRequests(data.requests)
-        console.log('💾 [fetchRequests] State mis à jour')
       } else {
-        console.error('❌ [fetchRequests] Erreur HTTP:', response.status)
+        toast.error('Erreur lors du chargement des demandes')
       }
     } catch (error) {
-      console.error('❌ [fetchRequests] Erreur lors du chargement:', error)
+      console.error('Error fetching requests:', error)
       toast.error('Erreur lors du chargement des demandes')
     } finally {
       setLoading(false)
-      console.log('🏁 [fetchRequests] Chargement terminé')
     }
   }
 
   const fetchHosts = async () => {
     try {
-      const response = await fetch('/api/admin/hosts', {
-        cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      })
+      const response = await fetch('/api/admin/hosts', { cache: 'no-store' })
       if (response.ok) {
         const data = await response.json()
         setHosts(data.hosts)
@@ -170,9 +255,6 @@ export default function AdminWithdrawalsPage() {
     try {
       const response = await fetch(`/api/admin/withdrawals/balance/${hostId}`, {
         cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
       })
       if (response.ok) {
         const data = await response.json()
@@ -184,224 +266,13 @@ export default function AdminWithdrawalsPage() {
     }
   }
 
-  const handleApprove = async (requestId: string) => {
-    console.log("✅ [handleApprove] Début de l'approbation pour:", requestId)
-    if (!confirm('Approuver cette demande de retrait ?')) {
-      console.log("⏸️ [handleApprove] Annulé par l'utilisateur")
-      return
-    }
-
-    try {
-      console.log('📤 [handleApprove] Envoi de la requête PUT...')
-      const response = await fetch(`/api/admin/withdrawals/${requestId}/approve`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ adminNotes: 'Approuvé' }),
-      })
-
-      console.log('📥 [handleApprove] Réponse reçue, status:', response.status)
-
-      if (response.ok) {
-        console.log('✅ [handleApprove] Approbation réussie')
-        toast.success('Demande approuvée')
-        console.log('🔄 [handleApprove] Appel de fetchRequests()...')
-        await fetchRequests()
-        console.log('✅ [handleApprove] fetchRequests() terminé')
-      } else {
-        const error = await response.json()
-        console.error('❌ [handleApprove] Erreur:', error)
-        toast.error(error.error || "Erreur lors de l'approbation")
-      }
-    } catch (error) {
-      console.error('❌ [handleApprove] Exception:', error)
-      toast.error("Erreur lors de l'approbation")
-    }
-  }
-
-  const handleReject = async (requestId: string) => {
-    console.log('❌ [handleReject] Début du rejet pour:', requestId)
-    const reason = prompt('Raison du refus :')
-    if (!reason) {
-      console.log("⏸️ [handleReject] Annulé par l'utilisateur")
-      return
-    }
-
-    try {
-      console.log('📤 [handleReject] Envoi de la requête PUT...')
-      const response = await fetch(`/api/admin/withdrawals/${requestId}/reject`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ rejectionReason: reason }),
-      })
-
-      console.log('📥 [handleReject] Réponse reçue, status:', response.status)
-
-      if (response.ok) {
-        console.log('✅ [handleReject] Rejet réussi')
-        toast.success('Demande rejetée')
-        console.log('🔄 [handleReject] Appel de fetchRequests()...')
-        await fetchRequests()
-        console.log('✅ [handleReject] fetchRequests() terminé')
-      } else {
-        const error = await response.json()
-        console.error('❌ [handleReject] Erreur:', error)
-        toast.error(error.error || 'Erreur lors du refus')
-      }
-    } catch (error) {
-      console.error('❌ [handleReject] Exception:', error)
-      toast.error('Erreur lors du refus')
-    }
-  }
-
-  const handleMarkPaid = async (requestId: string) => {
-    console.log('💰 [handleMarkPaid] Début du marquage comme payé pour:', requestId)
-    if (!confirm('Marquer cette demande comme payée ?')) {
-      console.log("⏸️ [handleMarkPaid] Annulé par l'utilisateur")
-      return
-    }
-
-    try {
-      console.log('📤 [handleMarkPaid] Envoi de la requête PUT...')
-      const response = await fetch(`/api/admin/withdrawals/${requestId}/mark-paid`, {
-        method: 'PUT',
-      })
-
-      console.log('📥 [handleMarkPaid] Réponse reçue, status:', response.status)
-
-      if (response.ok) {
-        console.log('✅ [handleMarkPaid] Marquage réussi')
-        toast.success('Demande marquée comme payée')
-        console.log('🔄 [handleMarkPaid] Appel de fetchRequests()...')
-        await fetchRequests()
-        console.log('✅ [handleMarkPaid] fetchRequests() terminé')
-      } else {
-        const error = await response.json()
-        console.error('❌ [handleMarkPaid] Erreur:', error)
-        toast.error(error.error || 'Erreur')
-      }
-    } catch (error) {
-      console.error('❌ [handleMarkPaid] Exception:', error)
-      toast.error('Erreur')
-    }
-  }
-
-  const handleValidateAccount = async (accountId: string) => {
-    console.log('🏦 [handleValidateAccount] Début de la validation pour:', accountId)
-    if (!confirm('Valider ce compte de paiement ?')) {
-      console.log("⏸️ [handleValidateAccount] Annulé par l'utilisateur")
-      return
-    }
-
-    try {
-      console.log('📤 [handleValidateAccount] Envoi de la requête PUT...')
-      const response = await fetch(
-        `/api/admin/withdrawals/payment-accounts/${accountId}/validate`,
-        {
-          method: 'PUT',
-        }
-      )
-
-      console.log('📥 [handleValidateAccount] Réponse reçue, status:', response.status)
-
-      if (response.ok) {
-        console.log('✅ [handleValidateAccount] Validation réussie')
-        toast.success('Compte validé')
-        console.log('🔄 [handleValidateAccount] Appel de fetchRequests()...')
-        await fetchRequests()
-        console.log('✅ [handleValidateAccount] fetchRequests() terminé')
-      } else {
-        const error = await response.json()
-        console.error('❌ [handleValidateAccount] Erreur:', error)
-        toast.error(error.error || 'Erreur')
-      }
-    } catch (error) {
-      console.error('❌ [handleValidateAccount] Exception:', error)
-      toast.error('Erreur')
-    }
-  }
-
-  const handleCreateWithdrawal = async () => {
-    console.log('➕ [handleCreateWithdrawal] Début de la création de demande')
-    console.log('👤 [handleCreateWithdrawal] Hôte sélectionné:', selectedHost)
-    console.log('💵 [handleCreateWithdrawal] Montant:', withdrawalForm.amount)
-
-    if (!selectedHost) {
-      console.log("❌ [handleCreateWithdrawal] Pas d'hôte sélectionné")
-      toast.error('Veuillez sélectionner un hôte')
-      return
-    }
-
-    if (!withdrawalForm.amount || parseFloat(withdrawalForm.amount) <= 0) {
-      console.log('❌ [handleCreateWithdrawal] Montant invalide')
-      toast.error('Veuillez saisir un montant valide')
-      return
-    }
-
-    if (!hostBalance || parseFloat(withdrawalForm.amount) > hostBalance.availableBalance) {
-      console.log('❌ [handleCreateWithdrawal] Montant dépasse le solde disponible')
-      toast.error('Le montant dépasse le solde disponible')
-      return
-    }
-
-    try {
-      console.log('📤 [handleCreateWithdrawal] Envoi de la requête POST...')
-      const response = await fetch('/api/admin/withdrawals/create-for-host', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          hostId: selectedHost,
-          amount: parseFloat(withdrawalForm.amount),
-          withdrawalType: withdrawalForm.withdrawalType,
-          paymentMethod: withdrawalForm.paymentMethod,
-          paymentDetails: paymentDetails,
-          notes: withdrawalForm.notes || `Demande créée par ${session?.user?.name || 'admin'}`,
-        }),
-      })
-
-      console.log('📥 [handleCreateWithdrawal] Réponse reçue, status:', response.status)
-
-      if (response.ok) {
-        console.log('✅ [handleCreateWithdrawal] Création réussie')
-        toast.success('Demande de retrait créée avec succès')
-        setShowCreateModal(false)
-        setWithdrawalForm({
-          amount: '',
-          withdrawalType: 'PARTIAL_50',
-          paymentMethod: 'SEPA_VIREMENT',
-          notes: '',
-        })
-        setPaymentDetails({
-          accountHolderName: '',
-          iban: '',
-          cardNumber: '',
-          cardEmail: '',
-          mobileNumber: '',
-          paypalUsername: '',
-          paypalEmail: '',
-          paypalPhone: '',
-          paypalIban: '',
-          moneygramFullName: '',
-          moneygramPhone: '',
-        })
-        console.log('🔄 [handleCreateWithdrawal] Appel de fetchRequests()...')
-        await fetchRequests()
-        console.log('🔄 [handleCreateWithdrawal] Appel de fetchHostBalance()...')
-        await fetchHostBalance(selectedHost)
-        console.log('✅ [handleCreateWithdrawal] Mise à jour terminée')
-      } else {
-        const error = await response.json()
-        console.error('❌ [handleCreateWithdrawal] Erreur:', error)
-        toast.error(error.error || 'Erreur lors de la création')
-      }
-    } catch (error) {
-      console.error('❌ [handleCreateWithdrawal] Exception:', error)
-      toast.error('Erreur lors de la création')
-    }
-  }
-
   useEffect(() => {
-    fetchRequests()
-  }, [filter])
+    if (canManage) {
+      fetchRequests()
+      fetchHosts()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canManage, statusFilter])
 
   useEffect(() => {
     if (selectedHost) {
@@ -411,678 +282,720 @@ export default function AdminWithdrawalsPage() {
     }
   }, [selectedHost])
 
-  const getStatusBadge = (status: WithdrawalStatus) => {
-    const styles = {
-      PENDING: 'bg-yellow-100 text-yellow-800',
-      ACCOUNT_VALIDATION: 'bg-orange-100 text-orange-800',
-      APPROVED: 'bg-blue-100 text-blue-800',
-      PAID: 'bg-green-100 text-green-800',
-      REJECTED: 'bg-red-100 text-red-800',
-      CANCELLED: 'bg-gray-100 text-gray-800',
+  const handleApprove = async (requestId: string) => {
+    if (!confirm('Approuver cette demande de retrait ?')) return
+    try {
+      const response = await fetch(`/api/admin/withdrawals/${requestId}/approve`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ adminNotes: 'Approuvé' }),
+      })
+      if (response.ok) {
+        toast.success('Demande approuvée')
+        await fetchRequests()
+      } else {
+        const error = await response.json()
+        toast.error(error.error || "Erreur lors de l'approbation")
+      }
+    } catch {
+      toast.error("Erreur lors de l'approbation")
     }
+  }
 
-    const labels = {
-      PENDING: 'En attente',
-      ACCOUNT_VALIDATION: 'Validation compte',
-      APPROVED: 'Approuvée',
-      PAID: 'Payée',
-      REJECTED: 'Rejetée',
-      CANCELLED: 'Annulée',
+  const handleReject = async (requestId: string) => {
+    const reason = prompt('Raison du refus :')
+    if (!reason) return
+    try {
+      const response = await fetch(`/api/admin/withdrawals/${requestId}/reject`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rejectionReason: reason }),
+      })
+      if (response.ok) {
+        toast.success('Demande rejetée')
+        await fetchRequests()
+      } else {
+        const error = await response.json()
+        toast.error(error.error || 'Erreur lors du refus')
+      }
+    } catch {
+      toast.error('Erreur lors du refus')
     }
+  }
 
-    return (
-      <span className={`px-2 py-1 text-xs font-semibold rounded-full ${styles[status]}`}>
-        {labels[status]}
-      </span>
+  const handleMarkPaid = async (requestId: string) => {
+    if (!confirm('Marquer cette demande comme payée ?')) return
+    try {
+      const response = await fetch(`/api/admin/withdrawals/${requestId}/mark-paid`, {
+        method: 'PUT',
+      })
+      if (response.ok) {
+        toast.success('Demande marquée comme payée')
+        await fetchRequests()
+      } else {
+        const error = await response.json()
+        toast.error(error.error || 'Erreur')
+      }
+    } catch {
+      toast.error('Erreur')
+    }
+  }
+
+  const handleValidateAccount = async (accountId: string) => {
+    if (!confirm('Valider ce compte de paiement ?')) return
+    try {
+      const response = await fetch(
+        `/api/admin/withdrawals/payment-accounts/${accountId}/validate`,
+        { method: 'PUT' }
+      )
+      if (response.ok) {
+        toast.success('Compte validé')
+        await fetchRequests()
+      } else {
+        const error = await response.json()
+        toast.error(error.error || 'Erreur')
+      }
+    } catch {
+      toast.error('Erreur')
+    }
+  }
+
+  const openCreateModal = () => {
+    setSelectedHost('')
+    setHostBalance(null)
+    setWithdrawalForm({
+      amount: '',
+      withdrawalType: 'PARTIAL_50',
+      paymentMethod: 'SEPA_VIREMENT',
+      notes: '',
+    })
+    setPaymentDetails({
+      accountHolderName: '',
+      iban: '',
+      cardNumber: '',
+      cardEmail: '',
+      mobileNumber: '',
+      paypalUsername: '',
+      paypalEmail: '',
+      paypalPhone: '',
+      paypalIban: '',
+      moneygramFullName: '',
+      moneygramPhone: '',
+    })
+    setShowCreateModal(true)
+  }
+
+  const handleCreateWithdrawal = async () => {
+    if (!selectedHost) {
+      toast.error('Veuillez sélectionner un hôte')
+      return
+    }
+    if (!withdrawalForm.amount || parseFloat(withdrawalForm.amount) <= 0) {
+      toast.error('Veuillez saisir un montant valide')
+      return
+    }
+    if (!hostBalance || parseFloat(withdrawalForm.amount) > hostBalance.availableBalance) {
+      toast.error('Le montant dépasse le solde disponible')
+      return
+    }
+    setIsCreating(true)
+    try {
+      const response = await fetch('/api/admin/withdrawals/create-for-host', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          hostId: selectedHost,
+          amount: parseFloat(withdrawalForm.amount),
+          withdrawalType: withdrawalForm.withdrawalType,
+          paymentMethod: withdrawalForm.paymentMethod,
+          paymentDetails,
+          notes: withdrawalForm.notes || `Demande créée par ${session?.user?.name || 'admin'}`,
+        }),
+      })
+      if (response.ok) {
+        toast.success('Demande de retrait créée')
+        setShowCreateModal(false)
+        await fetchRequests()
+      } else {
+        const error = await response.json()
+        toast.error(error.error || 'Erreur lors de la création')
+      }
+    } catch {
+      toast.error('Erreur lors de la création')
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  // Client-side search filter on the already-filtered requests
+  const filteredRequests = useMemo(() => {
+    if (!searchValue.trim()) return requests
+    const q = searchValue.toLowerCase()
+    return requests.filter(
+      r =>
+        r.user.name?.toLowerCase().includes(q) ||
+        r.user.email.toLowerCase().includes(q) ||
+        r.id.toLowerCase().includes(q)
     )
-  }
+  }, [requests, searchValue])
 
-  const getPaymentMethodLabel = (method: PaymentMethod) => {
-    const labels = {
-      SEPA_VIREMENT: 'SEPA',
-      PRIPEO: 'Pripeo',
-      MOBILE_MONEY: 'Mobile Money',
-      PAYPAL: 'PayPal',
-      MONEYGRAM: 'MoneyGram',
-      TAPTAP: 'TapTap',
-      INTERNATIONAL: 'International',
-      OTHER: 'Autre',
+  // Stats (derived from loaded requests — this endpoint doesn't return aggregated stats)
+  const stats = useMemo(() => {
+    const byStatus: Record<string, number> = {
+      PENDING: 0,
+      ACCOUNT_VALIDATION: 0,
+      APPROVED: 0,
+      PAID: 0,
+      REJECTED: 0,
+      CANCELLED: 0,
     }
-    return labels[method] || method
-  }
+    let pendingAmount = 0
+    let paidAmount = 0
+    for (const r of requests) {
+      byStatus[r.status] = (byStatus[r.status] || 0) + 1
+      if (r.status === 'PENDING' || r.status === 'APPROVED') pendingAmount += r.amount
+      if (r.status === 'PAID') paidAmount += r.amount
+    }
+    return { byStatus, pendingAmount, paidAmount, total: requests.length }
+  }, [requests])
+
+  const columns: DataTableColumn<WithdrawalRequest>[] = [
+    {
+      key: 'host',
+      header: 'Hôte',
+      sortable: true,
+      sortAccessor: r => r.user.name || r.user.email,
+      render: r => (
+        <div className='min-w-0'>
+          <p className='truncate text-sm font-semibold text-slate-900'>
+            {r.user.name || '—'}
+          </p>
+          <p className='truncate text-xs text-slate-500'>{r.user.email}</p>
+        </div>
+      ),
+    },
+    {
+      key: 'amount',
+      header: 'Montant',
+      sortable: true,
+      sortAccessor: r => r.amount,
+      align: 'right',
+      render: r => (
+        <div className='text-right'>
+          <p className='text-sm font-bold tabular-nums text-slate-900'>
+            {formatCurrency(r.amount)}
+          </p>
+          <p className='text-[10px] uppercase tracking-wide text-slate-500'>
+            {r.withdrawalType === 'PARTIAL_50' ? 'Partiel 50%' : 'Complet 100%'}
+          </p>
+        </div>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'method',
+      header: 'Méthode',
+      render: r => (
+        <div>
+          <p className='text-sm text-slate-900'>{PAYMENT_METHOD_LABEL[r.paymentMethod]}</p>
+          {r.paymentAccount && !r.paymentAccount.isValidated && (
+            <p className='text-[10px] font-medium uppercase tracking-wide text-amber-600'>
+              Non validé
+            </p>
+          )}
+        </div>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'status',
+      header: 'Statut',
+      sortable: true,
+      sortAccessor: r => r.status,
+      render: r => <StatusPill status={r.status} />,
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'createdAt',
+      header: 'Demandé le',
+      sortable: true,
+      sortAccessor: r => new Date(r.createdAt),
+      render: r => (
+        <p className='text-xs text-slate-500'>
+          {new Date(r.createdAt).toLocaleDateString('fr-FR', {
+            day: '2-digit',
+            month: 'short',
+            year: 'numeric',
+          })}
+        </p>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+  ]
 
   if (isAuthLoading || loading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
         </div>
       </div>
     )
   }
 
-  if (!session) {
-    return null
-  }
+  if (!session) return null
 
   return (
-    <div className='min-h-screen bg-gray-50 py-8'>
-      <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
-        {/* En-tête */}
-        <div className='mb-8'>
-          <h1 className='text-3xl font-bold text-gray-900'>Gestion des retraits</h1>
-          <p className='mt-2 text-sm text-gray-600'>
-            Gérer les demandes de retrait pour tous les hôtes
-          </p>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <PageHeader
+          backHref='/admin'
+          backLabel='Retour au panel admin'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title='Gestion des retraits'
+          subtitle='Approuvez, rejetez et suivez les demandes de retrait des hôtes. Vous pouvez aussi créer une demande au nom d’un hôte.'
+          actions={
+            <Button
+              onClick={openCreateModal}
+              className='gap-2 bg-gradient-to-r from-blue-600 to-indigo-600 text-white shadow-sm hover:from-blue-700 hover:to-indigo-700'
+            >
+              <UserPlus className='h-4 w-4' />
+              Nouvelle demande
+            </Button>
+          }
+        />
+
+        {/* KPI row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Total demandes'
+            value={stats.total}
+            hint='toutes statuts confondus'
+            icon={Wallet}
+            tone='blue'
+          />
+          <KpiCard
+            label='En attente'
+            value={stats.byStatus.PENDING ?? 0}
+            hint='à traiter en priorité'
+            icon={Clock}
+            tone='amber'
+          />
+          <KpiCard
+            label='Montant en attente'
+            value={formatCurrency(stats.pendingAmount)}
+            hint='pending + approuvées'
+            icon={TrendingUp}
+            tone='purple'
+          />
+          <KpiCard
+            label='Montant payé'
+            value={formatCurrency(stats.paidAmount)}
+            hint='total déjà versé'
+            icon={Banknote}
+            tone='emerald'
+          />
         </div>
 
-        {/* Sélecteur d'hôte et création de demande */}
-        <div className='bg-white shadow rounded-lg p-6 mb-8'>
-          <h2 className='text-lg font-semibold mb-4'>Créer une demande pour un hôte</h2>
-          <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
-            <div>
-              <label className='block text-sm font-medium text-gray-700 mb-2'>
-                Sélectionner un hôte
-              </label>
-              <select
-                value={selectedHost}
-                onChange={e => setSelectedHost(e.target.value)}
-                className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-              >
-                <option value=''>-- Choisir un hôte --</option>
-                {hosts.map(host => (
-                  <option key={host.id} value={host.id}>
-                    {host.name || host.email} ({host.email})
-                  </option>
-                ))}
-              </select>
-            </div>
+        {/* Secondary metrics */}
+        <div className='grid gap-3 sm:grid-cols-4'>
+          <KpiMetric
+            label='validation compte'
+            value={stats.byStatus.ACCOUNT_VALIDATION ?? 0}
+            icon={ShieldAlert}
+            tone='slate'
+          />
+          <KpiMetric
+            label='approuvées'
+            value={stats.byStatus.APPROVED ?? 0}
+            icon={CheckCircle2}
+            tone='blue'
+          />
+          <KpiMetric
+            label='payées'
+            value={stats.byStatus.PAID ?? 0}
+            icon={Banknote}
+            tone='emerald'
+          />
+          <KpiMetric
+            label='rejetées'
+            value={stats.byStatus.REJECTED ?? 0}
+            icon={XCircle}
+            tone='red'
+          />
+        </div>
 
-            {selectedHost && hostBalance && (
-              <div className='bg-blue-50 border border-blue-200 rounded-lg p-4'>
-                <p className='text-sm font-medium text-blue-900 mb-2'>Solde de l&apos;hôte</p>
-                <div className='grid grid-cols-3 gap-2 text-sm'>
-                  <div>
-                    <p className='text-blue-600'>Total gagné</p>
-                    <p className='font-bold text-blue-900'>{hostBalance.totalEarned.toFixed(2)}€</p>
-                  </div>
-                  <div>
-                    <p className='text-blue-600'>Retiré</p>
-                    <p className='font-bold text-blue-900'>
-                      {hostBalance.totalWithdrawn.toFixed(2)}€
-                    </p>
-                  </div>
-                  <div>
-                    <p className='text-blue-600'>Disponible</p>
-                    <p className='font-bold text-green-600'>
-                      {hostBalance.availableBalance.toFixed(2)}€
-                    </p>
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-
-          {selectedHost && hostBalance && (
-            <div className='mt-4'>
+        {/* Status filter chips */}
+        <div className='flex flex-wrap items-center gap-2'>
+          {STATUS_FILTERS.map(f => {
+            const Icon = f.icon
+            const active = statusFilter === f.value
+            return (
               <button
-                onClick={() => setShowCreateModal(true)}
-                className='px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700'
+                key={f.value}
+                onClick={() => setStatusFilter(f.value)}
+                className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+                  active
+                    ? 'bg-slate-900 text-white shadow-sm'
+                    : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50'
+                }`}
               >
-                Créer une demande de retrait pour cet hôte
+                <Icon className='h-3 w-3' />
+                {f.label}
               </button>
-            </div>
-          )}
+            )
+          })}
         </div>
 
-        {/* Filtres */}
-        <div className='bg-white shadow rounded-lg p-4 mb-6'>
-          <div className='flex gap-2 overflow-x-auto'>
-            <button
-              onClick={() => setFilter('ALL')}
-              className={`px-4 py-2 rounded-md text-sm font-medium ${
-                filter === 'ALL'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              Toutes ({requests.length})
-            </button>
-            <button
-              onClick={() => setFilter(WithdrawalStatus.PENDING)}
-              className={`px-4 py-2 rounded-md text-sm font-medium ${
-                filter === WithdrawalStatus.PENDING
-                  ? 'bg-yellow-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              En attente
-            </button>
-            <button
-              onClick={() => setFilter(WithdrawalStatus.ACCOUNT_VALIDATION)}
-              className={`px-4 py-2 rounded-md text-sm font-medium ${
-                filter === WithdrawalStatus.ACCOUNT_VALIDATION
-                  ? 'bg-orange-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              Validation compte
-            </button>
-            <button
-              onClick={() => setFilter(WithdrawalStatus.APPROVED)}
-              className={`px-4 py-2 rounded-md text-sm font-medium ${
-                filter === WithdrawalStatus.APPROVED
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              Approuvées
-            </button>
-            <button
-              onClick={() => setFilter(WithdrawalStatus.PAID)}
-              className={`px-4 py-2 rounded-md text-sm font-medium ${
-                filter === WithdrawalStatus.PAID
-                  ? 'bg-green-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              Payées
-            </button>
-          </div>
-        </div>
+        {/* Search */}
+        <FilterBar
+          searchValue={searchValue}
+          onSearchChange={setSearchValue}
+          searchPlaceholder='Rechercher par nom d’hôte ou email…'
+        />
 
-        {/* Liste des demandes */}
-        <div className='bg-white shadow rounded-lg overflow-hidden'>
-          <div className='overflow-x-auto'>
-            <table className='min-w-full divide-y divide-gray-200'>
-              <thead className='bg-gray-50'>
-                <tr>
-                  <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase'>
-                    Hôte
-                  </th>
-                  <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase'>
-                    Montant
-                  </th>
-                  <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase'>
-                    Méthode
-                  </th>
-                  <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase'>
-                    Statut
-                  </th>
-                  <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase'>
-                    Date
-                  </th>
-                  <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase'>
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody className='bg-white divide-y divide-gray-200'>
-                {requests.length === 0 ? (
-                  <tr>
-                    <td colSpan={6} className='px-6 py-8 text-center text-gray-500'>
-                      Aucune demande trouvée
-                    </td>
-                  </tr>
-                ) : (
-                  requests.map(request => (
-                    <tr key={request.id} className='hover:bg-gray-50'>
-                      <td className='px-6 py-4'>
-                        <div>
-                          <p className='text-sm font-medium text-gray-900'>{request.user.name}</p>
-                          <p className='text-sm text-gray-500'>{request.user.email}</p>
-                        </div>
-                      </td>
-                      <td className='px-6 py-4 whitespace-nowrap'>
-                        <p className='text-sm font-bold text-gray-900'>
-                          {request.amount.toFixed(2)}€
-                        </p>
-                      </td>
-                      <td className='px-6 py-4 whitespace-nowrap'>
-                        <div>
-                          <p className='text-sm text-gray-900'>
-                            {getPaymentMethodLabel(request.paymentMethod)}
-                          </p>
-                          {!request.paymentAccount?.isValidated && (
-                            <p className='text-xs text-orange-600'>Non validé</p>
-                          )}
-                        </div>
-                      </td>
-                      <td className='px-6 py-4 whitespace-nowrap'>
-                        {getStatusBadge(request.status)}
-                      </td>
-                      <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-500'>
-                        {new Date(request.createdAt).toLocaleDateString('fr-FR')}
-                      </td>
-                      <td className='px-6 py-4 whitespace-nowrap text-sm'>
-                        <div className='flex gap-2'>
-                          {request.status === WithdrawalStatus.ACCOUNT_VALIDATION &&
-                            request.paymentAccount && (
-                              <button
-                                onClick={() => handleValidateAccount(request.paymentAccount!.id)}
-                                className='text-orange-600 hover:text-orange-900'
-                              >
-                                Valider compte
-                              </button>
-                            )}
-                          {request.status === WithdrawalStatus.PENDING && (
-                            <>
-                              <button
-                                onClick={() => handleApprove(request.id)}
-                                className='text-green-600 hover:text-green-900'
-                              >
-                                Approuver
-                              </button>
-                              <button
-                                onClick={() => handleReject(request.id)}
-                                className='text-red-600 hover:text-red-900'
-                              >
-                                Rejeter
-                              </button>
-                            </>
-                          )}
-                          {request.status === WithdrawalStatus.APPROVED && (
-                            <button
-                              onClick={() => handleMarkPaid(request.id)}
-                              className='text-blue-600 hover:text-blue-900'
-                            >
-                              Marquer payé
-                            </button>
-                          )}
-                        </div>
-                      </td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-        </div>
+        {/* Data table */}
+        <DataTable<WithdrawalRequest>
+          columns={columns}
+          rows={filteredRequests}
+          getRowId={r => r.id}
+          loading={loading}
+          sort={sort}
+          onSortChange={setSort}
+          rowActions={request => {
+            const canValidateAccount =
+              request.status === 'ACCOUNT_VALIDATION' && request.paymentAccount
+            const canApproveReject = request.status === 'PENDING'
+            const canMarkPaid = request.status === 'APPROVED'
 
-        {/* Modal de création de demande */}
-        {showCreateModal && (
-          <div className='fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4'>
-            <div className='bg-white rounded-lg shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto'>
-              <div className='p-6'>
-                <div className='flex justify-between items-center mb-6'>
-                  <h2 className='text-2xl font-bold text-gray-900'>Créer une demande de retrait</h2>
-                  <button
-                    onClick={() => setShowCreateModal(false)}
-                    className='text-gray-400 hover:text-gray-600'
+            if (!canValidateAccount && !canApproveReject && !canMarkPaid) {
+              return <span className='text-xs text-slate-300'>—</span>
+            }
+
+            return (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant='ghost'
+                    size='sm'
+                    className='h-8 w-8 p-0'
+                    aria-label='Actions retrait'
                   >
-                    <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                      <path
-                        strokeLinecap='round'
-                        strokeLinejoin='round'
-                        strokeWidth={2}
-                        d='M6 18L18 6M6 6l12 12'
-                      />
-                    </svg>
-                  </button>
-                </div>
-
-                {/* Informations hôte */}
-                <div className='bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6'>
-                  <p className='text-sm font-medium text-blue-900 mb-2'>
-                    Hôte :{' '}
-                    {hosts.find(h => h.id === selectedHost)?.name ||
-                      hosts.find(h => h.id === selectedHost)?.email}
-                  </p>
-                  {hostBalance && (
-                    <div className='grid grid-cols-3 gap-4 text-sm'>
-                      <div>
-                        <p className='text-blue-600'>Total gagné</p>
-                        <p className='font-bold text-blue-900'>
-                          {hostBalance.totalEarned.toFixed(2)}€
-                        </p>
-                      </div>
-                      <div>
-                        <p className='text-blue-600'>Déjà retiré</p>
-                        <p className='font-bold text-blue-900'>
-                          {hostBalance.totalWithdrawn.toFixed(2)}€
-                        </p>
-                      </div>
-                      <div>
-                        <p className='text-green-600'>Disponible</p>
-                        <p className='font-bold text-green-900'>
-                          {hostBalance.availableBalance.toFixed(2)}€
-                        </p>
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                {/* Formulaire */}
-                <div className='space-y-4'>
-                  {/* Montant */}
-                  <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      Montant à retirer (€) *
-                    </label>
-                    <input
-                      type='number'
-                      step='0.01'
-                      min='0'
-                      max={hostBalance?.availableBalance || 0}
-                      value={withdrawalForm.amount}
-                      onChange={e =>
-                        setWithdrawalForm({ ...withdrawalForm, amount: e.target.value })
-                      }
-                      className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                      placeholder='0.00'
-                    />
-                    {hostBalance && (
-                      <p className='text-xs text-gray-500 mt-1'>
-                        Maximum disponible : {hostBalance.availableBalance.toFixed(2)}€
-                      </p>
-                    )}
-                  </div>
-
-                  {/* Type de retrait */}
-                  <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      Type de retrait *
-                    </label>
-                    <select
-                      value={withdrawalForm.withdrawalType}
-                      onChange={e =>
-                        setWithdrawalForm({
-                          ...withdrawalForm,
-                          withdrawalType: e.target.value as 'PARTIAL_50' | 'FULL_100',
-                        })
-                      }
-                      className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
+                    <MoreHorizontal className='h-4 w-4' />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end' className='w-52'>
+                  <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {canValidateAccount && (
+                    <DropdownMenuItem
+                      onClick={() => handleValidateAccount(request.paymentAccount!.id)}
+                      className='flex items-center gap-2 text-orange-700'
                     >
-                      <option value='PARTIAL_50'>Partiel 50% (selon contrat)</option>
-                      <option value='FULL_100'>Complet 100%</option>
-                    </select>
-                  </div>
-
-                  {/* Méthode de paiement */}
-                  <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      Méthode de paiement *
-                    </label>
-                    <select
-                      value={withdrawalForm.paymentMethod}
-                      onChange={e =>
-                        setWithdrawalForm({
-                          ...withdrawalForm,
-                          paymentMethod: e.target.value as PaymentMethod,
-                        })
-                      }
-                      className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
+                      <ShieldCheck className='h-4 w-4' />
+                      Valider le compte
+                    </DropdownMenuItem>
+                  )}
+                  {canApproveReject && (
+                    <>
+                      <DropdownMenuItem
+                        onClick={() => handleApprove(request.id)}
+                        className='flex items-center gap-2 text-emerald-700'
+                      >
+                        <CheckCircle2 className='h-4 w-4' />
+                        Approuver
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => handleReject(request.id)}
+                        className='flex items-center gap-2 text-red-600 focus:text-red-600'
+                      >
+                        <XCircle className='h-4 w-4' />
+                        Rejeter
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                  {canMarkPaid && (
+                    <DropdownMenuItem
+                      onClick={() => handleMarkPaid(request.id)}
+                      className='flex items-center gap-2 text-blue-700'
                     >
-                      <option value='SEPA_VIREMENT'>SEPA</option>
-                      <option value='PRIPEO'>Pripeo (+1.50€)</option>
-                      <option value='MOBILE_MONEY'>Mobile Money</option>
-                      <option value='PAYPAL'>PayPal</option>
-                      <option value='MONEYGRAM'>MoneyGram</option>
-                    </select>
-                    <p className='text-xs text-gray-500 mt-1'>
-                      Note : Le compte de paiement de l&apos;hôte sera utilisé s&apos;il existe, sinon un
-                      nouveau sera créé.
-                    </p>
-                  </div>
-
-                  {/* Champs conditionnels selon la méthode de paiement */}
-                  {withdrawalForm.paymentMethod === 'SEPA_VIREMENT' && (
-                    <>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Nom du titulaire *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.accountHolderName}
-                          onChange={e =>
-                            setPaymentDetails({
-                              ...paymentDetails,
-                              accountHolderName: e.target.value,
-                            })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='Jean Dupont'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          IBAN *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.iban}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, iban: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='FR76 XXXX XXXX XXXX XXXX XXXX XXX'
-                        />
-                      </div>
-                    </>
+                      <Banknote className='h-4 w-4' />
+                      Marquer comme payée
+                    </DropdownMenuItem>
                   )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )
+          }}
+          emptyState={{
+            icon: Wallet,
+            title: 'Aucune demande de retrait',
+            subtitle:
+              searchValue || statusFilter !== 'ALL'
+                ? 'Essayez d’ajuster vos filtres.'
+                : 'Aucun hôte n’a encore demandé de retrait. Vous pouvez en créer une depuis le bouton en haut.',
+          }}
+        />
 
-                  {withdrawalForm.paymentMethod === 'PRIPEO' && (
-                    <>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Nom du titulaire *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.accountHolderName}
-                          onChange={e =>
-                            setPaymentDetails({
-                              ...paymentDetails,
-                              accountHolderName: e.target.value,
-                            })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='Jean Dupont'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Numéro de carte Pripeo *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.cardNumber}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, cardNumber: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='1234 5678 9012 3456'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Email *
-                        </label>
-                        <input
-                          type='email'
-                          value={paymentDetails.cardEmail}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, cardEmail: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='email@example.com'
-                        />
-                      </div>
-                    </>
-                  )}
-
-                  {withdrawalForm.paymentMethod === 'MOBILE_MONEY' && (
-                    <>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Nom du titulaire *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.accountHolderName}
-                          onChange={e =>
-                            setPaymentDetails({
-                              ...paymentDetails,
-                              accountHolderName: e.target.value,
-                            })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='Jean Dupont'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Numéro de téléphone *
-                        </label>
-                        <input
-                          type='tel'
-                          value={paymentDetails.mobileNumber}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, mobileNumber: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='+261 XX XX XXX XX'
-                        />
-                      </div>
-                    </>
-                  )}
-
-                  {withdrawalForm.paymentMethod === 'PAYPAL' && (
-                    <>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Nom d&apos;utilisateur PayPal *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.paypalUsername}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, paypalUsername: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='@username'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Email PayPal *
-                        </label>
-                        <input
-                          type='email'
-                          value={paymentDetails.paypalEmail}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, paypalEmail: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='email@example.com'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Téléphone
-                        </label>
-                        <input
-                          type='tel'
-                          value={paymentDetails.paypalPhone}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, paypalPhone: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='+33 X XX XX XX XX'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          IBAN (optionnel)
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.paypalIban}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, paypalIban: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='FR76 XXXX XXXX XXXX XXXX XXXX XXX'
-                        />
-                      </div>
-                    </>
-                  )}
-
-                  {withdrawalForm.paymentMethod === 'MONEYGRAM' && (
-                    <>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Nom complet *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.moneygramFullName}
-                          onChange={e =>
-                            setPaymentDetails({
-                              ...paymentDetails,
-                              moneygramFullName: e.target.value,
-                            })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='Jean Dupont'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Numéro de téléphone *
-                        </label>
-                        <input
-                          type='tel'
-                          value={paymentDetails.moneygramPhone}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, moneygramPhone: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='+261 XX XX XXX XX'
-                        />
-                      </div>
-                    </>
-                  )}
-
-                  {/* Notes */}
-                  <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      Notes (optionnel)
-                    </label>
-                    <textarea
-                      value={withdrawalForm.notes}
-                      onChange={e =>
-                        setWithdrawalForm({ ...withdrawalForm, notes: e.target.value })
-                      }
-                      className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                      rows={3}
-                      placeholder='Notes additionnelles...'
-                    />
-                  </div>
+        {/* Create withdrawal dialog */}
+        <Dialog open={showCreateModal} onOpenChange={setShowCreateModal}>
+          <DialogContent className='max-h-[90vh] overflow-y-auto sm:max-w-2xl'>
+            <DialogHeader>
+              <div className='flex items-start gap-3'>
+                <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 ring-1 ring-blue-100'>
+                  <UserPlus className='h-5 w-5' />
                 </div>
-
-                {/* Actions */}
-                <div className='flex justify-end gap-3 mt-6'>
-                  <button
-                    onClick={() => setShowCreateModal(false)}
-                    className='px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50'
-                  >
-                    Annuler
-                  </button>
-                  <button
-                    onClick={handleCreateWithdrawal}
-                    className='px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700'
-                  >
-                    Créer la demande
-                  </button>
+                <div className='space-y-1'>
+                  <DialogTitle className='text-lg'>Créer une demande de retrait</DialogTitle>
+                  <DialogDescription className='text-sm text-slate-600'>
+                    Créez une demande au nom d’un hôte. La demande sera automatiquement marquée
+                    comme approuvée.
+                  </DialogDescription>
                 </div>
               </div>
+            </DialogHeader>
+
+            <div className='space-y-5 py-2'>
+              {/* Host selector */}
+              <div className='space-y-2'>
+                <Label htmlFor='host'>Hôte *</Label>
+                <Select value={selectedHost} onValueChange={setSelectedHost}>
+                  <SelectTrigger id='host'>
+                    <SelectValue placeholder='Choisir un hôte…' />
+                  </SelectTrigger>
+                  <SelectContent className='max-h-72'>
+                    {hosts.map(host => (
+                      <SelectItem key={host.id} value={host.id}>
+                        <span className='flex flex-col'>
+                          <span className='font-medium'>{host.name || host.email}</span>
+                          <span className='text-xs text-slate-500'>{host.email}</span>
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Host balance info */}
+              {hostBalance && (
+                <div className='rounded-xl border border-blue-200 bg-blue-50/60 p-4'>
+                  <p className='mb-2 text-xs font-semibold uppercase tracking-wide text-blue-700'>
+                    Solde de l’hôte
+                  </p>
+                  <div className='grid grid-cols-3 gap-3 text-sm'>
+                    <div>
+                      <p className='text-xs text-slate-600'>Total gagné</p>
+                      <p className='font-bold text-slate-900 tabular-nums'>
+                        {formatCurrency(hostBalance.totalEarned)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className='text-xs text-slate-600'>Déjà retiré</p>
+                      <p className='font-bold text-slate-900 tabular-nums'>
+                        {formatCurrency(hostBalance.totalWithdrawn)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className='text-xs text-slate-600'>Disponible</p>
+                      <p className='font-bold text-emerald-600 tabular-nums'>
+                        {formatCurrency(hostBalance.availableBalance)}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Amount + type */}
+              <div className='grid gap-4 sm:grid-cols-2'>
+                <div className='space-y-2'>
+                  <Label htmlFor='amount'>Montant (€) *</Label>
+                  <Input
+                    id='amount'
+                    type='number'
+                    step='0.01'
+                    min='0'
+                    max={hostBalance?.availableBalance || 0}
+                    value={withdrawalForm.amount}
+                    onChange={e =>
+                      setWithdrawalForm({ ...withdrawalForm, amount: e.target.value })
+                    }
+                    placeholder='0.00'
+                  />
+                  {hostBalance && (
+                    <p className='text-xs text-slate-500'>
+                      Max {formatCurrency(hostBalance.availableBalance)}
+                    </p>
+                  )}
+                </div>
+                <div className='space-y-2'>
+                  <Label htmlFor='type'>Type</Label>
+                  <Select
+                    value={withdrawalForm.withdrawalType}
+                    onValueChange={value =>
+                      setWithdrawalForm({
+                        ...withdrawalForm,
+                        withdrawalType: value as 'PARTIAL_50' | 'FULL_100',
+                      })
+                    }
+                  >
+                    <SelectTrigger id='type'>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value='PARTIAL_50'>Partiel 50% (selon contrat)</SelectItem>
+                      <SelectItem value='FULL_100'>Complet 100%</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              {/* Payment method */}
+              <div className='space-y-2'>
+                <Label htmlFor='paymentMethod'>Méthode de paiement *</Label>
+                <Select
+                  value={withdrawalForm.paymentMethod}
+                  onValueChange={value =>
+                    setWithdrawalForm({
+                      ...withdrawalForm,
+                      paymentMethod: value as PaymentMethod,
+                    })
+                  }
+                >
+                  <SelectTrigger id='paymentMethod'>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(Object.keys(PAYMENT_METHOD_LABEL) as PaymentMethod[]).map(method => (
+                      <SelectItem key={method} value={method}>
+                        {PAYMENT_METHOD_LABEL[method]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Payment details — simplified: title holder + IBAN for SEPA, otherwise common fields */}
+              {withdrawalForm.paymentMethod === 'SEPA_VIREMENT' && (
+                <div className='grid gap-4 sm:grid-cols-2'>
+                  <div className='space-y-2'>
+                    <Label htmlFor='holder'>Titulaire du compte</Label>
+                    <Input
+                      id='holder'
+                      value={paymentDetails.accountHolderName}
+                      onChange={e =>
+                        setPaymentDetails({
+                          ...paymentDetails,
+                          accountHolderName: e.target.value,
+                        })
+                      }
+                      placeholder='Jean Dupont'
+                    />
+                  </div>
+                  <div className='space-y-2'>
+                    <Label htmlFor='iban'>IBAN</Label>
+                    <Input
+                      id='iban'
+                      value={paymentDetails.iban}
+                      onChange={e =>
+                        setPaymentDetails({ ...paymentDetails, iban: e.target.value })
+                      }
+                      placeholder='FR76…'
+                    />
+                  </div>
+                </div>
+              )}
+
+              {(withdrawalForm.paymentMethod === 'PAYPAL' ||
+                withdrawalForm.paymentMethod === 'MOBILE_MONEY' ||
+                withdrawalForm.paymentMethod === 'MONEYGRAM') && (
+                <div className='space-y-2'>
+                  <Label htmlFor='contact'>Email / numéro de contact</Label>
+                  <Input
+                    id='contact'
+                    value={paymentDetails.paypalEmail || paymentDetails.mobileNumber}
+                    onChange={e =>
+                      setPaymentDetails({
+                        ...paymentDetails,
+                        paypalEmail:
+                          withdrawalForm.paymentMethod === 'PAYPAL'
+                            ? e.target.value
+                            : paymentDetails.paypalEmail,
+                        mobileNumber:
+                          withdrawalForm.paymentMethod !== 'PAYPAL'
+                            ? e.target.value
+                            : paymentDetails.mobileNumber,
+                      })
+                    }
+                    placeholder={
+                      withdrawalForm.paymentMethod === 'PAYPAL'
+                        ? 'email@paypal.com'
+                        : '+261 xx xx xx xx'
+                    }
+                  />
+                </div>
+              )}
+
+              {/* Notes */}
+              <div className='space-y-2'>
+                <Label htmlFor='notes'>Notes (optionnel)</Label>
+                <Textarea
+                  id='notes'
+                  rows={3}
+                  value={withdrawalForm.notes}
+                  onChange={e => setWithdrawalForm({ ...withdrawalForm, notes: e.target.value })}
+                  placeholder='Notes internes visibles uniquement par les admins…'
+                />
+              </div>
             </div>
-          </div>
-        )}
-      </div>
+
+            <DialogFooter className='gap-2'>
+              <Button
+                variant='outline'
+                onClick={() => setShowCreateModal(false)}
+                disabled={isCreating}
+              >
+                Annuler
+              </Button>
+              <Button
+                onClick={handleCreateWithdrawal}
+                disabled={
+                  isCreating ||
+                  !selectedHost ||
+                  !withdrawalForm.amount ||
+                  parseFloat(withdrawalForm.amount) <= 0
+                }
+                className='gap-2 bg-blue-600 text-white hover:bg-blue-700'
+              >
+                {isCreating ? (
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                ) : (
+                  <ArrowRight className='h-4 w-4' />
+                )}
+                Créer la demande
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </motion.div>
     </div>
   )
 }

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -54,7 +54,11 @@ export async function GET(request: NextRequest) {
 
     const offset = (page - 1) * limit
 
-    // Execute optimized single query with Promise.all for better performance
+    // Execute optimized single query with Promise.all for better performance.
+    // We include the three profile picture fields so the admin list can render
+    // the user's real avatar via `getUserAvatarUrl()`. `profilePictureBase64`
+    // can be heavy, but this endpoint is admin-only and capped at 50 rows per
+    // page, so the trade-off is acceptable.
     const [users, totalItems] = await Promise.all([
       prisma.user.findMany({
         where: whereClause,
@@ -66,6 +70,9 @@ export async function GET(request: NextRequest) {
           roles: true,
           createdAt: true,
           emailVerified: true,
+          image: true,
+          profilePicture: true,
+          profilePictureBase64: true,
         },
         orderBy: [{ createdAt: 'desc' }, { email: 'asc' }],
         skip: offset,

--- a/src/app/api/homepage-settings/route.ts
+++ b/src/app/api/homepage-settings/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
 import {
   getHomepageSettings,
   updateHomepageSettings,
@@ -16,12 +17,26 @@ export async function GET() {
 
 export async function PUT(request: NextRequest) {
   try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+    }
+
+    const canManageSettings = ['ADMIN', 'HOST_MANAGER'].includes(session.user.roles as string)
+    if (!canManageSettings) {
+      console.warn(
+        `[PUT /api/homepage-settings] forbidden: user=${session.user.id} role=${session.user.roles}`
+      )
+      return NextResponse.json({ error: 'Non autorisé' }, { status: 403 })
+    }
+
     const body = await request.json()
-    const { heroBackgroundImage, howItWorksImage } = body
+    const { heroBackgroundImage, howItWorksImage, authBackgroundImage } = body
 
     const updatedSettings = await updateHomepageSettings({
       heroBackgroundImage,
       howItWorksImage,
+      authBackgroundImage,
     })
 
     if (!updatedSettings) {

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -24,8 +24,11 @@ export async function GET(request: NextRequest) {
 
       posts = await getPostsByAuthor(authorId)
     } else {
-      // Get all posts (public access)
-      posts = await getPost()
+      // Get all posts (public access). `getPost()` now returns a paginated
+      // shape `{ posts, pagination }` for internal use — the public
+      // `/api/posts` contract stays a plain array, so we unwrap here.
+      const paginated = await getPost({ limit: 1000 })
+      posts = paginated?.posts ?? null
     }
 
     if (!posts) {

--- a/src/app/createPost/page.tsx
+++ b/src/app/createPost/page.tsx
@@ -1,443 +1,93 @@
 'use client'
 
-import React, { useState } from 'react'
-import { motion } from 'framer-motion'
-import { LazyMarkdownEditor, LazyMarkdownViewer } from '@/components/dynamic/LazyComponents'
-import Image from 'next/image'
-import { createPost } from '@/lib/services/post.service'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/shadcnui/card'
-import { Input } from '@/components/ui/shadcnui/input'
-import { Label } from '@/components/ui/shadcnui/label'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/shadcnui/tabs'
-import { ScrollArea } from '@/components/ui/shadcnui/scroll-area'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import {
-  ImagePlus,
-  FileImage,
-  Save,
-  X,
-  Eye,
-  Edit3,
-  ArrowLeft,
-  Sparkles,
-  BookOpen,
-  Users,
-  TrendingUp,
-} from 'lucide-react'
-import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
-import Link from 'next/link'
+import { BookOpen } from 'lucide-react'
+import { toast } from 'sonner'
+
 import { useAuth } from '@/hooks/useAuth'
-import RichEditorGuide from '@/components/ui/RichEditorGuide'
-import SEOFieldsCard, { type SEOData } from '@/components/ui/SEOFieldsCard'
+import { createPost } from '@/lib/services/post.service'
+import { BlogPostForm, type BlogPostFormData } from '@/components/admin/blog/BlogPostForm'
 
-const containerVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
-  },
-}
-
-const itemVariants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-  },
+async function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(file)
+  })
 }
 
 export default function CreatePostPage() {
-  const {
-    session,
-    isLoading: isAuthLoading,
-  } = useAuth({ required: true, redirectTo: '/auth' })
-  const [title, setTitle] = useState('')
-  const [content, setContent] = useState('')
-  const [images, setImages] = useState<File[]>([])
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [seoData, setSeoData] = useState<SEOData>({
-    metaTitle: '',
-    metaDescription: '',
-    keywords: '',
-    slug: '',
+  const { session, isLoading: isAuthLoading } = useAuth({
+    required: true,
+    redirectTo: '/auth',
   })
   const router = useRouter()
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files) {
-      const newImages = Array.from(e.target.files)
-      setImages([newImages[0]]) // Limit to 1 image
-    }
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!title.trim() || !content.trim()) {
-      toast.error('Le titre et le contenu sont requis')
-      return
-    }
-
-    if (images.length === 0) {
-      toast.error('Une image est requise')
-      return
-    }
-
-    if (!session?.user?.id) {
-      toast.error('Vous devez être connecté pour créer un article')
-      return
-    }
-
-    setIsSubmitting(true)
-    try {
-      const reader = new FileReader()
-      reader.readAsDataURL(images[0])
-      reader.onload = async () => {
-        const base64Image = reader.result as string
-
-        const newPost = await createPost(title, content, base64Image, session.user.id, seoData)
-
-        if (newPost) {
-          toast.success('Article créé avec succès !', {
-            description: 'Votre article est maintenant en ligne avec optimisation SEO',
-          })
-
-          // Reset form
-          setTitle('')
-          setContent('')
-          setImages([])
-          setSeoData({
-            metaTitle: '',
-            metaDescription: '',
-            keywords: '',
-            slug: '',
-          })
-
-          // Redirect to the newly created article
-          router.push(`/posts/article/${newPost.slug || newPost.id}`)
-        } else {
-          toast.error('Erreur lors de la création de l&apos;article')
-        }
-      }
-    } catch (error) {
-      toast.error("Erreur lors de la création de l'article")
-      console.error(error)
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
   if (isAuthLoading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-6xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
         </div>
       </div>
     )
   }
 
-  if (!session) {
-    return null
+  if (!session) return null
+
+  const handleSubmit = async (data: BlogPostFormData) => {
+    if (!session.user?.id) {
+      toast.error('Vous devez être connecté pour créer un article')
+      return
+    }
+    if (!data.newImageFile) {
+      toast.error('Une image de couverture est requise')
+      return
+    }
+
+    try {
+      const base64 = await fileToBase64(data.newImageFile)
+      const newPost = await createPost(
+        data.title,
+        data.content,
+        base64,
+        session.user.id,
+        data.seoData
+      )
+
+      if (newPost) {
+        toast.success('Article publié avec succès', {
+          description: 'Votre article est maintenant en ligne.',
+        })
+        router.push(`/posts/article/${newPost.slug || newPost.id}`)
+      } else {
+        toast.error("Erreur lors de la création de l'article")
+      }
+    } catch (error) {
+      console.error('Error creating post:', error)
+      toast.error("Erreur lors de la création de l'article")
+    }
   }
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
-      <div className='container mx-auto py-8 px-4 max-w-6xl'>
-        <motion.div
-          variants={containerVariants}
-          initial='hidden'
-          animate='visible'
-          className='space-y-8'
-        >
-          {/* Header */}
-          <motion.div variants={itemVariants} className='space-y-4'>
-            <Button
-              variant='ghost'
-              size='sm'
-              asChild
-              className='text-slate-600 hover:text-slate-800'
-            >
-              <Link href='/posts' className='flex items-center gap-2'>
-                <ArrowLeft className='h-4 w-4' />
-                Retour aux articles
-              </Link>
-            </Button>
-
-            <div className='text-center space-y-4'>
-              <div className='inline-flex items-center gap-2 px-4 py-2 bg-purple-100 text-purple-700 rounded-full text-sm font-medium'>
-                <BookOpen className='h-4 w-4' />
-                Création d&apos;article
-              </div>
-              <h1 className='text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-800 via-purple-700 to-indigo-700'>
-                Créer un nouvel article
-              </h1>
-              <p className='text-slate-600 max-w-2xl mx-auto text-lg'>
-                Partagez vos expériences et conseils avec la communauté Hosteed
-              </p>
-            </div>
-          </motion.div>
-
-          {/* Main Form */}
-          <motion.div variants={itemVariants}>
-            <Card className='border-0 shadow-xl bg-white/80 backdrop-blur-sm'>
-              <CardHeader className='space-y-4 pb-8'>
-                <div className='flex items-center justify-between'>
-                  <div>
-                    <CardTitle className='text-2xl font-bold flex items-center gap-3'>
-                      <div className='p-2 bg-purple-100 rounded-lg'>
-                        <Edit3 className='w-6 h-6 text-purple-600' />
-                      </div>
-                      Rédaction de l&apos;article
-                    </CardTitle>
-                    <CardDescription className='text-lg mt-2'>
-                      Utilisez Markdown pour une mise en forme riche et professionnelle
-                    </CardDescription>
-                  </div>
-                  <div className='flex items-center gap-3'>
-                    <Badge variant='secondary' className='bg-blue-50 text-blue-700 px-3 py-1'>
-                      <Users className='w-3 h-3 mr-1' />
-                      Public
-                    </Badge>
-                    <RichEditorGuide />
-                  </div>
-                </div>
-              </CardHeader>
-
-              <CardContent>
-                <form onSubmit={handleSubmit} className='space-y-8'>
-                  {/* Title */}
-                  <motion.div variants={itemVariants} className='space-y-3'>
-                    <Label
-                      htmlFor='title'
-                      className='text-lg font-semibold flex items-center gap-2'
-                    >
-                      <Sparkles className='w-5 h-5 text-purple-600' />
-                      Titre de l&apos;article
-                    </Label>
-                    <Input
-                      id='title'
-                      placeholder='Un titre captivant qui donne envie de lire...'
-                      value={title}
-                      onChange={e => setTitle(e.target.value)}
-                      required
-                      className='text-xl h-14 border-2 focus:border-purple-300 focus:ring-purple-200 bg-white'
-                    />
-                    <p className='text-sm text-slate-600 flex items-center gap-1'>
-                      <TrendingUp className='w-4 h-4' />
-                      Un bon titre augmente de 73% l&apos;engagement des lecteurs
-                    </p>
-                  </motion.div>
-
-                  {/* Image */}
-                  <motion.div variants={itemVariants} className='space-y-4'>
-                    <Label className='text-lg font-semibold flex items-center gap-2'>
-                      <FileImage className='w-5 h-5 text-purple-600' />
-                      Image de couverture
-                    </Label>
-
-                    {images.length === 0 ? (
-                      <div
-                        className='border-2 border-dashed border-purple-200 rounded-xl p-8 text-center bg-purple-50/50 hover:bg-purple-50 transition-colors cursor-pointer'
-                        onClick={() => document.getElementById('image-upload')?.click()}
-                      >
-                        <ImagePlus className='w-12 h-12 text-purple-400 mx-auto mb-4' />
-                        <h3 className='text-lg font-semibold text-purple-700 mb-2'>
-                          Ajoutez une image de couverture
-                        </h3>
-                        <p className='text-purple-600 mb-4'>
-                          Format recommandé : 1200x630px - JPG, PNG ou WebP
-                        </p>
-                        <Button
-                          type='button'
-                          variant='secondary'
-                          className='bg-purple-100 text-purple-700 hover:bg-purple-200'
-                        >
-                          <ImagePlus className='w-4 h-4 mr-2' />
-                          Choisir une image
-                        </Button>
-                      </div>
-                    ) : (
-                      <div className='relative group'>
-                        <div className='relative aspect-video rounded-xl overflow-hidden border-2 border-purple-200'>
-                          <Image
-                            src={URL.createObjectURL(images[0])}
-                            alt='Image de couverture'
-                            fill
-                            className='object-cover'
-                          />
-                          <div className='absolute inset-0 bg-black/0 group-hover:bg-black/20 transition-colors'>
-                            <Button
-                              type='button'
-                              variant='ghost'
-                              size='icon'
-                              className='absolute top-3 right-3 bg-white/80 hover:bg-white text-slate-700 hover:text-red-600'
-                              onClick={() => setImages([])}
-                            >
-                              <X className='w-4 h-4' />
-                            </Button>
-                          </div>
-                        </div>
-                        <Button
-                          type='button'
-                          variant='outline'
-                          className='mt-3'
-                          onClick={() => document.getElementById('image-upload')?.click()}
-                        >
-                          <ImagePlus className='w-4 h-4 mr-2' />
-                          Changer l&apos;image
-                        </Button>
-                      </div>
-                    )}
-
-                    <input
-                      id='image-upload'
-                      type='file'
-                      accept='image/*'
-                      onChange={handleImageChange}
-                      className='hidden'
-                    />
-                  </motion.div>
-
-                  {/* Content Editor */}
-                  <motion.div variants={itemVariants} className='space-y-4'>
-                    <div className='flex items-center justify-between'>
-                      <Label className='text-lg font-semibold flex items-center gap-2'>
-                        <Edit3 className='w-5 h-5 text-purple-600' />
-                        Contenu de l&apos;article
-                      </Label>
-                      <div className='flex items-center gap-2'>
-                        <Badge variant='secondary' className='bg-green-50 text-green-700'>
-                          Markdown
-                        </Badge>
-                        <Badge variant='secondary' className='bg-blue-50 text-blue-700'>
-                          Prévisualisation en temps réel
-                        </Badge>
-                      </div>
-                    </div>
-
-                    <Tabs defaultValue='edit' className='w-full'>
-                      <TabsList className='grid w-full grid-cols-2 bg-slate-100'>
-                        <TabsTrigger value='edit' className='flex items-center gap-2'>
-                          <Edit3 className='w-4 h-4' />
-                          Édition
-                        </TabsTrigger>
-                        <TabsTrigger value='preview' className='flex items-center gap-2'>
-                          <Eye className='w-4 h-4' />
-                          Prévisualisation
-                        </TabsTrigger>
-                      </TabsList>
-
-                      <TabsContent value='edit' className='mt-6'>
-                        <div
-                          data-color-mode='light'
-                          className='rounded-xl border-2 border-purple-200 overflow-hidden bg-white shadow-inner'
-                        >
-                          <LazyMarkdownEditor
-                            value={content}
-                            onChange={value => setContent(value || '')}
-                            height={500}
-                            preview='edit'
-                            className='!border-none'
-                            data-color-mode='light'
-                            visibleDragbar={false}
-                            textareaProps={{
-                              placeholder:
-                                'Commencez à écrire votre article ici...\n\n# Mon premier titre\n\nVotre contenu ici. Utilisez **gras** et *italique* pour mettre en forme.\n\n## Sous-titre\n\n- Liste à puces\n- Deuxième élément\n\n[Lien vers Hosteed](https://hosteed.com)',
-                            }}
-                          />
-                        </div>
-                        <p className='text-sm text-slate-600 mt-3 flex items-center gap-2'>
-                          <BookOpen className='w-4 h-4' />
-                          Utilisez le guide d&apos;écriture pour découvrir toutes les possibilités
-                          du Markdown
-                        </p>
-                      </TabsContent>
-
-                      <TabsContent value='preview' className='mt-6'>
-                        <div className='rounded-xl border-2 border-slate-200 bg-white'>
-                          <ScrollArea className='h-[500px] w-full p-6'>
-                            <div data-color-mode='light' className='prose prose-lg max-w-none'>
-                              <LazyMarkdownViewer
-                                source={content || '*Votre article apparaîtra ici...*'}
-                                style={{
-                                  backgroundColor: 'transparent',
-                                  fontFamily: 'inherit',
-                                }}
-                              />
-                            </div>
-                          </ScrollArea>
-                        </div>
-                      </TabsContent>
-                    </Tabs>
-                  </motion.div>
-                </form>
-              </CardContent>
-            </Card>
-          </motion.div>
-
-          {/* SEO Section */}
-          <motion.div variants={itemVariants}>
-            <SEOFieldsCard seoData={seoData} onSeoChange={setSeoData} articleTitle={title} />
-          </motion.div>
-
-          {/* Submit Button */}
-          <motion.div variants={itemVariants} className='flex justify-center pt-4'>
-            <Button
-              type='submit'
-              onClick={handleSubmit}
-              disabled={isSubmitting || !title.trim() || !content.trim() || images.length === 0}
-              className='h-14 px-8 text-lg font-semibold bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 shadow-lg hover:shadow-xl transition-all duration-300'
-            >
-              {isSubmitting ? (
-                <>
-                  <div className='w-5 h-5 mr-3 animate-spin rounded-full border-2 border-white border-t-transparent'></div>
-                  Publication en cours...
-                </>
-              ) : (
-                <>
-                  <Save className='w-5 h-5 mr-3' />
-                  Publier l&apos;article
-                </>
-              )}
-            </Button>
-          </motion.div>
-
-          {/* Tips Card */}
-          <motion.div variants={itemVariants}>
-            <Card className='border-amber-200 bg-gradient-to-r from-amber-50 to-orange-50'>
-              <CardContent className='pt-6'>
-                <div className='flex items-start gap-4'>
-                  <div className='p-2 bg-amber-100 rounded-lg'>
-                    <Sparkles className='w-5 h-5 text-amber-600' />
-                  </div>
-                  <div>
-                    <h3 className='font-semibold text-amber-800 mb-2'>
-                      💡 Conseils pour un article réussi
-                    </h3>
-                    <ul className='text-amber-700 space-y-1 text-sm'>
-                      <li>• Utilisez des titres clairs pour structurer votre contenu</li>
-                      <li>• Ajoutez des images pour illustrer vos propos</li>
-                      <li>• Rédigez une méta-description engageante pour le SEO</li>
-                      <li>• Prévisualisez votre article avant publication</li>
-                    </ul>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </motion.div>
-        </motion.div>
-      </div>
-    </div>
+    <BlogPostForm
+      mode='create'
+      backHref='/admin/blog'
+      backLabel='Retour au blog'
+      eyebrow='Espace rédaction'
+      eyebrowIcon={BookOpen}
+      pageTitle='Créer un article'
+      pageSubtitle='Partagez vos expériences et conseils avec la communauté Hosteed.'
+      imageRequired
+      submitLabel="Publier l'article"
+      submittingLabel='Publication…'
+      onSubmit={handleSubmit}
+    />
   )
 }

--- a/src/app/dashboard/host/page.tsx
+++ b/src/app/dashboard/host/page.tsx
@@ -191,8 +191,15 @@ export default function HostDashboard() {
             </Card>
           </motion.div>
         ) : (
+          // Re-key the grid on products.length so framer-motion remounts it when data
+          // arrives after the outer container's initial animation has already completed.
+          // Without this, item motion children stay stuck at the `hidden` variant
+          // because the stagger orchestration already ran before they were mounted.
           <motion.div
+            key={`grid-${products.length}`}
             className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'
+            initial='hidden'
+            animate='visible'
             variants={containerVariants}
           >
             {products.map(product => {

--- a/src/app/posts/article/[slug]/page.tsx
+++ b/src/app/posts/article/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { getPostBySlugOrId, getSuggestedPosts } from '@/lib/services/post.service'
 import MarkdownRenderer from '@/components/ui/MarkdownRenderer'
+import { toPlainTextPreview } from '@/lib/utils/contentFormat'
 import ShareButton from '@/components/ui/ShareButton'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
 import { Button } from '@/components/ui/shadcnui/button'
@@ -26,13 +27,15 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     }
   }
 
+  const plainPreview = toPlainTextPreview(post.content).substring(0, 160)
+
   return {
     title: post.metaTitle || post.title,
-    description: post.metaDescription || post.content.substring(0, 160),
+    description: post.metaDescription || plainPreview,
     keywords: post.keywords || '',
     openGraph: {
       title: post.metaTitle || post.title,
-      description: post.metaDescription || post.content.substring(0, 160),
+      description: post.metaDescription || plainPreview,
       type: 'article',
       publishedTime: post.createdAt.toISOString(),
       modifiedTime: post.updatedAt.toISOString(),
@@ -50,7 +53,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     twitter: {
       card: 'summary_large_image',
       title: post.metaTitle || post.title,
-      description: post.metaDescription || post.content.substring(0, 160),
+      description: post.metaDescription || plainPreview,
       images: post.image ? [post.image] : [],
     },
     alternates: {
@@ -79,10 +82,11 @@ export default async function PostPage({ params }: PageProps) {
   }
 
   const estimateReadingTime = (content: string) => {
+    // Strip HTML/Markdown so tags don't count as words.
+    const plain = toPlainTextPreview(content)
     const wordsPerMinute = 200
-    const words = content.split(/\s+/).length
-    const readingTime = Math.ceil(words / wordsPerMinute)
-    return readingTime
+    const words = plain.split(/\s+/).filter(Boolean).length
+    return Math.max(1, Math.ceil(words / wordsPerMinute))
   }
 
   // Use relative URL - ShareButton will construct the full URL
@@ -222,7 +226,8 @@ export default async function PostPage({ params }: PageProps) {
               '@context': 'https://schema.org',
               '@type': 'BlogPosting',
               headline: post.title,
-              description: post.metaDescription || post.content.substring(0, 160),
+              description:
+                post.metaDescription || toPlainTextPreview(post.content).substring(0, 160),
               image: post.image || '',
               author: {
                 '@type': 'Organization',

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -17,19 +17,21 @@ import { PlusCircle, Calendar, Clock, ChevronRight, Search } from 'lucide-react'
 import { format } from 'date-fns'
 import { fr } from 'date-fns/locale'
 import { Post } from '@prisma/client'
+import { toPlainTextPreview } from '@/lib/utils/contentFormat'
 
 function truncateText(text: string, maxLength: number) {
-  // Supprimer les balises Markdown
-  const strippedText = text.replace(/[#*-]/g, '').replace(/\n/g, ' ').trim()
+  // Handle both legacy Markdown and new Tiptap HTML content.
+  const strippedText = toPlainTextPreview(text)
   if (strippedText.length <= maxLength) return strippedText
   return strippedText.substring(0, maxLength) + '...'
 }
 
 function estimateReadingTime(content: string): number {
+  // Strip markup before counting words so HTML tags don't inflate the count.
+  const plain = toPlainTextPreview(content)
   const wordsPerMinute = 200
-  const words = content.split(/\s+/).length
-  const readingTime = Math.ceil(words / wordsPerMinute)
-  return readingTime
+  const words = plain.split(/\s+/).filter(Boolean).length
+  return Math.max(1, Math.ceil(words / wordsPerMinute))
 }
 
 type SortOption = 'recent' | 'old' | 'az' | 'za'

--- a/src/app/reservations/[id]/page.tsx
+++ b/src/app/reservations/[id]/page.tsx
@@ -1,17 +1,12 @@
-// TODO: Implement chat with the host for a reservation
-
 import Image from 'next/image'
-import Link from 'next/link'
 import { getReservationDetails } from './actions'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Card, CardContent } from '@/components/ui/shadcnui/card'
 import { getProfileImageUrl } from '@/lib/utils'
 import GuestReservationDetailsCard from './GuestReservationDetailsCard'
 import GuestPricingDetailsCard from './GuestPricingDetailsCard'
 import {
   MapPin,
   Calendar,
-  User,
+  Users as UsersIcon,
   Mail,
   Home,
   Info,
@@ -20,8 +15,12 @@ import {
   Car,
   Map,
   Star,
+  ArrowRight,
+  CreditCard,
+  BadgeCheck,
+  Phone,
 } from 'lucide-react'
-import {
+import type {
   Equipment,
   Service,
   Security,
@@ -36,25 +35,90 @@ import {
   getPaymentStatusColor,
   getRentStatusColor,
 } from './utils'
+import { PageHeader } from '@/components/admin/ui/PageHeader'
 
-function HostAvatar({ host }: { host: { name: string; email: string; image: string } }) {
-  const profileImage = getProfileImageUrl(host.image)
+interface FeatureBlockProps {
+  title: string
+  icon: React.ComponentType<{ className?: string }>
+  tone: 'blue' | 'emerald' | 'purple' | 'amber' | 'red' | 'indigo' | 'slate'
+  items: Array<{ id: string; name: string }>
+  itemIcon?: React.ComponentType<{ className?: string }>
+  emptyLabel?: string
+}
 
+const TONE: Record<
+  FeatureBlockProps['tone'],
+  { iconBg: string; iconText: string }
+> = {
+  blue: { iconBg: 'bg-blue-50', iconText: 'text-blue-600' },
+  emerald: { iconBg: 'bg-emerald-50', iconText: 'text-emerald-600' },
+  purple: { iconBg: 'bg-purple-50', iconText: 'text-purple-600' },
+  amber: { iconBg: 'bg-amber-50', iconText: 'text-amber-600' },
+  red: { iconBg: 'bg-red-50', iconText: 'text-red-600' },
+  indigo: { iconBg: 'bg-indigo-50', iconText: 'text-indigo-600' },
+  slate: { iconBg: 'bg-slate-100', iconText: 'text-slate-600' },
+}
+
+function FeatureBlock({
+  title,
+  icon: Icon,
+  tone,
+  items,
+  itemIcon: ItemIcon = Info,
+  emptyLabel = 'Aucun élément renseigné.',
+}: FeatureBlockProps) {
+  const toneClass = TONE[tone]
   return (
-    <div className='relative h-20 w-20 rounded-full overflow-hidden bg-gray-200'>
-      {profileImage && (
+    <div className='rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm'>
+      <div className='mb-4 flex items-center gap-3'>
+        <div
+          className={`flex h-9 w-9 items-center justify-center rounded-lg ${toneClass.iconBg} ${toneClass.iconText}`}
+        >
+          <Icon className='h-4 w-4' />
+        </div>
+        <h3 className='text-sm font-semibold uppercase tracking-wide text-slate-500'>
+          {title}
+        </h3>
+      </div>
+      {items.length === 0 ? (
+        <p className='text-sm text-slate-400'>{emptyLabel}</p>
+      ) : (
+        <ul className='space-y-1.5'>
+          {items.map(item => (
+            <li
+              key={item.id}
+              className='flex items-center gap-2 rounded-lg bg-slate-50 px-3 py-1.5 text-sm text-slate-700'
+            >
+              <ItemIcon className='h-3.5 w-3.5 shrink-0 text-slate-400' />
+              <span className='truncate'>{item.name}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function HostAvatarLarge({
+  host,
+}: {
+  host: { name: string; email: string; image: string }
+}) {
+  const profileImage = getProfileImageUrl(host.image)
+  return (
+    <div className='relative h-20 w-20 shrink-0 overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-500 to-purple-500 ring-4 ring-white shadow-lg'>
+      {profileImage ? (
         <Image
           src={profileImage}
-          alt={host.name ?? 'host'}
+          alt={host.name ?? 'Host'}
           width={80}
           height={80}
-          className='h-full w-full object-cover rounded-full'
+          className='h-full w-full object-cover'
           referrerPolicy='no-referrer'
         />
-      )}
-      {!profileImage && (
-        <div className='absolute inset-0 flex items-center justify-center text-lg font-medium text-gray-600 bg-gray-100'>
-          {host.name?.charAt(0) ?? 'H'}
+      ) : (
+        <div className='flex h-full w-full items-center justify-center text-2xl font-bold text-white'>
+          {host.name?.charAt(0)?.toUpperCase() ?? 'H'}
         </div>
       )}
     </div>
@@ -71,285 +135,273 @@ export default async function ReservationDetailsPage({
     resolvedParams.id
   )) as unknown as ReservationDetails
 
+  const rentStatus = getRentStatusColor(reservation.status)
+  const paymentStatus = getPaymentStatusColor(reservation.payment)
+
+  const isVerifiedHost = host.roles === 'HOST_VERIFIED' || host.roles === 'ADMIN'
+
+  const productImages = reservation.product.img as Array<{ img: string }> | undefined
+  const firstImage = productImages && productImages.length > 0 ? productImages[0].img : null
+
+  const numberOfNights = (() => {
+    const arrival = new Date(reservation.arrivingDate)
+    const departure = new Date(reservation.leavingDate)
+    const diff = Math.round((departure.getTime() - arrival.getTime()) / (1000 * 60 * 60 * 24))
+    return diff > 0 ? diff : 0
+  })()
+
   return (
-    <div className='min-h-screen bg-gradient-to-b from-blue-50 to-white py-10'>
-      <div className='container mx-auto px-4 sm:px-6 lg:px-8'>
-        <div className='max-w-4xl mx-auto space-y-8'>
-          {/* Header */}
-          <div className='flex items-center justify-between'>
-            <h1 className='text-3xl font-bold text-gray-900'>Détails de la réservation</h1>
-            <Link href='/account'>
-              <Button variant='outline'>Retour</Button>
-            </Link>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <div className='mx-auto max-w-6xl space-y-8 p-6'>
+        <PageHeader
+          backHref='/account'
+          backLabel='Retour à mon compte'
+          eyebrow={`Réservation #${reservation.id.slice(-6).toUpperCase()}`}
+          title='Détails de la réservation'
+          subtitle='Consultez les informations de votre séjour, votre hôte et les équipements inclus.'
+        />
+
+        {/* Status card row */}
+        <div className='grid gap-4 md:grid-cols-3'>
+          <div className='rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm'>
+            <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+              Statut
+            </p>
+            <span
+              className={`mt-2 inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ring-1 ring-inset ${rentStatus.bg} ${rentStatus.text} ring-current/10`}
+            >
+              {translateRentStatus(reservation.status)}
+            </span>
           </div>
+          <div className='rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm'>
+            <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+              Confirmation hôte
+            </p>
+            <span
+              className={`mt-2 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-semibold ring-1 ${
+                reservation.confirmed
+                  ? 'bg-emerald-50 text-emerald-700 ring-emerald-200'
+                  : 'bg-amber-50 text-amber-700 ring-amber-200'
+              }`}
+            >
+              <BadgeCheck className='h-3.5 w-3.5' />
+              {reservation.confirmed ? 'Confirmé' : 'En attente'}
+            </span>
+          </div>
+          <div className='rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm'>
+            <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+              Paiement
+            </p>
+            <span
+              className={`mt-2 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-semibold ring-1 ring-inset ${paymentStatus.bg} ${paymentStatus.text} ring-current/10`}
+            >
+              <CreditCard className='h-3.5 w-3.5' />
+              {translatePaymentStatus(reservation.payment)}
+            </span>
+          </div>
+        </div>
 
-          {/* Property Overview */}
-          <Card>
-            <CardContent className='p-6'>
-              <div className='flex flex-col md:flex-row gap-6'>
-                <div className='relative w-full md:w-1/3 aspect-[4/3]'>
-                  <Image
-                    src={reservation.product.img?.[0]?.img || '/placeholder.png'}
-                    alt={reservation.product.name}
-                    fill
-                    className='object-cover rounded-lg'
-                  />
+        {/* Property overview */}
+        <div className='overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm'>
+          <div className='grid gap-0 md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]'>
+            <div className='relative aspect-[4/3] w-full md:aspect-auto md:min-h-[280px]'>
+              {firstImage ? (
+                <Image
+                  src={firstImage}
+                  alt={reservation.product.name}
+                  fill
+                  className='object-cover'
+                  sizes='(max-width: 768px) 100vw, 40vw'
+                />
+              ) : (
+                <div className='flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200'>
+                  <Home className='h-16 w-16 text-slate-400' />
                 </div>
-                <div className='flex-1'>
-                  <h2 className='text-2xl font-semibold mb-4'>{reservation.product.name}</h2>
-                  <div className='flex items-center gap-2 text-gray-600 mb-4'>
-                    <MapPin className='w-4 h-4' />
-                    <span>{reservation.product.address}</span>
-                  </div>
-                  <div className='grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm'>
-                    <div>
-                      <p className='font-medium'>Arrivée</p>
-                      <div className='flex items-center gap-2 text-gray-600'>
-                        <Calendar className='w-4 h-4' />
-                        <span>{new Date(reservation.arrivingDate).toLocaleDateString()}</span>
-                      </div>
-                    </div>
-                    <div>
-                      <p className='font-medium'>Départ</p>
-                      <div className='flex items-center gap-2 text-gray-600'>
-                        <Calendar className='w-4 h-4' />
-                        <span>{new Date(reservation.leavingDate).toLocaleDateString()}</span>
-                      </div>
-                    </div>
-                    <div>
-                      <p className='font-medium'>Voyageurs</p>
-                      <div className='flex items-center gap-2 text-gray-600'>
-                        <User className='w-4 h-4' />
-                        <span>{reservation.numberPeople.toString()} personnes</span>
-                      </div>
-                    </div>
-                    <div>
-                      <p className='font-medium'>Prix total</p>
-                      <div className='flex items-center gap-2 text-gray-600'>
-                        <span>{reservation.prices.toString()}€</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
+              )}
+            </div>
+            <div className='space-y-5 p-6'>
+              <div>
+                <h2 className='text-2xl font-bold text-slate-900'>
+                  {reservation.product.name}
+                </h2>
+                <p className='mt-1 flex items-center gap-1.5 text-sm text-slate-500'>
+                  <MapPin className='h-4 w-4' />
+                  {reservation.product.address}
+                </p>
               </div>
-            </CardContent>
-          </Card>
 
-          {/* Host Information */}
-          <Card>
-            <CardContent className='p-6'>
-              <h3 className='text-xl font-semibold mb-4'>Informations sur l&apos;hôte</h3>
-              <div className='flex flex-col sm:flex-row items-start gap-6'>
-                <div className='flex items-center gap-4'>
-                  <HostAvatar
-                    host={host as unknown as { name: string; email: string; image: string }}
-                  />
-                  <div>
-                    <p className='font-medium text-lg'>{host.name}</p>
-                    <div className='flex flex-col gap-2 text-sm text-gray-600 mt-2'>
-                      <div className='flex items-center gap-2'>
-                        <Mail className='w-4 h-4' />
-                        <span>{host.email}</span>
-                      </div>
-                      {host.roles === 'HOST_VERIFIED' ||
-                        (host.roles === 'ADMIN' && (
-                          <div className='flex items-center gap-2'>
-                            <Star className='w-4 h-4 text-yellow-400' />
-                            <span>Hôte vérifié</span>
-                          </div>
-                        ))}
-                    </div>
-                  </div>
+              <div className='grid grid-cols-2 gap-4'>
+                <div className='rounded-xl bg-slate-50 p-3'>
+                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                    Arrivée
+                  </p>
+                  <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                    <Calendar className='h-4 w-4 text-blue-600' />
+                    {new Date(reservation.arrivingDate).toLocaleDateString('fr-FR', {
+                      day: '2-digit',
+                      month: 'short',
+                      year: 'numeric',
+                    })}
+                  </p>
                 </div>
-                <div className='flex-1 bg-gray-50 rounded-lg p-4 mt-4 sm:mt-0'>
-                  <p className='text-sm text-gray-600'>
-                    Pour toute question concernant votre séjour, n&apos;hésitez pas à contacter
-                    votre hôte directement par email.
+                <div className='rounded-xl bg-slate-50 p-3'>
+                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                    Départ
+                  </p>
+                  <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                    <Calendar className='h-4 w-4 text-blue-600' />
+                    {new Date(reservation.leavingDate).toLocaleDateString('fr-FR', {
+                      day: '2-digit',
+                      month: 'short',
+                      year: 'numeric',
+                    })}
+                  </p>
+                </div>
+                <div className='rounded-xl bg-slate-50 p-3'>
+                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                    Durée
+                  </p>
+                  <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                    <ArrowRight className='h-4 w-4 text-emerald-600' />
+                    {numberOfNights} nuit{numberOfNights > 1 ? 's' : ''}
+                  </p>
+                </div>
+                <div className='rounded-xl bg-slate-50 p-3'>
+                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                    Voyageurs
+                  </p>
+                  <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                    <UsersIcon className='h-4 w-4 text-purple-600' />
+                    {reservation.numberPeople.toString()} personne
+                    {Number(reservation.numberPeople) > 1 ? 's' : ''}
                   </p>
                 </div>
               </div>
-            </CardContent>
-          </Card>
-
-          {/* Property Details */}
-          <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
-            {/* Amenities */}
-            <Card>
-              <CardContent className='p-6'>
-                <h3 className='text-xl font-semibold mb-4'>Équipements</h3>
-                <div className='space-y-3'>
-                  {reservation.product.equipments.map((equipment: Equipment) => (
-                    <div key={equipment.id} className='flex items-center gap-2 text-gray-600'>
-                      <Home className='w-4 h-4' />
-                      <span>{equipment.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Services */}
-            <Card>
-              <CardContent className='p-6'>
-                <h3 className='text-xl font-semibold mb-4'>Services</h3>
-                <div className='space-y-3'>
-                  {reservation.product.servicesList.map((service: Service) => (
-                    <div key={service.id} className='flex items-center gap-2 text-gray-600'>
-                      <Info className='w-4 h-4' />
-                      <span>{service.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Security */}
-            <Card>
-              <CardContent className='p-6'>
-                <h3 className='text-xl font-semibold mb-4'>Sécurité</h3>
-                <div className='space-y-3'>
-                  {reservation.product.securities.map((security: Security) => (
-                    <div key={security.id} className='flex items-center gap-2 text-gray-600'>
-                      <Shield className='w-4 h-4' />
-                      <span>{security.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Meals */}
-            <Card>
-              <CardContent className='p-6'>
-                <h3 className='text-xl font-semibold mb-4'>Repas</h3>
-                <div className='space-y-3'>
-                  {reservation.product.mealsList.map((meal: Meal) => (
-                    <div key={meal.id} className='flex items-center gap-2 text-gray-600'>
-                      <Utensils className='w-4 h-4' />
-                      <span>{meal.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Transport */}
-            <Card>
-              <CardContent className='p-6'>
-                <h3 className='text-xl font-semibold mb-4'>Transport</h3>
-                <div className='space-y-3'>
-                  {reservation.product.transportOptions.map((transport: Transport) => (
-                    <div key={transport.id} className='flex items-center gap-2 text-gray-600'>
-                      <Car className='w-4 h-4' />
-                      <span>{transport.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Nearby Places */}
-            <Card>
-              <CardContent className='p-6'>
-                <h3 className='text-xl font-semibold mb-4'>À proximité</h3>
-                <div className='space-y-3'>
-                  {reservation.product.nearbyPlaces.map((place: NearbyPlace) => (
-                    <div key={place.id} className='flex items-center gap-2 text-gray-600'>
-                      <Map className='w-4 h-4' />
-                      <span>{place.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Proximity Landmarks (visible only with reservation) */}
-            {reservation.product.proximityLandmarks &&
-              reservation.product.proximityLandmarks.length > 0 && (
-                <Card className='border-blue-200 bg-blue-50/50'>
-                  <CardContent className='p-6'>
-                    <div className='flex items-start gap-3 mb-4'>
-                      <Info className='w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0' />
-                      <div>
-                        <h3 className='text-xl font-semibold text-blue-900 mb-1'>
-                          Points de repère pour vous aider à localiser
-                        </h3>
-                        <p className='text-sm text-blue-700'>
-                          Ces informations sont visibles uniquement pour faciliter votre arrivée
-                        </p>
-                      </div>
-                    </div>
-                    <div className='space-y-2'>
-                      {reservation.product.proximityLandmarks.map(
-                        (landmark: string, index: number) => (
-                          <div key={index} className='flex items-center gap-2 text-blue-800'>
-                            <MapPin className='w-4 h-4 flex-shrink-0' />
-                            <span>{landmark}</span>
-                          </div>
-                        )
-                      )}
-                    </div>
-                  </CardContent>
-                </Card>
-              )}
+            </div>
           </div>
+        </div>
 
-          {/* Status and Payment */}
-          <Card>
-            <CardContent className='p-6'>
-              <h3 className='text-xl font-semibold mb-4'>Statut de la réservation</h3>
-              <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
-                <div>
-                  <p className='font-medium mb-2'>Statut</p>
-                  <span
-                    className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
-                      getRentStatusColor(reservation.status).bg
-                    } ${getRentStatusColor(reservation.status).text}`}
-                  >
-                    {translateRentStatus(reservation.status)}
+        {/* Host card */}
+        <div className='rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm'>
+          <h3 className='mb-4 text-sm font-semibold uppercase tracking-wide text-slate-500'>
+            Votre hôte
+          </h3>
+          <div className='flex flex-col gap-6 sm:flex-row sm:items-start'>
+            <HostAvatarLarge
+              host={host as unknown as { name: string; email: string; image: string }}
+            />
+            <div className='flex-1'>
+              <div className='flex flex-wrap items-center gap-2'>
+                <p className='text-lg font-bold text-slate-900'>{host.name}</p>
+                {isVerifiedHost && (
+                  <span className='inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-700 ring-1 ring-emerald-200'>
+                    <Star className='h-3 w-3' />
+                    Hôte vérifié
                   </span>
-                </div>
-                {/* Add data for the host confirmation for this reservation (reservation.confirmed) */}
-                {reservation.confirmed ? (
-                  <div>
-                    <p className='font-medium mb-2'>Confirmation de l&apos;hôte</p>
-                    <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800'>
-                      Confirmé
-                    </span>
-                  </div>
-                ) : (
-                  <div>
-                    <p className='font-medium mb-2'>Confirmation de l&apos;hôte</p>
-                    <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-orange-100 text-orange-800'>
-                      En attente
-                    </span>
-                  </div>
                 )}
-                <div>
-                  <p className='font-medium mb-2'>Paiement</p>
-                  <span
-                    className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
-                      getPaymentStatusColor(reservation.payment).bg
-                    } ${getPaymentStatusColor(reservation.payment).text}`}
-                  >
-                    {translatePaymentStatus(reservation.payment)}
+              </div>
+              <div className='mt-3 space-y-2 text-sm text-slate-600'>
+                <div className='flex items-center gap-2'>
+                  <Mail className='h-4 w-4 text-slate-400' />
+                  <a href={`mailto:${host.email}`} className='hover:text-blue-600'>
+                    {host.email}
+                  </a>
+                </div>
+                <div className='flex items-center gap-2'>
+                  <Phone className='h-4 w-4 text-slate-400' />
+                  <span className='text-slate-500'>
+                    Contactez votre hôte par email pour toute question
                   </span>
                 </div>
               </div>
-            </CardContent>
-          </Card>
-
-          {/* Reservation Details Cards */}
-          <div className='grid grid-cols-1 xl:grid-cols-3 gap-8'>
-            {/* Guest Reservation Details */}
-            <div className='xl:col-span-2'>
-              <GuestReservationDetailsCard reservation={reservation} />
             </div>
+          </div>
+        </div>
 
-            {/* Pricing Details */}
-            <div>
-              <GuestPricingDetailsCard rent={reservation} />
+        {/* Property details grid */}
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
+          <FeatureBlock
+            title='Équipements'
+            icon={Home}
+            tone='blue'
+            items={reservation.product.equipments as Equipment[]}
+            itemIcon={Home}
+          />
+          <FeatureBlock
+            title='Services'
+            icon={Info}
+            tone='indigo'
+            items={reservation.product.servicesList as Service[]}
+          />
+          <FeatureBlock
+            title='Sécurité'
+            icon={Shield}
+            tone='red'
+            items={reservation.product.securities as Security[]}
+            itemIcon={Shield}
+          />
+          <FeatureBlock
+            title='Repas'
+            icon={Utensils}
+            tone='amber'
+            items={reservation.product.mealsList as Meal[]}
+            itemIcon={Utensils}
+          />
+          <FeatureBlock
+            title='Transport'
+            icon={Car}
+            tone='emerald'
+            items={reservation.product.transportOptions as Transport[]}
+            itemIcon={Car}
+          />
+          <FeatureBlock
+            title='À proximité'
+            icon={Map}
+            tone='purple'
+            items={reservation.product.nearbyPlaces as NearbyPlace[]}
+            itemIcon={MapPin}
+          />
+        </div>
+
+        {/* Proximity landmarks (visible only to guest who booked) */}
+        {reservation.product.proximityLandmarks &&
+          reservation.product.proximityLandmarks.length > 0 && (
+            <div className='rounded-2xl border border-blue-200 bg-blue-50/60 p-6'>
+              <div className='mb-4 flex items-start gap-3'>
+                <div className='flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-100 text-blue-600'>
+                  <Info className='h-5 w-5' />
+                </div>
+                <div>
+                  <h3 className='text-sm font-semibold uppercase tracking-wide text-blue-900'>
+                    Points de repère
+                  </h3>
+                  <p className='mt-1 text-sm text-blue-700'>
+                    Ces informations sont partagées uniquement avec les voyageurs ayant une
+                    réservation, pour faciliter votre arrivée.
+                  </p>
+                </div>
+              </div>
+              <ul className='space-y-2'>
+                {(reservation.product.proximityLandmarks as string[]).map((landmark, i) => (
+                  <li
+                    key={i}
+                    className='flex items-center gap-2 rounded-lg bg-white px-3 py-2 text-sm text-slate-700 ring-1 ring-blue-200/60'
+                  >
+                    <MapPin className='h-4 w-4 shrink-0 text-blue-600' />
+                    <span>{landmark}</span>
+                  </li>
+                ))}
+              </ul>
             </div>
+          )}
+
+        {/* Reservation + pricing details cards (existing components) */}
+        <div className='grid grid-cols-1 gap-6 xl:grid-cols-3'>
+          <div className='xl:col-span-2'>
+            <GuestReservationDetailsCard reservation={reservation} />
+          </div>
+          <div>
+            <GuestPricingDetailsCard rent={reservation} />
           </div>
         </div>
       </div>

--- a/src/components/admin/blog/BlogPostForm.tsx
+++ b/src/components/admin/blog/BlogPostForm.tsx
@@ -1,0 +1,357 @@
+'use client'
+
+import React, { useState } from 'react'
+import Image from 'next/image'
+import { motion } from 'framer-motion'
+import { toast } from 'sonner'
+import {
+  Save,
+  Loader2,
+  ImagePlus,
+  X,
+  FileText,
+  Eye,
+  Edit3,
+  type LucideIcon,
+} from 'lucide-react'
+
+import { Button } from '@/components/ui/shadcnui/button'
+import { Input } from '@/components/ui/shadcnui/input'
+import { Label } from '@/components/ui/shadcnui/label'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/shadcnui/tabs'
+import SEOFieldsCard, { type SEOData } from '@/components/ui/SEOFieldsCard'
+import {
+  LazyMarkdownEditor,
+  LazyMarkdownViewer,
+} from '@/components/dynamic/LazyComponents'
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+
+/**
+ * Form data emitted to the parent on submit. Image handling is the parent's
+ * responsibility — it can upload/convert the `newImageFile` to base64, or reuse
+ * the `imageUrl` when the user didn't touch the image picker.
+ */
+export interface BlogPostFormData {
+  title: string
+  content: string
+  seoData: SEOData
+  /** New file picked by the user, or null if unchanged. */
+  newImageFile: File | null
+  /** URL/base64 of the currently displayed image, or empty string if cleared. */
+  imageUrl: string
+}
+
+interface BlogPostFormProps {
+  mode: 'create' | 'edit'
+  /** PageHeader back link href. */
+  backHref: string
+  backLabel?: string
+  /** Eyebrow pill text above the title. */
+  eyebrow?: string
+  eyebrowIcon?: LucideIcon
+  /** Large page title. */
+  pageTitle: string
+  /** Subtitle under the page title. */
+  pageSubtitle?: string
+
+  /** Initial title value. */
+  initialTitle?: string
+  /** Initial markdown content. */
+  initialContent?: string
+  /** Initial image URL (for edit mode). */
+  initialImageUrl?: string
+  /** Initial SEO data. */
+  initialSeoData?: SEOData
+
+  /** Whether an image is required to submit (create mode usually requires one). */
+  imageRequired?: boolean
+
+  /** Label for the primary submit button. */
+  submitLabel?: string
+  /** Label shown on the submit button while in flight. */
+  submittingLabel?: string
+
+  /** Extra sidebar slot (e.g. post info card on edit). */
+  sidebarExtra?: React.ReactNode
+  /** Extra actions slot in the page header (e.g. "Aperçu" link). */
+  headerActions?: React.ReactNode
+
+  /** Called when the user submits the form. Return a promise — while it's
+   *  resolving, the submit button shows the loading state. */
+  onSubmit: (data: BlogPostFormData) => Promise<void>
+}
+
+export function BlogPostForm({
+  mode,
+  backHref,
+  backLabel = 'Retour',
+  eyebrow,
+  eyebrowIcon,
+  pageTitle,
+  pageSubtitle,
+  initialTitle = '',
+  initialContent = '',
+  initialImageUrl = '',
+  initialSeoData,
+  imageRequired = mode === 'create',
+  submitLabel,
+  submittingLabel,
+  sidebarExtra,
+  headerActions,
+  onSubmit,
+}: BlogPostFormProps) {
+  const [title, setTitle] = useState(initialTitle)
+  const [content, setContent] = useState(initialContent)
+  const [newImageFile, setNewImageFile] = useState<File | null>(null)
+  const [imageUrl, setImageUrl] = useState(initialImageUrl)
+  const [seoData, setSeoData] = useState<SEOData>(
+    initialSeoData ?? { metaTitle: '', metaDescription: '', keywords: '', slug: '' }
+  )
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const previewUrl = newImageFile ? URL.createObjectURL(newImageFile) : imageUrl
+  const hasImage = Boolean(previewUrl)
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setNewImageFile(file)
+  }
+
+  const handleImageRemove = () => {
+    setNewImageFile(null)
+    setImageUrl('')
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!title.trim()) {
+      toast.error("Le titre de l'article est requis")
+      return
+    }
+    if (!content.trim()) {
+      toast.error('Le contenu est requis')
+      return
+    }
+    if (imageRequired && !hasImage) {
+      toast.error("Une image de couverture est requise")
+      return
+    }
+
+    try {
+      setIsSubmitting(true)
+      await onSubmit({ title, content, seoData, newImageFile, imageUrl })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.form
+        onSubmit={handleSubmit}
+        className='mx-auto max-w-6xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <PageHeader
+          backHref={backHref}
+          backLabel={backLabel}
+          eyebrow={eyebrow}
+          eyebrowIcon={eyebrowIcon}
+          title={pageTitle}
+          subtitle={pageSubtitle}
+          actions={
+            <div className='flex items-center gap-2'>
+              {headerActions}
+              <Button
+                type='submit'
+                disabled={isSubmitting}
+                className='gap-2'
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className='h-4 w-4 animate-spin' />
+                    {submittingLabel ?? 'Enregistrement…'}
+                  </>
+                ) : (
+                  <>
+                    <Save className='h-4 w-4' />
+                    {submitLabel ?? (mode === 'create' ? "Publier l'article" : 'Sauvegarder')}
+                  </>
+                )}
+              </Button>
+            </div>
+          }
+        />
+
+        <div className='grid gap-6 lg:grid-cols-3'>
+          {/* Left column — title + content */}
+          <div className='space-y-6 lg:col-span-2'>
+            {/* Title card */}
+            <div className='rounded-2xl border border-slate-200/80 bg-white shadow-sm'>
+              <div className='flex items-center gap-3 border-b border-slate-100 px-6 py-4'>
+                <div className='flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600'>
+                  <FileText className='h-4 w-4' />
+                </div>
+                <div>
+                  <h2 className='text-sm font-semibold uppercase tracking-wide text-slate-500'>
+                    Titre de l&apos;article
+                  </h2>
+                </div>
+              </div>
+              <div className='p-6'>
+                <Label htmlFor='blog-title' className='sr-only'>
+                  Titre
+                </Label>
+                <Input
+                  id='blog-title'
+                  placeholder='Un titre captivant pour votre article…'
+                  value={title}
+                  onChange={e => setTitle(e.target.value)}
+                  className='h-12 text-lg font-medium'
+                />
+                <p className='mt-2 text-xs text-slate-500'>
+                  Un bon titre est clair, concis et donne envie de cliquer.
+                </p>
+              </div>
+            </div>
+
+            {/* Content editor card */}
+            <div className='rounded-2xl border border-slate-200/80 bg-white shadow-sm'>
+              <div className='flex items-center gap-3 border-b border-slate-100 px-6 py-4'>
+                <div className='flex h-9 w-9 items-center justify-center rounded-lg bg-indigo-50 text-indigo-600'>
+                  <Edit3 className='h-4 w-4' />
+                </div>
+                <div>
+                  <h2 className='text-sm font-semibold uppercase tracking-wide text-slate-500'>
+                    Contenu
+                  </h2>
+                </div>
+              </div>
+              <div className='p-6'>
+                <Tabs defaultValue='edit' className='w-full'>
+                  <TabsList className='grid w-full grid-cols-2'>
+                    <TabsTrigger value='edit' className='gap-2'>
+                      <Edit3 className='h-3.5 w-3.5' />
+                      Édition
+                    </TabsTrigger>
+                    <TabsTrigger value='preview' className='gap-2'>
+                      <Eye className='h-3.5 w-3.5' />
+                      Aperçu
+                    </TabsTrigger>
+                  </TabsList>
+                  <TabsContent value='edit' className='mt-4'>
+                    <div
+                      data-color-mode='light'
+                      className='overflow-hidden rounded-xl border border-slate-200 bg-white'
+                    >
+                      <LazyMarkdownEditor
+                        value={content}
+                        onChange={val => setContent(val || '')}
+                        preview='edit'
+                        height={460}
+                        data-color-mode='light'
+                        visibleDragbar={false}
+                        textareaProps={{
+                          placeholder:
+                            "Commencez à écrire votre article ici…\n\n# Titre principal\n\nVotre contenu. Utilisez **gras** et *italique* pour mettre en forme.\n\n## Sous-titre\n\n- Liste à puces\n- Deuxième élément\n\n[Lien](https://example.com)",
+                        }}
+                      />
+                    </div>
+                    <p className='mt-3 text-xs text-slate-500'>
+                      La syntaxe Markdown est prise en charge (titres, listes, liens, images,
+                      code…).
+                    </p>
+                  </TabsContent>
+                  <TabsContent value='preview' className='mt-4'>
+                    <div className='min-h-[460px] rounded-xl border border-slate-200 bg-white p-6'>
+                      <div data-color-mode='light' className='prose prose-sm max-w-none'>
+                        <LazyMarkdownViewer
+                          source={content || '*Votre article apparaîtra ici…*'}
+                          style={{ backgroundColor: 'transparent', fontFamily: 'inherit' }}
+                        />
+                      </div>
+                    </div>
+                  </TabsContent>
+                </Tabs>
+              </div>
+            </div>
+          </div>
+
+          {/* Right column — sidebar */}
+          <div className='space-y-6'>
+            {/* Cover image card */}
+            <div className='rounded-2xl border border-slate-200/80 bg-white shadow-sm'>
+              <div className='flex items-center gap-3 border-b border-slate-100 px-6 py-4'>
+                <div className='flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-50 text-emerald-600'>
+                  <ImagePlus className='h-4 w-4' />
+                </div>
+                <div>
+                  <h2 className='text-sm font-semibold uppercase tracking-wide text-slate-500'>
+                    Image de couverture
+                    {imageRequired && <span className='ml-1 text-red-500'>*</span>}
+                  </h2>
+                </div>
+              </div>
+              <div className='space-y-4 p-6'>
+                {hasImage ? (
+                  <div className='relative aspect-video overflow-hidden rounded-xl border border-slate-200 bg-slate-100'>
+                    <Image
+                      src={previewUrl}
+                      alt='Image de couverture'
+                      fill
+                      className='object-cover'
+                      sizes='(max-width: 1024px) 100vw, 400px'
+                      unoptimized
+                    />
+                    <button
+                      type='button'
+                      onClick={handleImageRemove}
+                      className='absolute right-2 top-2 rounded-full bg-white/90 p-1.5 text-red-600 shadow-sm transition hover:bg-white hover:text-red-700'
+                      aria-label='Retirer l’image'
+                    >
+                      <X className='h-4 w-4' />
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type='button'
+                    onClick={() => document.getElementById('blog-image-upload')?.click()}
+                    className='flex aspect-video w-full flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-slate-200 bg-slate-50/60 text-slate-500 transition hover:border-blue-300 hover:bg-blue-50/40 hover:text-blue-600'
+                  >
+                    <ImagePlus className='h-10 w-10' />
+                    <p className='text-sm font-medium'>Ajouter une image</p>
+                    <p className='text-xs'>Format recommandé : 1200 × 630 px</p>
+                  </button>
+                )}
+
+                <Label htmlFor='blog-image-upload' className='sr-only'>
+                  Image
+                </Label>
+                <Input
+                  id='blog-image-upload'
+                  type='file'
+                  accept='image/*'
+                  onChange={handleImageChange}
+                  className='file:mr-4 file:rounded-full file:border-0 file:bg-blue-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-blue-700 hover:file:bg-blue-100'
+                />
+              </div>
+            </div>
+
+            {/* SEO card */}
+            <SEOFieldsCard
+              seoData={seoData}
+              onSeoChange={setSeoData}
+              articleTitle={title}
+            />
+
+            {sidebarExtra}
+          </div>
+        </div>
+      </motion.form>
+    </div>
+  )
+}

--- a/src/components/admin/blog/BlogPostForm.tsx
+++ b/src/components/admin/blog/BlogPostForm.tsx
@@ -1,16 +1,16 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import Image from 'next/image'
 import { motion } from 'framer-motion'
 import { toast } from 'sonner'
+import { marked } from 'marked'
 import {
   Save,
   Loader2,
   ImagePlus,
   X,
   FileText,
-  Eye,
   Edit3,
   type LucideIcon,
 } from 'lucide-react'
@@ -18,13 +18,25 @@ import {
 import { Button } from '@/components/ui/shadcnui/button'
 import { Input } from '@/components/ui/shadcnui/input'
 import { Label } from '@/components/ui/shadcnui/label'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/shadcnui/tabs'
 import SEOFieldsCard, { type SEOData } from '@/components/ui/SEOFieldsCard'
-import {
-  LazyMarkdownEditor,
-  LazyMarkdownViewer,
-} from '@/components/dynamic/LazyComponents'
+import { LazyTiptapEditor } from '@/components/dynamic/LazyComponents'
 import { PageHeader } from '@/components/admin/ui/PageHeader'
+
+/**
+ * Convert existing Markdown content to HTML so the Tiptap editor can pick it up.
+ * Detects HTML by looking for a leading tag; otherwise parses as Markdown.
+ */
+function toEditorHtml(raw: string): string {
+  if (!raw) return ''
+  const trimmed = raw.trimStart()
+  if (trimmed.startsWith('<')) return raw
+  try {
+    return marked.parse(raw, { async: false }) as string
+  } catch (error) {
+    console.error('Failed to convert Markdown → HTML for the editor:', error)
+    return raw
+  }
+}
 
 /**
  * Form data emitted to the parent on submit. Image handling is the parent's
@@ -100,8 +112,10 @@ export function BlogPostForm({
   headerActions,
   onSubmit,
 }: BlogPostFormProps) {
+  const initialHtml = useMemo(() => toEditorHtml(initialContent), [initialContent])
+
   const [title, setTitle] = useState(initialTitle)
-  const [content, setContent] = useState(initialContent)
+  const [content, setContent] = useState(initialHtml)
   const [newImageFile, setNewImageFile] = useState<File | null>(null)
   const [imageUrl, setImageUrl] = useState(initialImageUrl)
   const [seoData, setSeoData] = useState<SEOData>(
@@ -232,51 +246,15 @@ export function BlogPostForm({
                 </div>
               </div>
               <div className='p-6'>
-                <Tabs defaultValue='edit' className='w-full'>
-                  <TabsList className='grid w-full grid-cols-2'>
-                    <TabsTrigger value='edit' className='gap-2'>
-                      <Edit3 className='h-3.5 w-3.5' />
-                      Édition
-                    </TabsTrigger>
-                    <TabsTrigger value='preview' className='gap-2'>
-                      <Eye className='h-3.5 w-3.5' />
-                      Aperçu
-                    </TabsTrigger>
-                  </TabsList>
-                  <TabsContent value='edit' className='mt-4'>
-                    <div
-                      data-color-mode='light'
-                      className='overflow-hidden rounded-xl border border-slate-200 bg-white'
-                    >
-                      <LazyMarkdownEditor
-                        value={content}
-                        onChange={val => setContent(val || '')}
-                        preview='edit'
-                        height={460}
-                        data-color-mode='light'
-                        visibleDragbar={false}
-                        textareaProps={{
-                          placeholder:
-                            "Commencez à écrire votre article ici…\n\n# Titre principal\n\nVotre contenu. Utilisez **gras** et *italique* pour mettre en forme.\n\n## Sous-titre\n\n- Liste à puces\n- Deuxième élément\n\n[Lien](https://example.com)",
-                        }}
-                      />
-                    </div>
-                    <p className='mt-3 text-xs text-slate-500'>
-                      La syntaxe Markdown est prise en charge (titres, listes, liens, images,
-                      code…).
-                    </p>
-                  </TabsContent>
-                  <TabsContent value='preview' className='mt-4'>
-                    <div className='min-h-[460px] rounded-xl border border-slate-200 bg-white p-6'>
-                      <div data-color-mode='light' className='prose prose-sm max-w-none'>
-                        <LazyMarkdownViewer
-                          source={content || '*Votre article apparaîtra ici…*'}
-                          style={{ backgroundColor: 'transparent', fontFamily: 'inherit' }}
-                        />
-                      </div>
-                    </div>
-                  </TabsContent>
-                </Tabs>
+                <LazyTiptapEditor
+                  content={content}
+                  onChange={setContent}
+                  placeholder='Commencez à écrire votre article ici…'
+                />
+                <p className='mt-3 text-xs text-slate-500'>
+                  Utilisez la barre d&apos;outils pour mettre en forme votre texte (gras, titres,
+                  listes, liens).
+                </p>
               </div>
             </div>
           </div>
@@ -341,16 +319,17 @@ export function BlogPostForm({
               </div>
             </div>
 
-            {/* SEO card */}
-            <SEOFieldsCard
-              seoData={seoData}
-              onSeoChange={setSeoData}
-              articleTitle={title}
-            />
-
             {sidebarExtra}
           </div>
         </div>
+
+        {/* Full-width SEO card — placed outside the 2/3 - 1/3 grid so it has
+         *  room to breathe on wide screens. */}
+        <SEOFieldsCard
+          seoData={seoData}
+          onSeoChange={setSeoData}
+          articleTitle={title}
+        />
       </motion.form>
     </div>
   )

--- a/src/components/admin/ui/DataTable.tsx
+++ b/src/components/admin/ui/DataTable.tsx
@@ -1,0 +1,303 @@
+'use client'
+
+import React, { useMemo } from 'react'
+import { ChevronDown, ChevronUp, LucideIcon } from 'lucide-react'
+
+export interface DataTableColumn<T> {
+  /** Unique key for the column. */
+  key: string
+  /** Column header label. */
+  header: string
+  /** Render the cell for a given row. */
+  render: (row: T) => React.ReactNode
+  /** Whether the column is sortable. */
+  sortable?: boolean
+  /** Accessor to extract the sort value (required if sortable). */
+  sortAccessor?: (row: T) => string | number | Date | null | undefined
+  /** Horizontal alignment. Defaults to 'left'. */
+  align?: 'left' | 'center' | 'right'
+  /** Optional CSS class for the cell (e.g. to cap width). */
+  cellClassName?: string
+  /** Optional CSS class for the header cell. */
+  headerClassName?: string
+}
+
+export interface DataTableSort {
+  key: string
+  direction: 'asc' | 'desc'
+}
+
+interface DataTableProps<T> {
+  columns: DataTableColumn<T>[]
+  rows: T[]
+  /** Stable unique id for each row (used as React key and for selection). */
+  getRowId: (row: T) => string
+  /** Loading state — renders skeleton rows. */
+  loading?: boolean
+  /** Number of skeleton rows to render while loading. */
+  skeletonRows?: number
+  /** Current sort state (controlled). */
+  sort?: DataTableSort | null
+  /** Called when a sortable header is clicked. */
+  onSortChange?: (sort: DataTableSort) => void
+  /** If provided, the table renders a leading checkbox column for selection. */
+  selection?: {
+    selectedIds: Set<string>
+    onSelectionChange: (selectedIds: Set<string>) => void
+  }
+  /** Optional per-row actions column rendered on the right. */
+  rowActions?: (row: T) => React.ReactNode
+  /** Empty state when there are no rows and loading is false. */
+  emptyState?: {
+    icon?: LucideIcon
+    title: string
+    subtitle?: string
+  }
+  /** Optional row href — makes the row clickable (via full-row link). */
+  getRowHref?: (row: T) => string | null
+  /** Extra className for the outer wrapper. */
+  className?: string
+}
+
+function defaultSortComparator<T>(
+  a: T,
+  b: T,
+  accessor: (row: T) => string | number | Date | null | undefined,
+  direction: 'asc' | 'desc'
+): number {
+  const av = accessor(a)
+  const bv = accessor(b)
+  const dir = direction === 'asc' ? 1 : -1
+
+  if (av == null && bv == null) return 0
+  if (av == null) return 1 * dir
+  if (bv == null) return -1 * dir
+
+  if (av instanceof Date && bv instanceof Date) {
+    return (av.getTime() - bv.getTime()) * dir
+  }
+  if (typeof av === 'number' && typeof bv === 'number') {
+    return (av - bv) * dir
+  }
+  return String(av).localeCompare(String(bv), 'fr', { sensitivity: 'base' }) * dir
+}
+
+/**
+ * Generic data table for admin pages.
+ *
+ * Usage:
+ *   <DataTable
+ *     columns={[{ key: 'name', header: 'Name', render: r => r.name, sortable: true, sortAccessor: r => r.name }]}
+ *     rows={users}
+ *     getRowId={u => u.id}
+ *     sort={sort}
+ *     onSortChange={setSort}
+ *     selection={{ selectedIds, onSelectionChange: setSelectedIds }}
+ *     rowActions={row => <DropdownMenu>...</DropdownMenu>}
+ *     emptyState={{ title: 'Aucun utilisateur', subtitle: 'Ajustez vos filtres.' }}
+ *   />
+ */
+export function DataTable<T>({
+  columns,
+  rows,
+  getRowId,
+  loading = false,
+  skeletonRows = 6,
+  sort,
+  onSortChange,
+  selection,
+  rowActions,
+  emptyState,
+  className = '',
+}: DataTableProps<T>) {
+  // Optional client-side sorting (only applied if we have a sortable column selected AND the consumer doesn't handle it server-side).
+  // We always return rows as-is if there's no sort or no sortAccessor — consumers with server sorting control the data directly.
+  const sortedRows = useMemo(() => {
+    if (!sort) return rows
+    const col = columns.find(c => c.key === sort.key)
+    if (!col?.sortAccessor) return rows
+    return [...rows].sort((a, b) => defaultSortComparator(a, b, col.sortAccessor!, sort.direction))
+  }, [rows, sort, columns])
+
+  const allSelected =
+    selection && rows.length > 0 && rows.every(r => selection.selectedIds.has(getRowId(r)))
+  const someSelected =
+    selection && !allSelected && rows.some(r => selection.selectedIds.has(getRowId(r)))
+
+  const toggleAll = () => {
+    if (!selection) return
+    const next = new Set(selection.selectedIds)
+    if (allSelected) {
+      rows.forEach(r => next.delete(getRowId(r)))
+    } else {
+      rows.forEach(r => next.add(getRowId(r)))
+    }
+    selection.onSelectionChange(next)
+  }
+
+  const toggleRow = (id: string) => {
+    if (!selection) return
+    const next = new Set(selection.selectedIds)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    selection.onSelectionChange(next)
+  }
+
+  const handleHeaderClick = (column: DataTableColumn<T>) => {
+    if (!column.sortable || !onSortChange) return
+    if (sort?.key === column.key) {
+      onSortChange({
+        key: column.key,
+        direction: sort.direction === 'asc' ? 'desc' : 'asc',
+      })
+    } else {
+      onSortChange({ key: column.key, direction: 'asc' })
+    }
+  }
+
+  const alignClass = (align?: 'left' | 'center' | 'right') => {
+    if (align === 'center') return 'text-center'
+    if (align === 'right') return 'text-right'
+    return 'text-left'
+  }
+
+  const showEmpty = !loading && rows.length === 0 && emptyState
+  const EmptyIcon = emptyState?.icon
+
+  return (
+    <div
+      className={`overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm ${className}`}
+    >
+      <div className='overflow-x-auto'>
+        <table className='w-full border-collapse text-sm'>
+          <thead>
+            <tr className='border-b border-slate-200 bg-slate-50/50 text-xs font-semibold uppercase tracking-wide text-slate-500'>
+              {selection && (
+                <th className='w-10 px-4 py-3'>
+                  <input
+                    type='checkbox'
+                    className='h-4 w-4 cursor-pointer rounded border-slate-300 text-blue-600 focus:ring-blue-500'
+                    checked={!!allSelected}
+                    ref={el => {
+                      if (el) el.indeterminate = !!someSelected
+                    }}
+                    onChange={toggleAll}
+                    aria-label='Sélectionner toutes les lignes'
+                  />
+                </th>
+              )}
+              {columns.map(col => {
+                const isActive = sort?.key === col.key
+                return (
+                  <th
+                    key={col.key}
+                    className={`px-4 py-3 ${alignClass(col.align)} ${col.headerClassName ?? ''} ${
+                      col.sortable ? 'cursor-pointer select-none hover:text-slate-700' : ''
+                    }`}
+                    onClick={() => handleHeaderClick(col)}
+                  >
+                    <span className='inline-flex items-center gap-1'>
+                      {col.header}
+                      {col.sortable && (
+                        <span className='text-slate-400'>
+                          {isActive && sort?.direction === 'asc' ? (
+                            <ChevronUp className='h-3 w-3' />
+                          ) : isActive && sort?.direction === 'desc' ? (
+                            <ChevronDown className='h-3 w-3' />
+                          ) : (
+                            <ChevronDown className='h-3 w-3 opacity-30' />
+                          )}
+                        </span>
+                      )}
+                    </span>
+                  </th>
+                )
+              })}
+              {rowActions && <th className='w-10 px-4 py-3' />}
+            </tr>
+          </thead>
+          <tbody className='divide-y divide-slate-100'>
+            {loading ? (
+              Array.from({ length: skeletonRows }).map((_, i) => (
+                <tr key={`skeleton-${i}`} className='animate-pulse'>
+                  {selection && (
+                    <td className='px-4 py-4'>
+                      <div className='h-4 w-4 rounded bg-slate-200' />
+                    </td>
+                  )}
+                  {columns.map(col => (
+                    <td key={col.key} className='px-4 py-4'>
+                      <div className='h-4 w-3/4 rounded bg-slate-200' />
+                    </td>
+                  ))}
+                  {rowActions && (
+                    <td className='px-4 py-4'>
+                      <div className='h-6 w-6 rounded bg-slate-200' />
+                    </td>
+                  )}
+                </tr>
+              ))
+            ) : sortedRows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={columns.length + (selection ? 1 : 0) + (rowActions ? 1 : 0)}
+                  className='px-4 py-16'
+                >
+                  {showEmpty && (
+                    <div className='flex flex-col items-center justify-center text-center'>
+                      <div className='mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-slate-100 text-slate-400'>
+                        {EmptyIcon ? <EmptyIcon className='h-7 w-7' /> : null}
+                      </div>
+                      <h3 className='text-base font-semibold text-slate-900'>
+                        {emptyState.title}
+                      </h3>
+                      {emptyState.subtitle && (
+                        <p className='mt-1 max-w-sm text-sm text-slate-500'>
+                          {emptyState.subtitle}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </td>
+              </tr>
+            ) : (
+              sortedRows.map(row => {
+                const id = getRowId(row)
+                const isSelected = selection?.selectedIds.has(id)
+                return (
+                  <tr
+                    key={id}
+                    className={`transition ${isSelected ? 'bg-blue-50/40' : 'hover:bg-slate-50/60'}`}
+                  >
+                    {selection && (
+                      <td className='px-4 py-3'>
+                        <input
+                          type='checkbox'
+                          className='h-4 w-4 cursor-pointer rounded border-slate-300 text-blue-600 focus:ring-blue-500'
+                          checked={!!isSelected}
+                          onChange={() => toggleRow(id)}
+                          aria-label={`Sélectionner la ligne ${id}`}
+                        />
+                      </td>
+                    )}
+                    {columns.map(col => (
+                      <td
+                        key={col.key}
+                        className={`px-4 py-3 ${alignClass(col.align)} ${col.cellClassName ?? ''}`}
+                      >
+                        {col.render(row)}
+                      </td>
+                    ))}
+                    {rowActions && (
+                      <td className='px-4 py-3 text-right'>{rowActions(row)}</td>
+                    )}
+                  </tr>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/ui/FilterBar.tsx
+++ b/src/components/admin/ui/FilterBar.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import React from 'react'
+import { Search, X } from 'lucide-react'
+
+interface FilterBarProps {
+  /** Current search value. */
+  searchValue: string
+  onSearchChange: (value: string) => void
+  searchPlaceholder?: string
+  /** Right-side slot for custom filters (selects, buttons, etc.). */
+  rightSlot?: React.ReactNode
+  /** Below-slot for secondary controls (active filter chips, bulk actions...). */
+  belowSlot?: React.ReactNode
+  className?: string
+}
+
+/**
+ * Shared filter bar for admin list pages.
+ *
+ * Layout:
+ *   [ 🔍 search input .................. ]  [ filters slot ]
+ *   [ (optional) below slot: chips / bulk actions bar       ]
+ */
+export function FilterBar({
+  searchValue,
+  onSearchChange,
+  searchPlaceholder = 'Rechercher…',
+  rightSlot,
+  belowSlot,
+  className = '',
+}: FilterBarProps) {
+  return (
+    <div
+      className={`rounded-2xl border border-slate-200/80 bg-white/80 p-4 shadow-sm backdrop-blur-sm ${className}`}
+    >
+      <div className='flex flex-col gap-3 md:flex-row md:items-center md:justify-between'>
+        <div className='relative flex-1 md:max-w-md'>
+          <Search className='pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400' />
+          <input
+            type='text'
+            value={searchValue}
+            onChange={e => onSearchChange(e.target.value)}
+            placeholder={searchPlaceholder}
+            className='w-full rounded-xl border border-slate-200 bg-white py-2.5 pl-10 pr-10 text-sm text-slate-900 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100'
+          />
+          {searchValue && (
+            <button
+              type='button'
+              onClick={() => onSearchChange('')}
+              className='absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600'
+              aria-label='Effacer la recherche'
+            >
+              <X className='h-4 w-4' />
+            </button>
+          )}
+        </div>
+
+        {rightSlot && <div className='flex flex-wrap items-center gap-2'>{rightSlot}</div>}
+      </div>
+
+      {belowSlot && <div className='mt-3 border-t border-slate-100 pt-3'>{belowSlot}</div>}
+    </div>
+  )
+}

--- a/src/components/admin/ui/KpiCard.tsx
+++ b/src/components/admin/ui/KpiCard.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { LucideIcon } from 'lucide-react'
+
+/**
+ * Color palette used by the primary KpiCard variant.
+ * Each tone provides a matching icon background and text color.
+ */
+export type KpiTone =
+  | 'slate'
+  | 'blue'
+  | 'indigo'
+  | 'emerald'
+  | 'amber'
+  | 'orange'
+  | 'red'
+  | 'purple'
+
+const TONE_CLASSES: Record<KpiTone, { bg: string; text: string; ring: string }> = {
+  slate: { bg: 'bg-slate-100', text: 'text-slate-700', ring: 'hover:ring-slate-200' },
+  blue: { bg: 'bg-blue-50', text: 'text-blue-600', ring: 'hover:ring-blue-200' },
+  indigo: { bg: 'bg-indigo-50', text: 'text-indigo-600', ring: 'hover:ring-indigo-200' },
+  emerald: {
+    bg: 'bg-emerald-50',
+    text: 'text-emerald-600',
+    ring: 'hover:ring-emerald-200',
+  },
+  amber: { bg: 'bg-amber-50', text: 'text-amber-600', ring: 'hover:ring-amber-200' },
+  orange: {
+    bg: 'bg-orange-50',
+    text: 'text-orange-600',
+    ring: 'hover:ring-orange-200',
+  },
+  red: { bg: 'bg-red-50', text: 'text-red-600', ring: 'hover:ring-red-200' },
+  purple: {
+    bg: 'bg-purple-50',
+    text: 'text-purple-600',
+    ring: 'hover:ring-purple-200',
+  },
+}
+
+interface KpiCardProps {
+  label: string
+  value: number | string
+  hint?: string
+  icon: LucideIcon
+  tone?: KpiTone
+  /** If provided, the card becomes a link to this href. */
+  href?: string
+  /** Loading state — renders a skeleton. */
+  loading?: boolean
+}
+
+/**
+ * Primary KpiCard — large card with big number, icon, and label.
+ * Used for the hero KPI row on admin dashboards.
+ */
+export function KpiCard({
+  label,
+  value,
+  hint,
+  icon: Icon,
+  tone = 'slate',
+  href,
+  loading = false,
+}: KpiCardProps) {
+  const toneClass = TONE_CLASSES[tone]
+
+  if (loading) {
+    return (
+      <div className='relative overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm'>
+        <div className='flex items-start justify-between gap-4'>
+          <div className='flex-1 space-y-2'>
+            <div className='h-4 w-24 animate-pulse rounded bg-slate-200' />
+            <div className='h-9 w-16 animate-pulse rounded bg-slate-200' />
+            <div className='h-3 w-32 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='h-12 w-12 animate-pulse rounded-xl bg-slate-200' />
+        </div>
+      </div>
+    )
+  }
+
+  const content = (
+    <div
+      className={`relative overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm ring-1 ring-transparent transition hover:shadow-md ${toneClass.ring}`}
+    >
+      <div className='flex items-start justify-between gap-4'>
+        <div className='space-y-1'>
+          <p className='text-sm font-medium text-slate-500'>{label}</p>
+          <p className={`text-4xl font-bold tracking-tight tabular-nums ${toneClass.text}`}>
+            {value}
+          </p>
+          {hint && <p className='text-xs text-slate-500'>{hint}</p>}
+        </div>
+        <div
+          className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-xl ${toneClass.bg} ${toneClass.text}`}
+        >
+          <Icon className='h-6 w-6' />
+        </div>
+      </div>
+    </div>
+  )
+
+  if (href) {
+    return (
+      <Link href={href} className='block'>
+        {content}
+      </Link>
+    )
+  }
+  return content
+}
+
+interface KpiMetricProps {
+  label: string
+  value: number | string
+  icon: LucideIcon
+  tone?: 'slate' | 'emerald' | 'red' | 'blue'
+  href?: string
+  loading?: boolean
+}
+
+const SECONDARY_TONE: Record<
+  NonNullable<KpiMetricProps['tone']>,
+  string
+> = {
+  slate: 'text-slate-600',
+  emerald: 'text-emerald-600',
+  red: 'text-red-600',
+  blue: 'text-blue-600',
+}
+
+/**
+ * Secondary metric chip — compact horizontal row with icon + value + label.
+ * Used for context metrics alongside the primary KpiCard row.
+ */
+export function KpiMetric({
+  label,
+  value,
+  icon: Icon,
+  tone = 'slate',
+  href,
+  loading = false,
+}: KpiMetricProps) {
+  const toneClass = SECONDARY_TONE[tone]
+
+  if (loading) {
+    return (
+      <div className='flex items-center gap-3 rounded-xl border border-slate-200/80 bg-white/60 px-4 py-3 backdrop-blur-sm'>
+        <div className='h-5 w-5 animate-pulse rounded bg-slate-200' />
+        <div className='flex flex-1 items-center gap-2'>
+          <div className='h-6 w-10 animate-pulse rounded bg-slate-200' />
+          <div className='h-4 w-24 animate-pulse rounded bg-slate-200' />
+        </div>
+      </div>
+    )
+  }
+
+  const content = (
+    <div className='flex items-center gap-3 rounded-xl border border-slate-200/80 bg-white/60 px-4 py-3 backdrop-blur-sm transition hover:bg-white'>
+      <div className={toneClass}>
+        <Icon className='h-5 w-5' />
+      </div>
+      <div className='flex items-baseline gap-2'>
+        <span className={`text-2xl font-semibold tabular-nums ${toneClass}`}>{value}</span>
+        <span className='text-sm font-medium text-slate-600'>{label}</span>
+      </div>
+    </div>
+  )
+
+  if (href) {
+    return (
+      <Link href={href} className='block'>
+        {content}
+      </Link>
+    )
+  }
+  return content
+}

--- a/src/components/admin/ui/PageHeader.tsx
+++ b/src/components/admin/ui/PageHeader.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+import { ArrowLeft, LucideIcon } from 'lucide-react'
+import { Button } from '@/components/ui/shadcnui/button'
+
+interface PageHeaderProps {
+  /** Small uppercase pill shown above the title (e.g. "Espace administrateur"). */
+  eyebrow?: string
+  /** Optional icon displayed inside the eyebrow pill. */
+  eyebrowIcon?: LucideIcon
+  /** Main page title. Rendered with a gradient. */
+  title: string
+  /** Optional subtitle / description under the title. */
+  subtitle?: string
+  /** Optional breadcrumb back link shown above the header. */
+  backHref?: string
+  /** Label for the back link. Defaults to "Retour". */
+  backLabel?: string
+  /** Right-side actions slot (buttons, etc.). */
+  actions?: React.ReactNode
+}
+
+/**
+ * Unified page header for admin pages.
+ *
+ * Layout:
+ *   [ ← back link                                           ]
+ *   [ eyebrow pill                        [right actions] ]
+ *   [ gradient title                                       ]
+ *   [ subtitle                                             ]
+ */
+export function PageHeader({
+  eyebrow,
+  eyebrowIcon: EyebrowIcon,
+  title,
+  subtitle,
+  backHref,
+  backLabel = 'Retour',
+  actions,
+}: PageHeaderProps) {
+  return (
+    <div className='space-y-4'>
+      {backHref && (
+        <motion.div
+          initial={{ opacity: 0, x: -8 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.3 }}
+        >
+          <Button
+            variant='ghost'
+            size='sm'
+            asChild
+            className='text-slate-600 hover:text-slate-900'
+          >
+            <Link href={backHref}>
+              <ArrowLeft className='mr-2 h-4 w-4' />
+              {backLabel}
+            </Link>
+          </Button>
+        </motion.div>
+      )}
+
+      <div className='flex flex-col gap-4 md:flex-row md:items-start md:justify-between'>
+        <div className='space-y-3'>
+          {eyebrow && (
+            <span className='inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700'>
+              {EyebrowIcon && <EyebrowIcon className='h-3.5 w-3.5' />}
+              {eyebrow}
+            </span>
+          )}
+          <h1 className='bg-gradient-to-r from-slate-900 via-blue-800 to-indigo-800 bg-clip-text text-4xl font-bold tracking-tight text-transparent md:text-5xl'>
+            {title}
+          </h1>
+          {subtitle && (
+            <p className='max-w-2xl text-base text-slate-600'>{subtitle}</p>
+          )}
+        </div>
+
+        {actions && <div className='shrink-0'>{actions}</div>}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/ui/PriorityList.tsx
+++ b/src/components/admin/ui/PriorityList.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { ArrowRight, Check, LucideIcon } from 'lucide-react'
+
+interface PriorityItemProps {
+  icon: LucideIcon
+  title: string
+  description: string
+  count: number
+  href: string
+  /** Color tone for the count badge + icon. */
+  tone: 'amber' | 'blue' | 'purple' | 'emerald' | 'red'
+}
+
+const TONE: Record<
+  PriorityItemProps['tone'],
+  { iconBg: string; iconText: string; badge: string; hoverBorder: string }
+> = {
+  amber: {
+    iconBg: 'bg-amber-50',
+    iconText: 'text-amber-600',
+    badge: 'bg-amber-100 text-amber-800 ring-1 ring-amber-200',
+    hoverBorder: 'hover:border-amber-300',
+  },
+  blue: {
+    iconBg: 'bg-blue-50',
+    iconText: 'text-blue-600',
+    badge: 'bg-blue-100 text-blue-800 ring-1 ring-blue-200',
+    hoverBorder: 'hover:border-blue-300',
+  },
+  purple: {
+    iconBg: 'bg-purple-50',
+    iconText: 'text-purple-600',
+    badge: 'bg-purple-100 text-purple-800 ring-1 ring-purple-200',
+    hoverBorder: 'hover:border-purple-300',
+  },
+  emerald: {
+    iconBg: 'bg-emerald-50',
+    iconText: 'text-emerald-600',
+    badge: 'bg-emerald-100 text-emerald-800 ring-1 ring-emerald-200',
+    hoverBorder: 'hover:border-emerald-300',
+  },
+  red: {
+    iconBg: 'bg-red-50',
+    iconText: 'text-red-600',
+    badge: 'bg-red-100 text-red-800 ring-1 ring-red-200',
+    hoverBorder: 'hover:border-red-300',
+  },
+}
+
+function PriorityItem({
+  icon: Icon,
+  title,
+  description,
+  count,
+  href,
+  tone,
+}: PriorityItemProps) {
+  const toneClass = TONE[tone]
+
+  return (
+    <Link
+      href={href}
+      className={`group flex items-center gap-4 rounded-xl border border-slate-200/80 bg-white p-4 transition hover:shadow-md ${toneClass.hoverBorder}`}
+    >
+      <div
+        className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl ${toneClass.iconBg} ${toneClass.iconText}`}
+      >
+        <Icon className='h-5 w-5' />
+      </div>
+      <div className='min-w-0 flex-1'>
+        <p className='truncate text-sm font-semibold text-slate-900'>{title}</p>
+        <p className='truncate text-xs text-slate-500'>{description}</p>
+      </div>
+      <span
+        className={`inline-flex h-7 min-w-[2rem] items-center justify-center rounded-full px-2.5 text-sm font-bold tabular-nums ${toneClass.badge}`}
+      >
+        {count}
+      </span>
+      <ArrowRight className='h-4 w-4 shrink-0 text-slate-300 transition group-hover:translate-x-0.5 group-hover:text-slate-600' />
+    </Link>
+  )
+}
+
+interface PriorityListProps {
+  title?: string
+  items: PriorityItemProps[]
+  loading?: boolean
+  /** Message shown when there are no items with count > 0. */
+  emptyTitle?: string
+  emptySubtitle?: string
+}
+
+/**
+ * A vertical list of prioritized actions for the admin dashboard.
+ * Items with count === 0 are hidden by default, and if no items remain
+ * an "all clear" empty state is rendered instead.
+ */
+export function PriorityList({
+  title = 'Priorités du jour',
+  items,
+  loading = false,
+  emptyTitle = 'Tout est à jour',
+  emptySubtitle = "Aucune action urgente ne vous attend. Profitez-en pour explorer le reste du panel.",
+}: PriorityListProps) {
+  const visibleItems = items.filter(i => i.count > 0)
+
+  return (
+    <div className='rounded-2xl border border-slate-200/80 bg-white/80 p-6 shadow-sm backdrop-blur-sm'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h2 className='text-lg font-semibold text-slate-900'>{title}</h2>
+        {!loading && visibleItems.length > 0 && (
+          <span className='rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-600'>
+            {visibleItems.length} {visibleItems.length > 1 ? 'actions' : 'action'}
+          </span>
+        )}
+      </div>
+
+      {loading ? (
+        <div className='space-y-3'>
+          {[0, 1, 2].map(i => (
+            <div
+              key={i}
+              className='flex items-center gap-4 rounded-xl border border-slate-200/80 bg-white p-4'
+            >
+              <div className='h-11 w-11 animate-pulse rounded-xl bg-slate-200' />
+              <div className='flex-1 space-y-2'>
+                <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+                <div className='h-3 w-56 animate-pulse rounded bg-slate-200' />
+              </div>
+              <div className='h-7 w-10 animate-pulse rounded-full bg-slate-200' />
+            </div>
+          ))}
+        </div>
+      ) : visibleItems.length === 0 ? (
+        <div className='flex flex-col items-center justify-center rounded-xl border border-dashed border-emerald-200 bg-emerald-50/40 py-10 px-6 text-center'>
+          <div className='mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-600'>
+            <Check className='h-6 w-6' />
+          </div>
+          <h3 className='text-base font-semibold text-slate-900'>{emptyTitle}</h3>
+          <p className='mt-1 max-w-sm text-sm text-slate-500'>{emptySubtitle}</p>
+        </div>
+      ) : (
+        <div className='space-y-3'>
+          {visibleItems.map(item => (
+            <PriorityItem key={item.href} {...item} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/ui/TaxonomyManager.tsx
+++ b/src/components/admin/ui/TaxonomyManager.tsx
@@ -1,0 +1,627 @@
+'use client'
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { motion } from 'framer-motion'
+import { LucideIcon, Plus, Edit, Trash2, Loader2, AlertTriangle } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { PageHeader } from './PageHeader'
+import { KpiCard, type KpiTone } from './KpiCard'
+import { FilterBar } from './FilterBar'
+import { DataTable, type DataTableColumn } from './DataTable'
+import { Button } from '@/components/ui/shadcnui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/shadcnui/dialog'
+import { Input } from '@/components/ui/shadcnui/input'
+import { Label } from '@/components/ui/shadcnui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+/**
+ * Data adapter for a taxonomy entity. Provides the four CRUD operations.
+ * Implementations may wrap REST fetch calls or direct service function calls.
+ */
+export interface TaxonomyAdapter<T, FormData> {
+  fetchAll: () => Promise<T[]>
+  create: (data: FormData) => Promise<T | null>
+  update: (id: string, data: FormData) => Promise<T | null>
+  /** Delete the item. Return true on success. Throw an Error with a readable message on failure. */
+  delete: (id: string) => Promise<boolean>
+}
+
+type FieldType = 'text' | 'textarea' | 'number' | 'select'
+
+/**
+ * Describes a single form field in the add/edit dialog.
+ */
+export interface TaxonomyField<FormData> {
+  name: keyof FormData & string
+  label: string
+  type: FieldType
+  required?: boolean
+  placeholder?: string
+  help?: string
+  /** Required when `type === 'select'`. */
+  options?: Array<{ value: string; label: string }>
+  /** Applied to <input type="number">. */
+  step?: string
+  min?: string
+}
+
+export interface TaxonomyManagerProps<T, FormData extends object> {
+  /** PageHeader eyebrow pill (e.g. "Espace administrateur"). */
+  eyebrow?: string
+  eyebrowIcon?: LucideIcon
+  /** Main page title. */
+  title: string
+  subtitle?: string
+  backHref?: string
+  backLabel?: string
+
+  /** Lucide icon representing this taxonomy. Used in KPIs and empty state. */
+  icon: LucideIcon
+  /** Optional color tone for the primary KPI. */
+  kpiTone?: KpiTone
+
+  /** Singular French label used in labels/toasts (e.g. "un point fort"). */
+  itemLabelSingular: string
+  /** Plural French label used in KPI hints (e.g. "points forts"). */
+  itemLabelPlural: string
+
+  /** Placeholder for the search input. */
+  searchPlaceholder?: string
+  /** Extracts a stable id from an item (used by DataTable). */
+  getItemId: (item: T) => string
+  /** Returns the display name (used in dialogs and delete confirmation). */
+  getItemName: (item: T) => string
+  /** Returns the "number of products using this" count. Return `undefined` if not applicable. */
+  getItemCount?: (item: T) => number
+  /** Returns true if the item matches the given lowercased query. */
+  searchMatches: (item: T, queryLower: string) => boolean
+
+  /** Columns to render in addition to the mandatory "Nom" column (which is auto-rendered). */
+  extraColumns?: Array<DataTableColumn<T>>
+
+  /** Form field definitions — determine what appears in the add/edit dialog. */
+  fields: Array<TaxonomyField<FormData>>
+  /** Empty form data used when opening "add" dialog and after reset. */
+  emptyFormData: FormData
+  /** Converts an item to form data when opening the "edit" dialog. */
+  toFormData: (item: T) => FormData
+  /** Custom client-side validation. Return an error message to block submit, or null to pass. */
+  validate?: (formData: FormData) => string | null
+
+  /** Data adapter backing this taxonomy. */
+  adapter: TaxonomyAdapter<T, FormData>
+}
+
+/**
+ * Generic, reusable CRUD manager for admin taxonomy pages.
+ *
+ * Provides PageHeader, KPI summary, search + DataTable, add/edit dialog, and a
+ * delete confirmation dialog. Specialises per-page via the `fields`, `adapter`,
+ * and `extraColumns` props.
+ */
+export function TaxonomyManager<T, FormData extends object>(
+  props: TaxonomyManagerProps<T, FormData>
+) {
+  const {
+    eyebrow,
+    eyebrowIcon,
+    title,
+    subtitle,
+    backHref,
+    backLabel,
+    icon: Icon,
+    kpiTone = 'blue',
+    itemLabelSingular,
+    itemLabelPlural,
+    searchPlaceholder,
+    getItemId,
+    getItemName,
+    getItemCount,
+    searchMatches,
+    extraColumns = [],
+    fields,
+    emptyFormData,
+    toFormData,
+    validate,
+    adapter,
+  } = props
+
+  const [items, setItems] = useState<T[]>([])
+  const [loading, setLoading] = useState(true)
+  const [searchValue, setSearchValue] = useState('')
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingItem, setEditingItem] = useState<T | null>(null)
+  const [formData, setFormData] = useState<FormData>(emptyFormData)
+  const [submitting, setSubmitting] = useState(false)
+
+  const [deleteTarget, setDeleteTarget] = useState<T | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  const fetchItems = useCallback(async () => {
+    try {
+      setLoading(true)
+      const result = await adapter.fetchAll()
+      setItems(result ?? [])
+    } catch (error) {
+      console.error(`Erreur lors du chargement des ${itemLabelPlural}:`, error)
+      toast.error(`Erreur lors du chargement des ${itemLabelPlural}`)
+    } finally {
+      setLoading(false)
+    }
+    // adapter is expected to be stable; itemLabelPlural is a primitive string
+  }, [adapter, itemLabelPlural])
+
+  useEffect(() => {
+    fetchItems()
+  }, [fetchItems])
+
+  const filteredItems = useMemo(() => {
+    const query = searchValue.trim().toLowerCase()
+    if (!query) return items
+    return items.filter(item => searchMatches(item, query))
+  }, [items, searchValue, searchMatches])
+
+  const stats = useMemo(() => {
+    const total = items.length
+    if (!getItemCount) return { total, inUse: 0, unused: 0, totalUsages: 0 }
+    let inUse = 0
+    let totalUsages = 0
+    for (const item of items) {
+      const count = getItemCount(item) ?? 0
+      totalUsages += count
+      if (count > 0) inUse += 1
+    }
+    return { total, inUse, unused: total - inUse, totalUsages }
+  }, [items, getItemCount])
+
+  const openAddDialog = () => {
+    setEditingItem(null)
+    setFormData(emptyFormData)
+    setDialogOpen(true)
+  }
+
+  const openEditDialog = (item: T) => {
+    setEditingItem(item)
+    setFormData(toFormData(item))
+    setDialogOpen(true)
+  }
+
+  const closeDialog = () => {
+    if (submitting) return
+    setDialogOpen(false)
+    setEditingItem(null)
+    setFormData(emptyFormData)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (validate) {
+      const error = validate(formData)
+      if (error) {
+        toast.error(error)
+        return
+      }
+    } else {
+      // Default: require every `required` field to be non-empty
+      for (const field of fields) {
+        if (field.required) {
+          const value = formData[field.name]
+          if (value === undefined || value === null || String(value).trim() === '') {
+            toast.error(`${field.label} est requis`)
+            return
+          }
+        }
+      }
+    }
+
+    try {
+      setSubmitting(true)
+      if (editingItem) {
+        const updated = await adapter.update(getItemId(editingItem), formData)
+        if (!updated) {
+          toast.error('Erreur lors de la mise à jour')
+          return
+        }
+        toast.success(`${capitalize(itemLabelSingular)} mis à jour`)
+      } else {
+        const created = await adapter.create(formData)
+        if (!created) {
+          toast.error('Erreur lors de la création')
+          return
+        }
+        toast.success(`${capitalize(itemLabelSingular)} créé`)
+      }
+      setDialogOpen(false)
+      setEditingItem(null)
+      setFormData(emptyFormData)
+      // Refetch to pick up derived fields such as `_count.products`.
+      await fetchItems()
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Erreur lors de la sauvegarde'
+      toast.error(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return
+    try {
+      setDeleting(true)
+      const success = await adapter.delete(getItemId(deleteTarget))
+      if (!success) {
+        toast.error('Erreur lors de la suppression')
+        return
+      }
+      toast.success(`${capitalize(itemLabelSingular)} supprimé`)
+      setDeleteTarget(null)
+      await fetchItems()
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Erreur lors de la suppression'
+      toast.error(message)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  const nameColumn: DataTableColumn<T> = {
+    key: 'name',
+    header: 'Nom',
+    sortable: true,
+    sortAccessor: item => getItemName(item).toLowerCase(),
+    render: item => (
+      <div className='flex items-center gap-3 min-w-0'>
+        <div className='flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-600'>
+          <Icon className='h-4 w-4' />
+        </div>
+        <p className='truncate text-sm font-semibold text-slate-900'>
+          {getItemName(item)}
+        </p>
+      </div>
+    ),
+  }
+
+  const countColumn: DataTableColumn<T> | null = getItemCount
+    ? {
+        key: 'count',
+        header: 'Utilisations',
+        sortable: true,
+        sortAccessor: item => getItemCount(item) ?? 0,
+        align: 'right',
+        render: item => {
+          const count = getItemCount(item) ?? 0
+          return (
+            <span
+              className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${
+                count > 0
+                  ? 'bg-blue-50 text-blue-700 ring-blue-200'
+                  : 'bg-slate-50 text-slate-600 ring-slate-200'
+              }`}
+            >
+              {count} produit{count > 1 ? 's' : ''}
+            </span>
+          )
+        },
+        cellClassName: 'whitespace-nowrap',
+      }
+    : null
+
+  const columns: Array<DataTableColumn<T>> = [
+    nameColumn,
+    ...extraColumns,
+    ...(countColumn ? [countColumn] : []),
+  ]
+
+  return (
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <PageHeader
+          backHref={backHref}
+          backLabel={backLabel}
+          eyebrow={eyebrow}
+          eyebrowIcon={eyebrowIcon}
+          title={title}
+          subtitle={subtitle}
+          actions={
+            <Button onClick={openAddDialog} className='gap-2'>
+              <Plus className='h-4 w-4' />
+              Ajouter
+            </Button>
+          }
+        />
+
+        {/* KPI row */}
+        <div
+          className={`grid gap-4 ${
+            getItemCount ? 'md:grid-cols-2 lg:grid-cols-3' : 'md:grid-cols-2'
+          }`}
+        >
+          <KpiCard
+            label={`Total ${itemLabelPlural}`}
+            value={stats.total}
+            hint='enregistrés dans le catalogue'
+            icon={Icon}
+            tone={kpiTone}
+            loading={loading}
+          />
+          {getItemCount && (
+            <>
+              <KpiCard
+                label='Utilisés'
+                value={stats.inUse}
+                hint={`sur ${stats.total} au total`}
+                icon={Icon}
+                tone='emerald'
+                loading={loading}
+              />
+              <KpiCard
+                label='Associations totales'
+                value={stats.totalUsages}
+                hint={`produit${stats.totalUsages > 1 ? 's' : ''} concerné${stats.totalUsages > 1 ? 's' : ''}`}
+                icon={Icon}
+                tone='indigo'
+                loading={loading}
+              />
+            </>
+          )}
+          {!getItemCount && (
+            <KpiCard
+              label='Affichés'
+              value={filteredItems.length}
+              hint='après filtres'
+              icon={Icon}
+              tone='indigo'
+              loading={loading}
+            />
+          )}
+        </div>
+
+        {/* Search */}
+        <FilterBar
+          searchValue={searchValue}
+          onSearchChange={setSearchValue}
+          searchPlaceholder={searchPlaceholder ?? `Rechercher un ${itemLabelSingular}…`}
+        />
+
+        {/* Data table */}
+        <DataTable<T>
+          columns={columns}
+          rows={filteredItems}
+          getRowId={getItemId}
+          loading={loading}
+          rowActions={item => (
+            <div className='flex items-center justify-end gap-1'>
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={() => openEditDialog(item)}
+                className='text-slate-600 hover:text-slate-900'
+              >
+                <Edit className='h-4 w-4' />
+              </Button>
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={() => setDeleteTarget(item)}
+                className='text-red-600 hover:bg-red-50 hover:text-red-700'
+              >
+                <Trash2 className='h-4 w-4' />
+              </Button>
+            </div>
+          )}
+          emptyState={{
+            icon: Icon,
+            title: `Aucun ${itemLabelSingular}`,
+            subtitle:
+              searchValue.trim().length > 0
+                ? 'Essayez d’ajuster votre recherche.'
+                : `Commencez par ajouter votre premier ${itemLabelSingular}.`,
+          }}
+        />
+      </motion.div>
+
+      {/* Add / edit dialog */}
+      <Dialog open={dialogOpen} onOpenChange={open => !open && closeDialog()}>
+        <DialogContent className='sm:max-w-[520px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 ring-1 ring-blue-100'>
+                <Icon className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>
+                  {editingItem ? 'Modifier' : 'Ajouter'} {itemLabelSingular}
+                </DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  {editingItem
+                    ? `Mettez à jour les informations de ${itemLabelSingular}.`
+                    : `Créez ${itemLabelSingular} pour le catalogue.`}
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <form onSubmit={handleSubmit} className='space-y-4 py-2'>
+            {fields.map(field => (
+              <div key={field.name} className='space-y-1.5'>
+                <Label htmlFor={field.name}>
+                  {field.label}
+                  {field.required && <span className='ml-0.5 text-red-500'>*</span>}
+                </Label>
+                {field.type === 'textarea' ? (
+                  <textarea
+                    id={field.name}
+                    value={(formData[field.name] as string | undefined) ?? ''}
+                    onChange={e =>
+                      setFormData(prev => ({ ...prev, [field.name]: e.target.value }))
+                    }
+                    rows={3}
+                    placeholder={field.placeholder}
+                    className='w-full resize-none rounded-md border border-slate-200 bg-white p-3 text-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20'
+                  />
+                ) : field.type === 'select' ? (
+                  <Select
+                    value={(formData[field.name] as string | undefined) ?? ''}
+                    onValueChange={value =>
+                      setFormData(prev => ({ ...prev, [field.name]: value }))
+                    }
+                  >
+                    <SelectTrigger id={field.name}>
+                      <SelectValue placeholder={field.placeholder ?? 'Sélectionner…'} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {field.options?.map(opt => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <Input
+                    id={field.name}
+                    type={field.type === 'number' ? 'number' : 'text'}
+                    step={field.step}
+                    min={field.min}
+                    value={(formData[field.name] as string | number | undefined) ?? ''}
+                    onChange={e =>
+                      setFormData(prev => ({
+                        ...prev,
+                        [field.name]:
+                          field.type === 'number' ? e.target.value : e.target.value,
+                      }))
+                    }
+                    placeholder={field.placeholder}
+                  />
+                )}
+                {field.help && <p className='text-xs text-slate-500'>{field.help}</p>}
+              </div>
+            ))}
+
+            <DialogFooter className='gap-2 pt-2'>
+              <Button
+                type='button'
+                variant='outline'
+                onClick={closeDialog}
+                disabled={submitting}
+              >
+                Annuler
+              </Button>
+              <Button type='submit' disabled={submitting} className='gap-2'>
+                {submitting ? (
+                  <>
+                    <Loader2 className='h-4 w-4 animate-spin' />
+                    {editingItem ? 'Mise à jour…' : 'Création…'}
+                  </>
+                ) : editingItem ? (
+                  'Mettre à jour'
+                ) : (
+                  'Créer'
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <Dialog
+        open={Boolean(deleteTarget)}
+        onOpenChange={open => !open && !deleting && setDeleteTarget(null)}
+      >
+        <DialogContent className='sm:max-w-[480px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-red-50 text-red-600 ring-1 ring-red-100'>
+                <AlertTriangle className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>
+                  Supprimer {itemLabelSingular}
+                </DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  {deleteTarget ? (
+                    <>
+                      Cette action supprimera définitivement{' '}
+                      <span className='font-semibold text-slate-900'>
+                        {getItemName(deleteTarget)}
+                      </span>
+                      . Elle est <strong>irréversible</strong>.
+                    </>
+                  ) : null}
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          {deleteTarget && getItemCount && (getItemCount(deleteTarget) ?? 0) > 0 && (
+            <div className='flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50/60 p-3 text-sm'>
+              <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0 text-amber-600' />
+              <p className='text-amber-800'>
+                Cet élément est actuellement utilisé par{' '}
+                <strong>{getItemCount(deleteTarget)}</strong> produit
+                {(getItemCount(deleteTarget) ?? 0) > 1 ? 's' : ''}. La suppression
+                pourrait affecter ces hébergements.
+              </p>
+            </div>
+          )}
+
+          <DialogFooter className='gap-2'>
+            <Button
+              variant='outline'
+              onClick={() => setDeleteTarget(null)}
+              disabled={deleting}
+            >
+              Annuler
+            </Button>
+            <Button
+              variant='destructive'
+              onClick={handleDelete}
+              disabled={deleting}
+              className='gap-2'
+            >
+              {deleting ? (
+                <>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Suppression…
+                </>
+              ) : (
+                <>
+                  <Trash2 className='h-4 w-4' />
+                  Supprimer
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import { Button } from '@/components/ui/shadcnui/button'
 import { LoginForm } from './LoginForm'
@@ -17,6 +18,22 @@ interface AuthFormProps {
 
 export const AuthForm = ({ mode = 'login' }: AuthFormProps) => {
   const router = useRouter()
+  const [backgroundImage, setBackgroundImage] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const response = await fetch('/api/homepage-settings')
+        if (response.ok) {
+          const data = await response.json()
+          setBackgroundImage(data.authBackgroundImage || null)
+        }
+      } catch (error) {
+        console.error('Error fetching homepage settings:', error)
+      }
+    }
+    fetchSettings()
+  }, [])
 
   const handleGoogleSignIn = () => {
     signIn('google', { redirectTo: '/host' })
@@ -77,17 +94,39 @@ export const AuthForm = ({ mode = 'login' }: AuthFormProps) => {
       }
     >
       <div className='flex' style={{ height: 'calc(100vh - 64px)' }}>
-        {/* Left side - Image */}
-        <div className='hidden lg:flex lg:w-1/2 bg-gradient-to-br from-orange-400 via-pink-500 to-purple-600'>
-          <div className='w-full flex flex-col items-center justify-center text-white'>
+        {/* Left side - Image or gradient fallback */}
+        <div
+          className={`relative hidden lg:flex lg:w-1/2 overflow-hidden ${
+            backgroundImage
+              ? ''
+              : 'bg-gradient-to-br from-orange-400 via-pink-500 to-purple-600'
+          }`}
+        >
+          {backgroundImage && (
+            <>
+              <Image
+                src={backgroundImage}
+                alt='Auth background'
+                fill
+                className='object-cover'
+                priority
+                sizes='50vw'
+              />
+              {/* Dark overlay to keep the white text readable whatever the image */}
+              <div className='absolute inset-0 bg-gradient-to-b from-black/50 via-black/30 to-black/50' />
+            </>
+          )}
+          <div className='relative z-10 w-full flex flex-col items-center justify-center text-white'>
             <div className='text-center'>
               <div className='text-6xl mb-4'>☀️</div>
               <h1 className='text-4xl font-bold mb-2'>Bienvenue sur Hosteed</h1>
               <p className='text-xl'>Découvrez des hébergements exceptionnels</p>
             </div>
-            <div className='absolute bottom-10'>
-              <Image src='/window.svg' alt='Window' width={64} height={64} />
-            </div>
+            {!backgroundImage && (
+              <div className='absolute bottom-10'>
+                <Image src='/window.svg' alt='Window' width={64} height={64} />
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -107,6 +107,7 @@ export const LoginForm = () => {
                 <div className='relative'>
                   <Input {...field} type={showPassword ? 'text' : 'password'} className='py-6' />
                   <Button
+                    type='button'
                     variant='ghost'
                     size='icon'
                     onClick={() => setShowPassword(!showPassword)}

--- a/src/lib/services/homepageSettings.service.ts
+++ b/src/lib/services/homepageSettings.service.ts
@@ -15,6 +15,7 @@ export async function getHomepageSettings(): Promise<HomepageSettings | null> {
 export async function updateHomepageSettings(data: {
   heroBackgroundImage?: string | null
   howItWorksImage?: string | null
+  authBackgroundImage?: string | null
 }): Promise<HomepageSettings | null> {
   try {
     // Récupérer l'enregistrement existant ou créer un nouveau

--- a/src/lib/services/stats.service.ts
+++ b/src/lib/services/stats.service.ts
@@ -1,7 +1,118 @@
 'use server'
 
 import prisma from '@/lib/prisma'
-import { ProductValidation } from '@prisma/client'
+import { ProductValidation, PaymentStatus, WithdrawalStatus } from '@prisma/client'
+
+export interface AdminDashboardStats {
+  // Actionable — drives the "Priorités" list
+  productsWaitingValidation: number
+  reviewsPendingModeration: number
+  withdrawalsPending: number
+
+  // Monthly KPIs — the hero row
+  rentsThisMonth: number
+  revenueThisMonth: number
+  newUsersThisWeek: number
+  productsWaiting: number
+
+  // Context metrics — secondary row
+  usersTotal: number
+  productsActive: number
+  rentsYearly: number
+}
+
+/**
+ * Returns all the counts and sums needed to render the admin dashboard home
+ * in a single parallel fetch. Each individual query is cheap and indexed.
+ */
+export async function getAdminDashboardStats(): Promise<AdminDashboardStats | null> {
+  try {
+    const now = new Date()
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+    const startOfNextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1)
+    const startOfYear = new Date(now.getFullYear(), 0, 1)
+    const startOfNextYear = new Date(now.getFullYear() + 1, 0, 1)
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+
+    // Any payment state beyond NOT_PAID counts as a realized booking.
+    const paidPaymentStates: PaymentStatus[] = [
+      PaymentStatus.CLIENT_PAID,
+      PaymentStatus.MID_TRANSFER_REQ,
+      PaymentStatus.MID_TRANSFER_DONE,
+      PaymentStatus.REST_TRANSFER_REQ,
+      PaymentStatus.REST_TRANSFER_DONE,
+      PaymentStatus.FULL_TRANSFER_REQ,
+      PaymentStatus.FULL_TRANSFER_DONE,
+    ]
+
+    const [
+      usersTotal,
+      newUsersThisWeek,
+      productsActive,
+      productsWaiting,
+      rentsThisMonth,
+      rentsYearly,
+      revenueThisMonthAgg,
+      reviewsPendingModeration,
+      withdrawalsPending,
+    ] = await Promise.all([
+      prisma.user.count(),
+      prisma.user.count({ where: { createdAt: { gte: sevenDaysAgo } } }),
+      prisma.product.count({
+        where: { validate: ProductValidation.Approve, isDraft: false },
+      }),
+      prisma.product.count({
+        where: {
+          isDraft: false,
+          validate: {
+            in: [ProductValidation.NotVerified, ProductValidation.RecheckRequest],
+          },
+        },
+      }),
+      prisma.rent.count({
+        where: {
+          arrivingDate: { gte: startOfMonth, lt: startOfNextMonth },
+          payment: { in: paidPaymentStates },
+        },
+      }),
+      prisma.rent.count({
+        where: {
+          arrivingDate: { gte: startOfYear, lt: startOfNextYear },
+          payment: { in: paidPaymentStates },
+        },
+      }),
+      prisma.rent.aggregate({
+        _sum: { totalAmount: true },
+        where: {
+          arrivingDate: { gte: startOfMonth, lt: startOfNextMonth },
+          payment: { in: paidPaymentStates },
+        },
+      }),
+      prisma.review.count({ where: { approved: false } }),
+      prisma.withdrawalRequest.count({
+        where: {
+          status: { in: [WithdrawalStatus.PENDING, WithdrawalStatus.ACCOUNT_VALIDATION] },
+        },
+      }),
+    ])
+
+    return {
+      productsWaitingValidation: productsWaiting,
+      reviewsPendingModeration,
+      withdrawalsPending,
+      rentsThisMonth,
+      revenueThisMonth: revenueThisMonthAgg._sum.totalAmount ?? 0,
+      newUsersThisWeek,
+      productsWaiting,
+      usersTotal,
+      productsActive,
+      rentsYearly,
+    }
+  } catch (error) {
+    console.error('Erreur lors du chargement des stats dashboard admin:', error)
+    return null
+  }
+}
 
 export async function getAdminStatsYearly() {
   try {

--- a/src/lib/utils/contentFormat.ts
+++ b/src/lib/utils/contentFormat.ts
@@ -6,3 +6,46 @@ export function isHtmlContent(content: string): boolean {
   if (!content) return false
   return /<[a-z][\s\S]*>/i.test(content.trim())
 }
+
+/**
+ * Strips HTML tags and common Markdown syntax from a string and returns a plain
+ * text preview suitable for short descriptions (cards, tooltips, etc.).
+ *
+ * This is intentionally simple and safe for previews only — it is NOT a
+ * sanitizer and must not be used to render trusted HTML back to the DOM.
+ */
+export function toPlainTextPreview(content: string | null | undefined): string {
+  if (!content) return ''
+
+  let text = content
+
+  // Remove HTML tags
+  text = text.replace(/<[^>]*>/g, ' ')
+
+  // Decode common HTML entities
+  text = text
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+
+  // Remove Markdown bold/italic/code/strikethrough markers
+  text = text
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/_([^_]+)_/g, '$1')
+    .replace(/~~([^~]+)~~/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+
+  // Remove Markdown headings (#, ##, ### ...)
+  text = text.replace(/^#{1,6}\s+/gm, '')
+
+  // Collapse whitespace
+  text = text.replace(/\s+/g, ' ').trim()
+
+  return text
+}

--- a/src/lib/utils/userAvatar.ts
+++ b/src/lib/utils/userAvatar.ts
@@ -1,0 +1,38 @@
+/**
+ * User-like shape the avatar helper needs to work with. Permissive on purpose
+ * so callers can pass any User subtype (from Prisma, from session, from a DTO).
+ */
+export interface UserAvatarSource {
+  email: string
+  image?: string | null
+  profilePicture?: string | null
+  profilePictureBase64?: string | null
+}
+
+/**
+ * Returns the best available URL to use as the user's avatar image.
+ *
+ * Priority:
+ *   1. `user.image`                  — NextAuth standard field (OAuth providers)
+ *   2. `user.profilePicture`         — Custom uploaded profile picture path/URL
+ *   3. `user.profilePictureBase64`   — Base64 data URL fallback
+ *   4. Dicebear placeholder seeded with the user's email
+ *
+ * If no real profile picture is defined, the returned Dicebear URL is a
+ * deterministic placeholder that still avoids the generic fallback initials
+ * pattern.
+ */
+export function getUserAvatarUrl(user: UserAvatarSource): string {
+  if (user.image) return user.image
+  if (user.profilePicture) return user.profilePicture
+  if (user.profilePictureBase64) return user.profilePictureBase64
+  return `https://api.dicebear.com/7.x/avataaars/svg?seed=${encodeURIComponent(user.email)}`
+}
+
+/**
+ * Convenience helper that returns `true` when the user has a real, user-uploaded
+ * profile picture (i.e. not the Dicebear fallback).
+ */
+export function hasRealProfilePicture(user: UserAvatarSource): boolean {
+  return Boolean(user.image || user.profilePicture || user.profilePictureBase64)
+}


### PR DESCRIPTION
## Summary

Promotes to production the fix for the "empty /dashboard/host on first render" bug.

Includes:
- TristanHourtoulle/hosteed#64 — fix(dashboard): keep host products visible on first mount

## Root cause recap

On `/dashboard/host`, the outer `<motion.div initial='hidden' animate='visible'>` ran its stagger orchestration immediately on mount. While React Query loaded, the empty-state branch rendered (grid subtree absent from tree). By the time data arrived and the grid subtree mounted, the outer stagger had already completed — the new card `<motion.div variants={itemVariants}>` children inherited the parent's named variant (`hidden` by default) and stayed stuck at `{ opacity: 0, y: 20 }`. Switching tabs "fixed" it because the second mount had data in cache, so the grid children were present from the first render of the subtree.

The bug was not related to: React Query cache, HTTP cache (`next.config.ts` forces `no-store` in dev), Next.js Router Cache, data ownership, or the createProduct redirect. It was purely a framer-motion orchestration timing bug, reproducible on a simple hard reload.

## Fix

Inner grid `<motion.div>` gets its own animation lifecycle:
- `key={`grid-${products.length}`}` — forces remount when data arrives so framer-motion sees a fresh subtree with card children present
- explicit `initial='hidden' animate='visible'` — independent stagger, not dependent on outer container state

## Verified scenarios

Local Chrome DevTools MCP, logged as Cathy (ADMIN, 4 owned products):
- Hard reload: cards visible, `opacity:1 transform:none` ✅
- `/createProduct` → `/dashboard/host` via next/link: ✅
- Fresh URL navigation: ✅
- Tab switch Mes annonces → Calendrier → Mes annonces: still works ✅
- Empty state branch: untouched, still renders the "Vous n'avez pas encore d'annonces" card

## Post-deploy verification

- [ ] After deploy, log in and land on `/dashboard/host` directly (hard reload) — cards should appear immediately
- [ ] Create an annonce → redirect to `/dashboard/host` — new annonce + existing ones should all appear immediately