### PR TITLE
feat(admin): redesign /admin/validation + fix motion visibility bug

### DIFF
--- a/src/app/admin/validation/components/ProductValidationCard.tsx
+++ b/src/app/admin/validation/components/ProductValidationCard.tsx
@@ -4,10 +4,17 @@ import React, { useState, useMemo, useCallback } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { ProductValidation } from '@prisma/client'
-import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import { CheckCircle, XCircle, Eye, MapPin, Home, User, Loader2 } from 'lucide-react'
+import {
+  CheckCircle2,
+  XCircle,
+  Eye,
+  MapPin,
+  Home,
+  Loader2,
+  UserCircle2,
+} from 'lucide-react'
+import { toPlainTextPreview } from '@/lib/utils/contentFormat'
 import { approveProduct, rejectProduct } from '../actions'
 
 interface Product {
@@ -25,7 +32,6 @@ interface Product {
     email: string
     image?: string | null
   }
-  // Nouvelles métadonnées pour le contexte de validation
   isRecentlyModified?: boolean
   wasRecheckRequested?: boolean
 }
@@ -36,49 +42,65 @@ interface ProductValidationCardProps {
   onUpdate: () => void
 }
 
+type StatusAccent = {
+  label: string
+  badgeClass: string
+  borderClass: string
+}
+
+function getStatusAccent(
+  validate: ProductValidation,
+  isRecentlyModified?: boolean
+): StatusAccent {
+  switch (validate) {
+    case ProductValidation.NotVerified:
+      if (isRecentlyModified) {
+        return {
+          label: 'Modifié · à revalider',
+          badgeClass: 'bg-blue-100 text-blue-800 ring-1 ring-blue-200',
+          borderClass: 'before:bg-blue-500',
+        }
+      }
+      return {
+        label: 'En attente',
+        badgeClass: 'bg-amber-100 text-amber-800 ring-1 ring-amber-200',
+        borderClass: 'before:bg-amber-500',
+      }
+    case ProductValidation.RecheckRequest:
+      return {
+        label: 'Révision demandée',
+        badgeClass: 'bg-orange-100 text-orange-800 ring-1 ring-orange-200',
+        borderClass: 'before:bg-orange-500',
+      }
+    case ProductValidation.Approve:
+      return {
+        label: 'Validé',
+        badgeClass: 'bg-emerald-100 text-emerald-800 ring-1 ring-emerald-200',
+        borderClass: 'before:bg-emerald-500',
+      }
+    case ProductValidation.Refused:
+      return {
+        label: 'Refusé',
+        badgeClass: 'bg-red-100 text-red-800 ring-1 ring-red-200',
+        borderClass: 'before:bg-red-500',
+      }
+    default:
+      return {
+        label: 'Inconnu',
+        badgeClass: 'bg-slate-100 text-slate-700 ring-1 ring-slate-200',
+        borderClass: 'before:bg-slate-400',
+      }
+  }
+}
+
 function ProductValidationCard({ product, currentUserId, onUpdate }: ProductValidationCardProps) {
   const [loading, setLoading] = useState(false)
 
-  // Memoize the validation badge to prevent recreation on every render
-  const validationBadge = useMemo(() => {
-    switch (product.validate) {
-      case ProductValidation.NotVerified:
-        if (product.isRecentlyModified) {
-          return (
-            <Badge variant='secondary' className='bg-blue-100 text-blue-800 border-blue-300'>
-              Modifié - À revalider
-            </Badge>
-          )
-        }
-        return (
-          <Badge variant='secondary' className='bg-yellow-100 text-yellow-800'>
-            En attente
-          </Badge>
-        )
-      case ProductValidation.RecheckRequest:
-        return (
-          <Badge variant='secondary' className='bg-orange-100 text-orange-800'>
-            Révision demandée
-          </Badge>
-        )
-      case ProductValidation.Approve:
-        return (
-          <Badge variant='default' className='bg-green-100 text-green-800'>
-            Validé
-          </Badge>
-        )
-      case ProductValidation.Refused:
-        return (
-          <Badge variant='destructive' className='bg-red-100 text-red-800'>
-            Refusé
-          </Badge>
-        )
-      default:
-        return <Badge variant='outline'>Inconnu</Badge>
-    }
-  }, [product.validate, product.isRecentlyModified])
+  const statusAccent = useMemo(
+    () => getStatusAccent(product.validate, product.isRecentlyModified),
+    [product.validate, product.isRecentlyModified]
+  )
 
-  // Memoize user display name to prevent recalculation
   const userDisplayName = useMemo(() => {
     const user = product.owner
     if (user?.name && user?.lastname) {
@@ -87,7 +109,15 @@ function ProductValidationCard({ product, currentUserId, onUpdate }: ProductVali
     return user?.email || 'Utilisateur inconnu'
   }, [product.owner])
 
-  // Memoize whether validation actions should be shown
+  const initials = useMemo(() => {
+    const name = userDisplayName
+    const parts = name.split(/\s+/).filter(Boolean)
+    if (parts.length >= 2) {
+      return (parts[0][0] + parts[1][0]).toUpperCase()
+    }
+    return (parts[0]?.[0] || '?').toUpperCase()
+  }, [userDisplayName])
+
   const showValidationActions = useMemo(() => {
     return (
       product.validate === ProductValidation.NotVerified ||
@@ -95,26 +125,27 @@ function ProductValidationCard({ product, currentUserId, onUpdate }: ProductVali
     )
   }, [product.validate])
 
-  // Memoize first image URL
   const firstImageUrl = useMemo(() => {
     return product.img && product.img.length > 0 ? product.img[0].img : null
   }, [product.img])
 
-  // Memoized validation action handler to prevent recreation
+  const descriptionPreview = useMemo(
+    () => toPlainTextPreview(product.description),
+    [product.description]
+  )
+
   const handleValidationAction = useCallback(
     async (action: 'approve' | 'reject') => {
       setLoading(true)
       try {
-        let result
-        if (action === 'approve') {
-          result = await approveProduct(product.id, currentUserId, 'Approuvé par admin')
-        } else {
-          result = await rejectProduct(
-            product.id,
-            currentUserId,
-            "Produit rejeté par l'administrateur"
-          )
-        }
+        const result =
+          action === 'approve'
+            ? await approveProduct(product.id, currentUserId, 'Approuvé par admin')
+            : await rejectProduct(
+                product.id,
+                currentUserId,
+                "Produit rejeté par l'administrateur"
+              )
 
         if (result.success) {
           onUpdate()
@@ -133,141 +164,173 @@ function ProductValidationCard({ product, currentUserId, onUpdate }: ProductVali
     [product.id, currentUserId, onUpdate]
   )
 
-  // Memoized click handlers to prevent recreation
   const handleApprove = useCallback(
     () => handleValidationAction('approve'),
     [handleValidationAction]
   )
-  const handleReject = useCallback(() => handleValidationAction('reject'), [handleValidationAction])
+  const handleReject = useCallback(
+    () => handleValidationAction('reject'),
+    [handleValidationAction]
+  )
 
   return (
-    <Card className='overflow-hidden hover:shadow-lg transition-all duration-300'>
-      {/* Product Image */}
-      <div className='relative h-48 w-full'>
+    <article
+      className={`group relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg before:absolute before:left-0 before:top-0 before:h-full before:w-1.5 ${statusAccent.borderClass}`}
+    >
+      {/* Image + status badge overlay */}
+      <div className='relative h-56 w-full overflow-hidden bg-slate-100'>
         {firstImageUrl ? (
-          <Image src={firstImageUrl} alt={product.name} fill className='object-cover' />
+          <Image
+            src={firstImageUrl}
+            alt={product.name}
+            fill
+            className='object-cover transition-transform duration-500 group-hover:scale-[1.03]'
+            sizes='(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw'
+          />
         ) : (
-          <div className='w-full h-full bg-gray-200 flex items-center justify-center'>
-            <Home className='h-12 w-12 text-gray-400' />
+          <div className='flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200'>
+            <Home className='h-12 w-12 text-slate-400' />
           </div>
         )}
-        <div className='absolute top-4 right-4'>{validationBadge}</div>
+
+        <div className='absolute left-4 top-4'>
+          <span
+            className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${statusAccent.badgeClass}`}
+          >
+            {statusAccent.label}
+          </span>
+        </div>
+
+        <div className='absolute right-4 top-4'>
+          <span className='inline-flex items-center gap-1 rounded-full bg-black/60 px-3 py-1 text-xs font-semibold text-white backdrop-blur-sm'>
+            {product.basePrice}€
+            <span className='font-normal opacity-80'>/nuit</span>
+          </span>
+        </div>
       </div>
 
-      <CardContent className='p-4'>
-        <div className='space-y-3'>
-          {/* Product Title */}
-          <div>
-            <h3 className='font-semibold text-lg text-gray-900 line-clamp-1'>{product.name}</h3>
-            <p className='text-gray-600 text-sm line-clamp-2 mt-1'>{product.description}</p>
-          </div>
-
-          {/* Location and Price */}
-          <div className='flex items-center justify-between'>
-            <div className='flex items-center gap-1 text-gray-600'>
-              <MapPin className='h-4 w-4' />
-              <span className='text-sm line-clamp-1'>{product.address}</span>
+      {/* Body */}
+      <div className='flex flex-1 flex-col gap-4 p-5'>
+        {/* Host row */}
+        <div className='flex items-center gap-3 border-b border-slate-100 pb-4'>
+          {product.owner.image ? (
+            <Image
+              src={product.owner.image}
+              alt={userDisplayName}
+              width={36}
+              height={36}
+              className='h-9 w-9 rounded-full object-cover ring-2 ring-white'
+            />
+          ) : (
+            <div className='flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-purple-500 text-xs font-semibold text-white ring-2 ring-white'>
+              {initials}
             </div>
-            <div className='text-lg font-bold text-primary'>{product.basePrice}€</div>
-          </div>
-
-          {/* Host Info */}
-          <div className='flex items-center gap-2 text-sm text-gray-600'>
-            <User className='h-4 w-4' />
-            <span>{userDisplayName}</span>
-          </div>
-
-          {/* Actions */}
-          <div className='flex gap-2 pt-2'>
-            <Button variant='outline' size='sm' asChild className='flex-1'>
-              <Link href={`/admin/validation/${product.id}`}>
-                <Eye className='h-4 w-4 mr-1' />
-                Détails
-              </Link>
-            </Button>
-
-            {showValidationActions && (
-              <>
-                <Button
-                  size='sm'
-                  onClick={handleApprove}
-                  className='bg-green-600 hover:bg-green-700'
-                  disabled={loading}
-                >
-                  {loading ? (
-                    <Loader2 className='h-4 w-4 animate-spin' />
-                  ) : (
-                    <CheckCircle className='h-4 w-4' />
-                  )}
-                </Button>
-                <Button variant='destructive' size='sm' onClick={handleReject} disabled={loading}>
-                  {loading ? (
-                    <Loader2 className='h-4 w-4 animate-spin' />
-                  ) : (
-                    <XCircle className='h-4 w-4' />
-                  )}
-                </Button>
-              </>
-            )}
+          )}
+          <div className='min-w-0 flex-1'>
+            <p className='truncate text-sm font-medium text-slate-900'>{userDisplayName}</p>
+            <p className='truncate text-xs text-slate-500'>
+              <UserCircle2 className='inline h-3 w-3 align-text-bottom' /> {product.owner.email}
+            </p>
           </div>
         </div>
-      </CardContent>
-    </Card>
+
+        {/* Title + description */}
+        <div className='space-y-2'>
+          <h3 className='line-clamp-1 text-lg font-semibold text-slate-900'>{product.name}</h3>
+          <p className='line-clamp-2 text-sm text-slate-600'>
+            {descriptionPreview || 'Aucune description'}
+          </p>
+        </div>
+
+        {/* Location */}
+        <div className='flex items-start gap-2 text-sm text-slate-500'>
+          <MapPin className='mt-0.5 h-4 w-4 shrink-0' />
+          <span className='line-clamp-1'>{product.address}</span>
+        </div>
+
+        {/* Actions */}
+        <div className='mt-auto flex flex-wrap items-center gap-2 pt-2'>
+          <Button variant='outline' size='sm' asChild className='flex-1 min-w-[110px]'>
+            <Link href={`/admin/validation/${product.id}`}>
+              <Eye className='mr-1 h-4 w-4' />
+              Détails
+            </Link>
+          </Button>
+
+          {showValidationActions && (
+            <div className='flex gap-2'>
+              <Button
+                size='sm'
+                onClick={handleApprove}
+                className='bg-emerald-600 text-white hover:bg-emerald-700'
+                disabled={loading}
+                aria-label='Approuver l’annonce'
+                title='Approuver'
+              >
+                {loading ? (
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                ) : (
+                  <CheckCircle2 className='h-4 w-4' />
+                )}
+              </Button>
+              <Button
+                size='sm'
+                variant='destructive'
+                onClick={handleReject}
+                disabled={loading}
+                aria-label='Refuser l’annonce'
+                title='Refuser'
+              >
+                {loading ? (
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                ) : (
+                  <XCircle className='h-4 w-4' />
+                )}
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
   )
 }
 
-// Custom comparison function for React.memo to prevent unnecessary re-renders
 const arePropsEqual = (
   prevProps: ProductValidationCardProps,
   nextProps: ProductValidationCardProps
 ) => {
-  // Check if currentUserId changed
-  if (prevProps.currentUserId !== nextProps.currentUserId) {
-    return false
-  }
+  if (prevProps.currentUserId !== nextProps.currentUserId) return false
+  if (prevProps.onUpdate !== nextProps.onUpdate) return false
 
-  // Check if onUpdate function reference changed
-  if (prevProps.onUpdate !== nextProps.onUpdate) {
-    return false
-  }
-
-  // Check if product has changed (deep comparison of key fields)
-  const prevProduct = prevProps.product
-  const nextProduct = nextProps.product
+  const p = prevProps.product
+  const n = nextProps.product
 
   if (
-    prevProduct.id !== nextProduct.id ||
-    prevProduct.name !== nextProduct.name ||
-    prevProduct.description !== nextProduct.description ||
-    prevProduct.address !== nextProduct.address ||
-    prevProduct.basePrice !== nextProduct.basePrice ||
-    prevProduct.validate !== nextProduct.validate ||
-    prevProduct.isRecentlyModified !== nextProduct.isRecentlyModified ||
-    prevProduct.wasRecheckRequested !== nextProduct.wasRecheckRequested
+    p.id !== n.id ||
+    p.name !== n.name ||
+    p.description !== n.description ||
+    p.address !== n.address ||
+    p.basePrice !== n.basePrice ||
+    p.validate !== n.validate ||
+    p.isRecentlyModified !== n.isRecentlyModified ||
+    p.wasRecheckRequested !== n.wasRecheckRequested
   ) {
     return false
   }
 
-  // Check if images changed (shallow comparison)
-  if (prevProduct.img?.length !== nextProduct.img?.length) {
-    return false
+  if (p.img?.length !== n.img?.length) return false
+  if (p.img && n.img && p.img.length > 0) {
+    if (p.img[0].img !== n.img[0].img) return false
   }
 
-  if (prevProduct.img && nextProduct.img && prevProduct.img.length > 0) {
-    if (prevProduct.img[0].img !== nextProduct.img[0].img) {
-      return false
-    }
-  }
-
-  // Check if user data changed
-  const prevUser = prevProduct.owner
-  const nextUser = nextProduct.owner
-
+  const pu = p.owner
+  const nu = n.owner
   if (
-    prevUser?.id !== nextUser?.id ||
-    prevUser?.name !== nextUser?.name ||
-    prevUser?.lastname !== nextUser?.lastname ||
-    prevUser?.email !== nextUser?.email
+    pu?.id !== nu?.id ||
+    pu?.name !== nu?.name ||
+    pu?.lastname !== nu?.lastname ||
+    pu?.email !== nu?.email ||
+    pu?.image !== nu?.image
   ) {
     return false
   }

--- a/src/app/admin/validation/components/ValidationStatsCards.tsx
+++ b/src/app/admin/validation/components/ValidationStatsCards.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { CheckCircle, XCircle, Clock, Home, Edit, FileText } from 'lucide-react'
+import { Clock, Edit3, FileText, CheckCircle2, XCircle, LayoutGrid } from 'lucide-react'
 
 interface ValidationStats {
   pending: number
@@ -17,76 +16,131 @@ interface ValidationStatsCardsProps {
   stats: ValidationStats
 }
 
-export function ValidationStatsCards({ stats }: ValidationStatsCardsProps) {
+interface PrimaryCardProps {
+  label: string
+  value: number
+  hint: string
+  icon: React.ReactNode
+  accent: {
+    bg: string
+    text: string
+    ring: string
+    iconBg: string
+  }
+}
+
+function PrimaryStatCard({ label, value, hint, icon, accent }: PrimaryCardProps) {
   return (
-    <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4 mb-8'>
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <CardTitle className='text-sm font-medium'>Total</CardTitle>
-          <Home className='h-4 w-4 text-muted-foreground' />
-        </CardHeader>
-        <CardContent>
-          <div className='text-2xl font-bold'>{stats.total}</div>
-          <p className='text-xs text-muted-foreground'>annonces au total</p>
-        </CardContent>
-      </Card>
+    <div
+      className={`relative overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm ring-1 ring-transparent transition hover:shadow-md hover:${accent.ring}`}
+    >
+      <div className='flex items-start justify-between gap-4'>
+        <div className='space-y-1'>
+          <p className='text-sm font-medium text-slate-500'>{label}</p>
+          <p className={`text-4xl font-bold tracking-tight ${accent.text}`}>{value}</p>
+          <p className='text-xs text-slate-500'>{hint}</p>
+        </div>
+        <div
+          className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-xl ${accent.bg} ${accent.text}`}
+        >
+          {icon}
+        </div>
+      </div>
+    </div>
+  )
+}
 
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <CardTitle className='text-sm font-medium'>En attente</CardTitle>
-          <Clock className='h-4 w-4 text-yellow-600' />
-        </CardHeader>
-        <CardContent>
-          <div className='text-2xl font-bold text-yellow-600'>{stats.pending}</div>
-          <p className='text-xs text-muted-foreground'>nouvelles</p>
-        </CardContent>
-      </Card>
+interface SecondaryMetricProps {
+  label: string
+  value: number
+  icon: React.ReactNode
+  tone: 'slate' | 'green' | 'red'
+}
 
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <CardTitle className='text-sm font-medium'>Révisions</CardTitle>
-          <Edit className='h-4 w-4 text-blue-600' />
-        </CardHeader>
-        <CardContent>
-          <div className='text-2xl font-bold text-blue-600'>{stats.recheckRequest}</div>
-          <p className='text-xs text-muted-foreground'>à corriger</p>
-        </CardContent>
-      </Card>
+function SecondaryMetric({ label, value, icon, tone }: SecondaryMetricProps) {
+  const tones = {
+    slate: 'text-slate-600',
+    green: 'text-emerald-600',
+    red: 'text-red-600',
+  } as const
+  return (
+    <div className='flex items-center gap-3 rounded-xl border border-slate-200/80 bg-white/60 px-4 py-3 backdrop-blur-sm'>
+      <div className={`${tones[tone]}`}>{icon}</div>
+      <div className='flex items-baseline gap-2'>
+        <span className={`text-2xl font-semibold tabular-nums ${tones[tone]}`}>{value}</span>
+        <span className='text-sm font-medium text-slate-600'>{label}</span>
+      </div>
+    </div>
+  )
+}
 
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <CardTitle className='text-sm font-medium'>Modifications</CardTitle>
-          <FileText className='h-4 w-4 text-purple-600' />
-        </CardHeader>
-        <CardContent>
-          <div className='text-2xl font-bold text-purple-600'>
-            {stats.modificationPending + stats.drafts}
-          </div>
-          <p className='text-xs text-muted-foreground'>en attente</p>
-        </CardContent>
-      </Card>
+export function ValidationStatsCards({ stats }: ValidationStatsCardsProps) {
+  const actionable = stats.pending + stats.recheckRequest
+  const modifications = stats.modificationPending + stats.drafts
 
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <CardTitle className='text-sm font-medium'>Validées</CardTitle>
-          <CheckCircle className='h-4 w-4 text-green-600' />
-        </CardHeader>
-        <CardContent>
-          <div className='text-2xl font-bold text-green-600'>{stats.approved}</div>
-          <p className='text-xs text-muted-foreground'>approuvées</p>
-        </CardContent>
-      </Card>
+  return (
+    <div className='space-y-4'>
+      {/* Primary — actionable items */}
+      <div className='grid gap-4 md:grid-cols-3'>
+        <PrimaryStatCard
+          label='À traiter'
+          value={actionable}
+          hint={actionable === 0 ? 'Rien en attente' : 'annonces en attente d’action'}
+          icon={<Clock className='h-6 w-6' />}
+          accent={{
+            bg: 'bg-amber-50',
+            text: 'text-amber-600',
+            ring: 'ring-amber-200',
+            iconBg: 'bg-amber-50',
+          }}
+        />
+        <PrimaryStatCard
+          label='Révisions demandées'
+          value={stats.recheckRequest}
+          hint='à corriger par l’hôte'
+          icon={<Edit3 className='h-6 w-6' />}
+          accent={{
+            bg: 'bg-blue-50',
+            text: 'text-blue-600',
+            ring: 'ring-blue-200',
+            iconBg: 'bg-blue-50',
+          }}
+        />
+        <PrimaryStatCard
+          label='Modifications'
+          value={modifications}
+          hint='changements en attente de revue'
+          icon={<FileText className='h-6 w-6' />}
+          accent={{
+            bg: 'bg-purple-50',
+            text: 'text-purple-600',
+            ring: 'ring-purple-200',
+            iconBg: 'bg-purple-50',
+          }}
+        />
+      </div>
 
-      <Card>
-        <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-          <CardTitle className='text-sm font-medium'>Refusées</CardTitle>
-          <XCircle className='h-4 w-4 text-red-600' />
-        </CardHeader>
-        <CardContent>
-          <div className='text-2xl font-bold text-red-600'>{stats.rejected}</div>
-          <p className='text-xs text-muted-foreground'>rejetées</p>
-        </CardContent>
-      </Card>
+      {/* Secondary — resolved / total metrics */}
+      <div className='grid gap-3 sm:grid-cols-3'>
+        <SecondaryMetric
+          label='annonces au total'
+          value={stats.total}
+          icon={<LayoutGrid className='h-5 w-5' />}
+          tone='slate'
+        />
+        <SecondaryMetric
+          label='validées'
+          value={stats.approved}
+          icon={<CheckCircle2 className='h-5 w-5' />}
+          tone='green'
+        />
+        <SecondaryMetric
+          label='refusées'
+          value={stats.rejected}
+          icon={<XCircle className='h-5 w-5' />}
+          tone='red'
+        />
+      </div>
     </div>
   )
 }

--- a/src/app/admin/validation/components/ValidationTabs.tsx
+++ b/src/app/admin/validation/components/ValidationTabs.tsx
@@ -1,10 +1,17 @@
 'use client'
 
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { ProductValidation } from '@prisma/client'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Card, CardContent } from '@/components/ui/card'
-import { Home, Loader2 } from 'lucide-react'
+import {
+  Bell,
+  CheckCircle2,
+  ClipboardList,
+  Home,
+  LayoutGrid,
+  PenLine,
+  XCircle,
+} from 'lucide-react'
 import { motion } from 'framer-motion'
 import ProductValidationCard from './ProductValidationCard'
 import { RejectedProductsTab } from './RejectedProductsTab'
@@ -55,26 +62,29 @@ interface ValidationTabsProps {
 
 const ITEMS_PER_PAGE = 20
 
-const TAB_STATUS_MAP: Record<string, { status?: ProductValidation; statuses?: ProductValidation[] }> = {
+const TAB_STATUS_MAP: Record<
+  string,
+  { status?: ProductValidation; statuses?: ProductValidation[] }
+> = {
   all: {},
-  pending: { statuses: [ProductValidation.NotVerified, ProductValidation.RecheckRequest] },
+  pending: {
+    statuses: [ProductValidation.NotVerified, ProductValidation.RecheckRequest],
+  },
   new: { status: ProductValidation.NotVerified },
   resubmitted: { status: ProductValidation.RecheckRequest },
   approved: { status: ProductValidation.Approve },
   rejected: { status: ProductValidation.Refused },
 }
 
-const itemVariants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: 'tween' as const,
-      duration: 0.5,
-      ease: 'easeOut' as const,
-    },
-  },
+interface TabDefinition {
+  key: string
+  label: string
+  icon: React.ReactNode
+  count: number
+  badgeClass: string
+  activeClass: string
+  emptyTitle: string
+  emptySubtitle: string
 }
 
 interface TabState {
@@ -88,6 +98,46 @@ const initialTabState = (): TabState => ({
   pagination: null,
   loading: false,
 })
+
+function SkeletonCard() {
+  return (
+    <div className='relative overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm'>
+      <div className='h-56 w-full animate-pulse bg-slate-200' />
+      <div className='space-y-4 p-5'>
+        <div className='flex items-center gap-3 border-b border-slate-100 pb-4'>
+          <div className='h-9 w-9 animate-pulse rounded-full bg-slate-200' />
+          <div className='flex-1 space-y-2'>
+            <div className='h-3 w-24 animate-pulse rounded bg-slate-200' />
+            <div className='h-3 w-32 animate-pulse rounded bg-slate-200' />
+          </div>
+        </div>
+        <div className='space-y-2'>
+          <div className='h-5 w-3/4 animate-pulse rounded bg-slate-200' />
+          <div className='h-3 w-full animate-pulse rounded bg-slate-200' />
+          <div className='h-3 w-5/6 animate-pulse rounded bg-slate-200' />
+        </div>
+        <div className='h-3 w-2/3 animate-pulse rounded bg-slate-200' />
+        <div className='flex gap-2 pt-2'>
+          <div className='h-9 flex-1 animate-pulse rounded-md bg-slate-200' />
+          <div className='h-9 w-9 animate-pulse rounded-md bg-slate-200' />
+          <div className='h-9 w-9 animate-pulse rounded-md bg-slate-200' />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function EmptyState({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div className='flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-white/60 py-16 px-6 text-center'>
+      <div className='mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-slate-100'>
+        <Home className='h-8 w-8 text-slate-400' />
+      </div>
+      <h3 className='mb-1 text-lg font-semibold text-slate-900'>{title}</h3>
+      <p className='max-w-md text-sm text-slate-500'>{subtitle}</p>
+    </div>
+  )
+}
 
 function ValidationTabs({ stats, currentUserId, onUpdate }: ValidationTabsProps) {
   const [activeTab, setActiveTab] = useState('all')
@@ -108,42 +158,38 @@ function ValidationTabs({ stats, currentUserId, onUpdate }: ValidationTabsProps)
     rejected: initialTabState(),
   })
 
-  const fetchTab = useCallback(
-    async (tab: string, page: number) => {
+  const fetchTab = useCallback(async (tab: string, page: number) => {
+    setTabStates(prev => ({
+      ...prev,
+      [tab]: { ...prev[tab], loading: true },
+    }))
+
+    const { status, statuses } = TAB_STATUS_MAP[tab]
+
+    const result = await getValidationProductsByStatus({
+      status,
+      statuses,
+      page,
+      limit: ITEMS_PER_PAGE,
+    })
+
+    if (result.success && result.data) {
+      const products = result.data as Product[]
       setTabStates(prev => ({
         ...prev,
-        [tab]: { ...prev[tab], loading: true },
+        [tab]: {
+          products,
+          pagination: result.pagination ?? null,
+          loading: false,
+        },
       }))
-
-      const { status, statuses } = TAB_STATUS_MAP[tab]
-
-      const result = await getValidationProductsByStatus({
-        status,
-        statuses,
-        page,
-        limit: ITEMS_PER_PAGE,
-      })
-
-      if (result.success && result.data) {
-        const products = result.data as Product[]
-
-        setTabStates(prev => ({
-          ...prev,
-          [tab]: {
-            products,
-            pagination: result.pagination ?? null,
-            loading: false,
-          },
-        }))
-      } else {
-        setTabStates(prev => ({
-          ...prev,
-          [tab]: { ...prev[tab], loading: false },
-        }))
-      }
-    },
-    []
-  )
+    } else {
+      setTabStates(prev => ({
+        ...prev,
+        [tab]: { ...prev[tab], loading: false },
+      }))
+    }
+  }, [])
 
   useEffect(() => {
     fetchTab(activeTab, pages[activeTab])
@@ -163,41 +209,131 @@ function ValidationTabs({ stats, currentUserId, onUpdate }: ValidationTabsProps)
 
   const handleUpdate = useCallback(() => {
     onUpdate()
-    // Re-fetch current tab after a mutation
     fetchTab(activeTab, pages[activeTab])
   }, [onUpdate, fetchTab, activeTab, pages])
 
+  const tabDefinitions: TabDefinition[] = useMemo(
+    () => [
+      {
+        key: 'all',
+        label: 'Toutes',
+        icon: <LayoutGrid className='h-4 w-4' />,
+        count: stats.total,
+        badgeClass: 'bg-slate-100 text-slate-700',
+        activeClass:
+          'data-[state=active]:border-slate-900 data-[state=active]:text-slate-900',
+        emptyTitle: 'Aucune annonce',
+        emptySubtitle: 'Il n’y a pas encore d’annonces créées sur la plateforme.',
+      },
+      {
+        key: 'pending',
+        label: 'À traiter',
+        icon: <ClipboardList className='h-4 w-4' />,
+        count: stats.pending + stats.recheckRequest,
+        badgeClass: 'bg-amber-100 text-amber-800',
+        activeClass:
+          'data-[state=active]:border-amber-500 data-[state=active]:text-amber-700',
+        emptyTitle: 'Tout est à jour',
+        emptySubtitle: 'Aucune annonce en attente d’action. Bon travail !',
+      },
+      {
+        key: 'new',
+        label: 'Nouvelles',
+        icon: <Bell className='h-4 w-4' />,
+        count: stats.pending,
+        badgeClass: 'bg-yellow-100 text-yellow-800',
+        activeClass:
+          'data-[state=active]:border-yellow-500 data-[state=active]:text-yellow-700',
+        emptyTitle: 'Aucune nouvelle annonce',
+        emptySubtitle:
+          'Les nouvelles annonces soumises par les hôtes apparaîtront ici.',
+      },
+      {
+        key: 'resubmitted',
+        label: 'Modifiées',
+        icon: <PenLine className='h-4 w-4' />,
+        count: stats.recheckRequest,
+        badgeClass: 'bg-orange-100 text-orange-800',
+        activeClass:
+          'data-[state=active]:border-orange-500 data-[state=active]:text-orange-700',
+        emptyTitle: 'Aucune révision en cours',
+        emptySubtitle:
+          'Les annonces renvoyées après une demande de révision apparaîtront ici.',
+      },
+      {
+        key: 'approved',
+        label: 'Validées',
+        icon: <CheckCircle2 className='h-4 w-4' />,
+        count: stats.approved,
+        badgeClass: 'bg-emerald-100 text-emerald-800',
+        activeClass:
+          'data-[state=active]:border-emerald-500 data-[state=active]:text-emerald-700',
+        emptyTitle: 'Aucune annonce validée',
+        emptySubtitle: 'Les annonces que vous validez apparaîtront ici.',
+      },
+      {
+        key: 'rejected',
+        label: 'Rejetées',
+        icon: <XCircle className='h-4 w-4' />,
+        count: stats.rejected,
+        badgeClass: 'bg-red-100 text-red-800',
+        activeClass:
+          'data-[state=active]:border-red-500 data-[state=active]:text-red-700',
+        emptyTitle: 'Aucune annonce refusée',
+        emptySubtitle: 'Les annonces que vous refusez apparaîtront ici.',
+      },
+    ],
+    [stats]
+  )
+
   const renderTabContent = useCallback(
-    (tab: string) => {
-      const { products, pagination, loading } = tabStates[tab]
+    (tab: TabDefinition) => {
+      const { products, pagination, loading } = tabStates[tab.key]
 
       if (loading) {
         return (
-          <div className='flex items-center justify-center py-16'>
-            <Loader2 className='h-8 w-8 text-blue-500 animate-spin' />
+          <div className='grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3'>
+            {Array.from({ length: 6 }).map((_, i) => (
+              <SkeletonCard key={i} />
+            ))}
           </div>
         )
       }
 
       if (products.length === 0) {
-        return (
-          <Card>
-            <CardContent className='flex flex-col items-center justify-center py-12'>
-              <Home className='h-12 w-12 text-gray-400 mb-4' />
-              <h3 className='text-lg font-medium text-gray-900 mb-2'>Aucune annonce trouvée</h3>
-              <p className='text-gray-500 text-center'>
-                Aucune annonce dans cet onglet pour le moment.
-              </p>
-            </CardContent>
-          </Card>
-        )
+        return <EmptyState title={tab.emptyTitle} subtitle={tab.emptySubtitle} />
       }
 
       return (
-        <div className='space-y-6'>
-          <div className='grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6'>
-            {products.map((product, index) => (
-              <motion.div key={product.id} variants={itemVariants} transition={{ delay: index * 0.05 }}>
+        <div className='space-y-8'>
+          {/* Re-key the grid on activeTab + page so framer-motion remounts the subtree
+              when data changes and the stagger orchestration runs with the children
+              already present. Same pattern as the host dashboard fix. */}
+          <motion.div
+            key={`grid-${tab.key}-${pagination?.page ?? 1}-${products.length}`}
+            className='grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3'
+            initial='hidden'
+            animate='visible'
+            variants={{
+              hidden: { opacity: 0 },
+              visible: {
+                opacity: 1,
+                transition: { staggerChildren: 0.06 },
+              },
+            }}
+          >
+            {products.map(product => (
+              <motion.div
+                key={product.id}
+                variants={{
+                  hidden: { opacity: 0, y: 16 },
+                  visible: {
+                    opacity: 1,
+                    y: 0,
+                    transition: { type: 'tween', duration: 0.4, ease: 'easeOut' },
+                  },
+                }}
+              >
                 <ProductValidationCard
                   product={product}
                   currentUserId={currentUserId}
@@ -205,10 +341,10 @@ function ValidationTabs({ stats, currentUserId, onUpdate }: ValidationTabsProps)
                 />
               </motion.div>
             ))}
-          </div>
+          </motion.div>
 
           {pagination && pagination.totalPages > 1 && (
-            <div className='flex flex-col items-center gap-2'>
+            <div className='flex flex-col items-center gap-2 pt-4'>
               <Pagination
                 currentPage={pagination.page}
                 totalPages={pagination.totalPages}
@@ -217,7 +353,7 @@ function ValidationTabs({ stats, currentUserId, onUpdate }: ValidationTabsProps)
                 showNumbers={true}
                 maxVisiblePages={5}
               />
-              <p className='text-sm text-gray-500'>
+              <p className='text-xs text-slate-500'>
                 Affichage de {(pagination.page - 1) * pagination.limit + 1} à{' '}
                 {Math.min(pagination.page * pagination.limit, pagination.total)} sur{' '}
                 {pagination.total} annonces
@@ -232,51 +368,42 @@ function ValidationTabs({ stats, currentUserId, onUpdate }: ValidationTabsProps)
 
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} className='w-full'>
-      <TabsList className='grid w-full grid-cols-6'>
-        <TabsTrigger value='all'>Toutes ({stats.total})</TabsTrigger>
-        <TabsTrigger value='pending'>
-          À traiter ({stats.pending + stats.recheckRequest})
-        </TabsTrigger>
-        <TabsTrigger value='new'>Nouvelles ({stats.pending})</TabsTrigger>
-        <TabsTrigger value='resubmitted' className='text-orange-600'>
-          Modifiées ({stats.recheckRequest})
-        </TabsTrigger>
-        <TabsTrigger value='approved'>Validées ({stats.approved})</TabsTrigger>
-        <TabsTrigger value='rejected' className='text-red-600'>
-          Rejetées ({stats.rejected})
-        </TabsTrigger>
+      <TabsList className='flex h-auto w-full flex-wrap gap-1 rounded-xl border border-slate-200/80 bg-white/60 p-1.5 backdrop-blur-sm'>
+        {tabDefinitions.map(tab => (
+          <TabsTrigger
+            key={tab.key}
+            value={tab.key}
+            className={`flex flex-1 items-center justify-center gap-2 rounded-lg border-b-2 border-transparent px-4 py-2.5 text-sm font-medium text-slate-600 transition data-[state=active]:bg-slate-50 data-[state=active]:shadow-sm ${tab.activeClass}`}
+          >
+            {tab.icon}
+            <span>{tab.label}</span>
+            <span
+              className={`inline-flex min-w-[1.5rem] items-center justify-center rounded-full px-1.5 py-0.5 text-xs font-semibold tabular-nums ${tab.badgeClass}`}
+            >
+              {tab.count}
+            </span>
+          </TabsTrigger>
+        ))}
       </TabsList>
 
-      <TabsContent value='all' className='mt-6'>
-        {renderTabContent('all')}
-      </TabsContent>
-
-      <TabsContent value='pending' className='mt-6'>
-        {renderTabContent('pending')}
-      </TabsContent>
-
-      <TabsContent value='new' className='mt-6'>
-        {renderTabContent('new')}
-      </TabsContent>
-
-      <TabsContent value='resubmitted' className='mt-6'>
-        {renderTabContent('resubmitted')}
-      </TabsContent>
-
-      <TabsContent value='approved' className='mt-6'>
-        {renderTabContent('approved')}
-      </TabsContent>
-
-      <TabsContent value='rejected' className='mt-6'>
-        <RejectedProductsTab
-          products={tabStates['rejected'].products}
-          loading={tabStates['rejected'].loading}
-          pagination={tabStates['rejected'].pagination}
-          currentUserId={currentUserId}
-          onUpdate={handleUpdate}
-          onPageChange={handlePageChange}
-        />
-      </TabsContent>
+      {tabDefinitions.map(tab =>
+        tab.key === 'rejected' ? (
+          <TabsContent key={tab.key} value={tab.key} className='mt-6'>
+            <RejectedProductsTab
+              products={tabStates['rejected'].products}
+              loading={tabStates['rejected'].loading}
+              pagination={tabStates['rejected'].pagination}
+              currentUserId={currentUserId}
+              onUpdate={handleUpdate}
+              onPageChange={handlePageChange}
+            />
+          </TabsContent>
+        ) : (
+          <TabsContent key={tab.key} value={tab.key} className='mt-6'>
+            {renderTabContent(tab)}
+          </TabsContent>
+        )
+      )}
     </Tabs>
   )
 }

--- a/src/app/admin/validation/page.tsx
+++ b/src/app/admin/validation/page.tsx
@@ -7,7 +7,7 @@ import { isAdmin } from '@/hooks/useAdminAuth'
 import { motion, Variants } from 'framer-motion'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { XCircle, ArrowLeft } from 'lucide-react'
+import { XCircle, ArrowLeft, RefreshCw, ShieldCheck, Loader2 } from 'lucide-react'
 import { getValidationStats } from './actions'
 import { ValidationStatsCards } from './components/ValidationStatsCards'
 import ValidationTabs from './components/ValidationTabs'
@@ -53,6 +53,7 @@ export default function ValidationPage() {
   } = useAuth({ required: true, redirectTo: '/auth' })
   const router = useRouter()
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [stats, setStats] = useState<ValidationStats>({
     pending: 0,
@@ -80,9 +81,14 @@ export default function ValidationPage() {
     }
   }, [isAuthenticated, session, router])
 
-  const fetchData = async () => {
+  const fetchData = async (opts?: { silent?: boolean }) => {
+    const silent = opts?.silent ?? false
     try {
-      setLoading(true)
+      if (silent) {
+        setRefreshing(true)
+      } else {
+        setLoading(true)
+      }
       const statsResult = await getValidationStats()
       if (statsResult.success && statsResult.data) {
         setStats(statsResult.data)
@@ -93,16 +99,45 @@ export default function ValidationPage() {
       console.error('Erreur lors du chargement des données:', err)
       setError('Erreur lors du chargement des données')
     } finally {
-      setLoading(false)
+      if (silent) {
+        setRefreshing(false)
+      } else {
+        setLoading(false)
+      }
     }
+  }
+
+  const handleRefresh = () => {
+    setError(null)
+    fetchData({ silent: true })
   }
 
   if (isAuthLoading || loading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='container mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-3'>
+            {[0, 1, 2].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-14 animate-pulse rounded-xl border border-slate-200/80 bg-white' />
+          <div className='grid gap-6 lg:grid-cols-2 xl:grid-cols-3'>
+            {[0, 1, 2].map(i => (
+              <div
+                key={i}
+                className='h-[30rem] animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
         </div>
       </div>
     )
@@ -112,54 +147,87 @@ export default function ValidationPage() {
     return null
   }
 
-  if (error) {
-    return (
-      <div className='container mx-auto p-6 max-w-4xl'>
-        <Alert className='border-red-200 bg-red-50'>
-          <XCircle className='h-4 w-4 text-red-600' />
-          <AlertDescription className='text-red-800'>{error}</AlertDescription>
-        </Alert>
-      </div>
-    )
-  }
-
   return (
-    <motion.div
-      className='container mx-auto p-6 max-w-7xl'
-      variants={containerVariants}
-      initial='hidden'
-      animate='visible'
-    >
-      {/* Header */}
-      <motion.div className='flex items-center gap-4 mb-8' variants={itemVariants}>
-        <Button
-          variant='ghost'
-          size='sm'
-          onClick={() => router.push('/admin')}
-          className='flex items-center gap-2'
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='container mx-auto max-w-7xl space-y-8 p-6'
+        variants={containerVariants}
+        initial='hidden'
+        animate='visible'
+      >
+        {/* Breadcrumb / back link */}
+        <motion.div variants={itemVariants}>
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={() => router.push('/admin')}
+            className='text-slate-600 hover:text-slate-900'
+          >
+            <ArrowLeft className='mr-2 h-4 w-4' />
+            Retour au panel admin
+          </Button>
+        </motion.div>
+
+        {/* Header */}
+        <motion.div
+          variants={itemVariants}
+          className='flex flex-col gap-4 md:flex-row md:items-start md:justify-between'
         >
-          <ArrowLeft className='h-4 w-4' />
-          Retour au dashboard
-        </Button>
-        <div>
-          <h1 className='text-3xl font-bold text-gray-900'>Validation des annonces</h1>
-          <p className='text-gray-600 mt-1'>Gérer et valider les annonces soumises par les hôtes</p>
-        </div>
-      </motion.div>
+          <div className='space-y-3'>
+            <span className='inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700'>
+              <ShieldCheck className='h-3.5 w-3.5' />
+              Espace administrateur
+            </span>
+            <h1 className='bg-gradient-to-r from-slate-900 via-blue-800 to-indigo-800 bg-clip-text text-4xl font-bold tracking-tight text-transparent md:text-5xl'>
+              Validation des annonces
+            </h1>
+            <p className='max-w-2xl text-base text-slate-600'>
+              Passez en revue, validez ou refusez les annonces soumises par les hôtes.
+              Les annonces en attente d’action sont mises en avant en haut de la liste.
+            </p>
+          </div>
 
-      {/* Statistics Cards */}
-      <motion.div variants={itemVariants}>
-        <ValidationStatsCards stats={stats} />
-      </motion.div>
+          <div className='shrink-0'>
+            <Button
+              onClick={handleRefresh}
+              disabled={refreshing}
+              variant='outline'
+              className='gap-2 border-slate-200 bg-white/80 text-slate-700 shadow-sm hover:bg-slate-50'
+            >
+              {refreshing ? (
+                <Loader2 className='h-4 w-4 animate-spin' />
+              ) : (
+                <RefreshCw className='h-4 w-4' />
+              )}
+              {refreshing ? 'Actualisation…' : 'Actualiser'}
+            </Button>
+          </div>
+        </motion.div>
 
-      {/* Validation Tabs */}
-      <motion.div variants={itemVariants}>
-        <ValidationTabs
-          stats={stats}
-          currentUserId={session?.user?.id || ''}
-          onUpdate={fetchData}
-        />
+        {/* Error */}
+        {error && (
+          <motion.div variants={itemVariants}>
+            <Alert className='border-red-200 bg-red-50'>
+              <XCircle className='h-4 w-4 text-red-600' />
+              <AlertDescription className='text-red-800'>{error}</AlertDescription>
+            </Alert>
+          </motion.div>
+        )}
+
+        {/* Statistics */}
+        <motion.div variants={itemVariants}>
+          <ValidationStatsCards stats={stats} />
+        </motion.div>
+
+        {/* Validation Tabs */}
+        <motion.div variants={itemVariants}>
+          <ValidationTabs
+            stats={stats}
+            currentUserId={session?.user?.id || ''}
+            onUpdate={() => fetchData({ silent: true })}
+          />
+        </motion.div>
       </motion.div>
-    </motion.div>
+    </div>
   )
 }

--- a/src/lib/utils/contentFormat.ts
+++ b/src/lib/utils/contentFormat.ts
@@ -6,3 +6,46 @@ export function isHtmlContent(content: string): boolean {
   if (!content) return false
   return /<[a-z][\s\S]*>/i.test(content.trim())
 }
+
+/**
+ * Strips HTML tags and common Markdown syntax from a string and returns a plain
+ * text preview suitable for short descriptions (cards, tooltips, etc.).
+ *
+ * This is intentionally simple and safe for previews only — it is NOT a
+ * sanitizer and must not be used to render trusted HTML back to the DOM.
+ */
+export function toPlainTextPreview(content: string | null | undefined): string {
+  if (!content) return ''
+
+  let text = content
+
+  // Remove HTML tags
+  text = text.replace(/<[^>]*>/g, ' ')
+
+  // Decode common HTML entities
+  text = text
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+
+  // Remove Markdown bold/italic/code/strikethrough markers
+  text = text
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/_([^_]+)_/g, '$1')
+    .replace(/~~([^~]+)~~/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+
+  // Remove Markdown headings (#, ##, ### ...)
+  text = text.replace(/^#{1,6}\s+/gm, '')
+
+  // Collapse whitespace
+  text = text.replace(/\s+/g, ' ').trim()
+
+  return text
+}


### PR DESCRIPTION
## Summary

Full redesign of `/admin/validation`, with a modernized layout and a fix for the same framer-motion orchestration bug we hit on the host dashboard (cards mounted after the parent stagger completed were stuck at the `hidden` variant and invisible).

Verified end-to-end in Chrome DevTools on the current local DB.

## The motion bug

`ValidationTabs` rendered each product card inside `<motion.div variants={itemVariants}>` **without** its own `initial`/`animate` props, relying on parent variant inheritance. The tab panels fetch their data asynchronously via `fetchTab()` after mount. By the time the async resolves and cards mount, the outer stagger orchestration has already completed — the new children inherit the parent's named variant (`hidden` by default) and stay stuck at `{opacity: 0, y: 20}` forever.

**Before the fix** (walking up from a card `<h3>`):
```
level 5 motion.div wrapper:  opacity: 0  transform: matrix(1, 0, 0, 1, 0, 20)
```
DOM had the 4 products. Screen showed empty space. Same pattern as the host dashboard.

**After the fix**: the grid is wrapped in its own `<motion.div>` with explicit `initial='hidden' animate='visible'` + a `key` that re-keys on `${tab}-${page}-${products.length}`, so the subtree remounts cleanly on tab switch and data changes. Children are orchestrated correctly.

## Redesign

### `page.tsx`
- Gradient background (slate → blue → indigo, same family as `/admin/homepage`)
- Breadcrumb back link above the header
- Big gradient heading with a "Espace administrateur" pill tag
- Refresh button with silent-refresh state (no full-page reload spinner)
- Full-page skeleton while initial stats load, instead of a centered spinner

### `ValidationStatsCards`
- **Primary row** (3 large cards with accent colors): À traiter · Révisions demandées · Modifications
- **Secondary row** (3 compact metric chips): Total · Validées · Refusées
- Replaces the old 6-cards-all-equal layout that hid the urgent items among the already-handled ones

### `ValidationTabs`
- Tab triggers: icon + label + colored count badge, with per-tab active underline color (amber / yellow / orange / emerald / red) matching the status semantics
- Loading state: 6 skeleton cards that match the real card layout, so the grid does not jump when data arrives
- Empty states: per-tab messages ("Tout est à jour" / "Aucune nouvelle annonce" / ...) instead of the previous generic "Aucune annonce dans cet onglet"
- Pagination kept but repositioned with a cleaner caption

### `ProductValidationCard` (rebuilt)
- 56-high image with gradient fallback when no image
- Status badge **and** price chip overlaid on the image (top-left and top-right)
- Host header row: avatar (or gradient initials fallback) + name + email
- Title + 2-line description preview, **HTML/Markdown stripped** (previously showed raw `<p><strong>...</strong></p>` or Markdown `**` markers)
- Location row with MapPin icon
- Actions row: Détails (outline, flex-1) + Approve/Reject (only when status requires action, icon-only, clearly colored)
- Colored **left border (1.5 w)** matching the status (amber / blue / orange / emerald / red) — lets admins scan the list and spot what needs action

### Helper
Added `toPlainTextPreview()` in `src/lib/utils/contentFormat.ts`. Strips HTML tags, decodes common entities, removes Markdown bold/italic/heading markers, collapses whitespace. Preview-only, never used to render HTML back to the DOM.

## Test plan

Verified in Chrome DevTools on the local staging DB (4 products, all owned by the admin account, all with status `Approve`):

- [x] Hard reload `/admin/validation` → cards visible, `opacity:1 transform:none` confirmed
- [x] Tab switch (Toutes → Validées → Toutes) → cards visible on each switch
- [x] Markdown description correctly stripped ("NOUVELLE VILLA SUR LE MARKET Magnifique…" instead of raw `# **NOUVELLE VILLA...**`)
- [x] HTML description correctly stripped ("dazdasda" instead of `<p><strong><em>dazdasda</em></strong></p>`)
- [x] Empty state tabs show the per-tab message
- [x] Refresh button triggers a silent refetch (no full-screen skeleton)
- [x] Lint: 0 errors
- [x] `tsc --noEmit`: clean

## Scope explicitly out

- No changes to `/admin/validation/[id]` detail page (different concern)
- No changes to `RejectedProductsTab` internals (already had correct motion init)
- No refactor of the shared `<Pagination>` component
- User asked to **stop at staging merge for now** — no `staging → main` promotion in this PR