### PR TITLE
feat(admin): configurable auth page background + login form fixes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model HomepageSettings {
   id                  String   @id @default(cuid())
   heroBackgroundImage String? // Image de fond de la Hero Section
   howItWorksImage     String? // Image de la section "Comment ça marche"
+  authBackgroundImage String? // Image de fond du panneau gauche de la page d'authentification (desktop)
   updatedAt           DateTime @updatedAt
   createdAt           DateTime @default(now())
 

--- a/src/app/admin/homepage/page.tsx
+++ b/src/app/admin/homepage/page.tsx
@@ -55,6 +55,7 @@ export default function HomepageSettingsPage() {
 
   const [heroImage, setHeroImage] = useState<string | null>(null)
   const [howItWorksImage, setHowItWorksImage] = useState<string | null>(null)
+  const [authImage, setAuthImage] = useState<string | null>(null)
 
   useEffect(() => {
     if (isAuthenticated && (!session?.user?.roles || !isAdmin(session.user.roles))) {
@@ -70,6 +71,7 @@ export default function HomepageSettingsPage() {
           const data = await response.json()
           setHeroImage(data.heroBackgroundImage || null)
           setHowItWorksImage(data.howItWorksImage || null)
+          setAuthImage(data.authBackgroundImage || null)
         }
       } catch (err) {
         setError('Erreur lors du chargement des paramètres')
@@ -93,6 +95,7 @@ export default function HomepageSettingsPage() {
         body: JSON.stringify({
           heroBackgroundImage: heroImage,
           howItWorksImage: howItWorksImage,
+          authBackgroundImage: authImage,
         }),
       })
 
@@ -178,7 +181,7 @@ export default function HomepageSettingsPage() {
         )}
 
         {/* Settings Cards */}
-        <div className='grid gap-6 md:grid-cols-2'>
+        <div className='grid gap-6 md:grid-cols-2 lg:grid-cols-3'>
           {/* Hero Section Image */}
           <motion.div variants={itemVariants}>
             <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm h-full'>
@@ -220,6 +223,31 @@ export default function HomepageSettingsPage() {
                   onImageChange={setHowItWorksImage}
                   entityType='homepage'
                   entityId='how-it-works'
+                />
+              </CardContent>
+            </Card>
+          </motion.div>
+
+          {/* Auth Page Left Panel Image */}
+          <motion.div variants={itemVariants}>
+            <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm h-full'>
+              <CardHeader>
+                <CardTitle className='flex items-center gap-2'>
+                  <ImageIcon className='h-5 w-5 text-emerald-600' />
+                  Page d&apos;authentification
+                </CardTitle>
+                <CardDescription>
+                  Image de fond du panneau gauche des pages de connexion, inscription et
+                  réinitialisation (desktop uniquement). Format portrait recommandé. Si aucune image
+                  n&apos;est définie, le dégradé actuel sera affiché.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ImageUpload
+                  currentImage={authImage}
+                  onImageChange={setAuthImage}
+                  entityType='homepage'
+                  entityId='auth-background'
                 />
               </CardContent>
             </Card>

--- a/src/app/api/homepage-settings/route.ts
+++ b/src/app/api/homepage-settings/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/lib/auth'
 import {
   getHomepageSettings,
   updateHomepageSettings,
@@ -16,12 +17,26 @@ export async function GET() {
 
 export async function PUT(request: NextRequest) {
   try {
+    const session = await auth()
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Non authentifié' }, { status: 401 })
+    }
+
+    const canManageSettings = ['ADMIN', 'HOST_MANAGER'].includes(session.user.roles as string)
+    if (!canManageSettings) {
+      console.warn(
+        `[PUT /api/homepage-settings] forbidden: user=${session.user.id} role=${session.user.roles}`
+      )
+      return NextResponse.json({ error: 'Non autorisé' }, { status: 403 })
+    }
+
     const body = await request.json()
-    const { heroBackgroundImage, howItWorksImage } = body
+    const { heroBackgroundImage, howItWorksImage, authBackgroundImage } = body
 
     const updatedSettings = await updateHomepageSettings({
       heroBackgroundImage,
       howItWorksImage,
+      authBackgroundImage,
     })
 
     if (!updatedSettings) {

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import { Button } from '@/components/ui/shadcnui/button'
 import { LoginForm } from './LoginForm'
@@ -17,6 +18,22 @@ interface AuthFormProps {
 
 export const AuthForm = ({ mode = 'login' }: AuthFormProps) => {
   const router = useRouter()
+  const [backgroundImage, setBackgroundImage] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const response = await fetch('/api/homepage-settings')
+        if (response.ok) {
+          const data = await response.json()
+          setBackgroundImage(data.authBackgroundImage || null)
+        }
+      } catch (error) {
+        console.error('Error fetching homepage settings:', error)
+      }
+    }
+    fetchSettings()
+  }, [])
 
   const handleGoogleSignIn = () => {
     signIn('google', { redirectTo: '/host' })
@@ -77,17 +94,39 @@ export const AuthForm = ({ mode = 'login' }: AuthFormProps) => {
       }
     >
       <div className='flex' style={{ height: 'calc(100vh - 64px)' }}>
-        {/* Left side - Image */}
-        <div className='hidden lg:flex lg:w-1/2 bg-gradient-to-br from-orange-400 via-pink-500 to-purple-600'>
-          <div className='w-full flex flex-col items-center justify-center text-white'>
+        {/* Left side - Image or gradient fallback */}
+        <div
+          className={`relative hidden lg:flex lg:w-1/2 overflow-hidden ${
+            backgroundImage
+              ? ''
+              : 'bg-gradient-to-br from-orange-400 via-pink-500 to-purple-600'
+          }`}
+        >
+          {backgroundImage && (
+            <>
+              <Image
+                src={backgroundImage}
+                alt='Auth background'
+                fill
+                className='object-cover'
+                priority
+                sizes='50vw'
+              />
+              {/* Dark overlay to keep the white text readable whatever the image */}
+              <div className='absolute inset-0 bg-gradient-to-b from-black/50 via-black/30 to-black/50' />
+            </>
+          )}
+          <div className='relative z-10 w-full flex flex-col items-center justify-center text-white'>
             <div className='text-center'>
               <div className='text-6xl mb-4'>☀️</div>
               <h1 className='text-4xl font-bold mb-2'>Bienvenue sur Hosteed</h1>
               <p className='text-xl'>Découvrez des hébergements exceptionnels</p>
             </div>
-            <div className='absolute bottom-10'>
-              <Image src='/window.svg' alt='Window' width={64} height={64} />
-            </div>
+            {!backgroundImage && (
+              <div className='absolute bottom-10'>
+                <Image src='/window.svg' alt='Window' width={64} height={64} />
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -107,6 +107,7 @@ export const LoginForm = () => {
                 <div className='relative'>
                   <Input {...field} type={showPassword ? 'text' : 'password'} className='py-6' />
                   <Button
+                    type='button'
                     variant='ghost'
                     size='icon'
                     onClick={() => setShowPassword(!showPassword)}

--- a/src/lib/services/homepageSettings.service.ts
+++ b/src/lib/services/homepageSettings.service.ts
@@ -15,6 +15,7 @@ export async function getHomepageSettings(): Promise<HomepageSettings | null> {
 export async function updateHomepageSettings(data: {
   heroBackgroundImage?: string | null
   howItWorksImage?: string | null
+  authBackgroundImage?: string | null
 }): Promise<HomepageSettings | null> {
   try {
     // Récupérer l'enregistrement existant ou créer un nouveau


### PR DESCRIPTION
## Summary

Adds a 3rd background image slot to the admin homepage settings panel, this one driving the **left-hand panel of the auth pages** (login, register, reset) on desktop. If no image is configured, the existing orange/pink/purple gradient is preserved unchanged.

Reuses the existing `HomepageSettings` single-row table and its service/API/admin plumbing — one new nullable column, zero new files in the data layer.

Ships with two unrelated-but-adjacent fixes discovered during manual testing.

## Changes

### Main feature — configurable auth background
- `prisma/schema.prisma` — add `HomepageSettings.authBackgroundImage String?`
- `src/lib/services/homepageSettings.service.ts` — widen `updateHomepageSettings()` signature
- `src/app/admin/homepage/page.tsx` — third `<Card>` bound to `entityType='homepage' entityId='auth-background'`; grid upgraded to `md:grid-cols-2 lg:grid-cols-3`
- `src/components/auth/AuthForm.tsx`:
  - fetch `/api/homepage-settings` on mount (mirrors `HeroSection` pattern)
  - conditionally render `<Image fill>` with a dark gradient overlay for white-text readability, fall back to the existing gradient when `authBackgroundImage` is null
  - hide the bottom decorative `window.svg` icon when a background image is used (keeps composition clean)

### Bonus security fix
- `src/app/api/homepage-settings/route.ts` — the `PUT` endpoint was previously **completely unauthenticated** and could be called by anyone to change any homepage image. Now requires a valid session and `ADMIN` or `HOST_MANAGER` role. Same pattern as the `/api/products/[id]/images` fix.

### Bonus bug fix
- `src/components/auth/LoginForm.tsx` — the show/hide password eye button inherited `type='submit'` from the shadcn `Button` default and was **submitting the login form on every toggle click**. Explicit `type='button'` added.

## Test plan (verified manually via Chrome DevTools MCP on local staging)

| Scenario | Result |
|---|---|
| `authBackgroundImage = null` on `/auth?mode=login` | Gradient + window icon unchanged ✅ |
| `authBackgroundImage = /uploads/homepage/hero/...webp` | Image renders behind dark overlay, white text readable, no window icon ✅ |
| Click the eye icon in login password field | Toggles visibility, **no form submit** (URL stays `/auth?mode=login`, no POST to `/api/auth/callback/credentials`) ✅ |
| `PUT /api/homepage-settings` without auth | 401 Non authentifié (was 200 before) ✅ |
| `PUT /api/homepage-settings` as ADMIN | Still works ✅ |
| Admin homepage page loads with 3 cards | ✅ |

## Migration

No manual migration needed. The deploy workflow already runs `pnpm prisma db push --skip-generate` after pulling, which applies the new nullable column safely.

## Scope explicitly out

- No rename of `HomepageSettings` to `SiteSettings` (deliberately kept scope small)
- No refactor of the shared `ImageUpload` component (works as-is)
- User asked to **stop at staging merge for this PR** — no `staging → main` promotion in this session