### PR TITLE
feat(admin): redesign dashboard home, section cards and admin navbar

### DIFF
--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -106,7 +106,15 @@ export default function BlogManagementPage() {
       }
 
       const data = await response.json()
-      setPosts(data)
+      // Defensive: the /api/posts contract is an array, but guard against a
+      // wrapped shape (e.g. `{ posts, pagination }`) in case an upstream
+      // change accidentally leaks the paginated object through.
+      const normalized = Array.isArray(data)
+        ? data
+        : Array.isArray((data as { posts?: unknown }).posts)
+          ? ((data as { posts: Post[] }).posts)
+          : []
+      setPosts(normalized)
     } catch (error) {
       console.error('Error fetching posts:', error)
       toast.error('Erreur lors du chargement des articles')

--- a/src/app/admin/components/ActionCardGroup.tsx
+++ b/src/app/admin/components/ActionCardGroup.tsx
@@ -2,10 +2,77 @@
 
 import React from 'react'
 import Link from 'next/link'
-import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/shadcnui/card'
-import { Badge } from '@/components/ui/shadcnui/badge'
 import { motion } from 'framer-motion'
-import { ArrowRight, LucideIcon } from 'lucide-react'
+import { ArrowUpRight, LucideIcon } from 'lucide-react'
+
+export type ActionCardTone =
+  | 'slate'
+  | 'blue'
+  | 'indigo'
+  | 'emerald'
+  | 'amber'
+  | 'orange'
+  | 'red'
+  | 'purple'
+
+const TONE_CLASSES: Record<
+  ActionCardTone,
+  {
+    iconBg: string
+    iconText: string
+    hoverBorder: string
+    accent: string
+  }
+> = {
+  slate: {
+    iconBg: 'bg-slate-100',
+    iconText: 'text-slate-600',
+    hoverBorder: 'hover:border-slate-300',
+    accent: 'group-hover:text-slate-700',
+  },
+  blue: {
+    iconBg: 'bg-blue-50',
+    iconText: 'text-blue-600',
+    hoverBorder: 'hover:border-blue-300',
+    accent: 'group-hover:text-blue-700',
+  },
+  indigo: {
+    iconBg: 'bg-indigo-50',
+    iconText: 'text-indigo-600',
+    hoverBorder: 'hover:border-indigo-300',
+    accent: 'group-hover:text-indigo-700',
+  },
+  emerald: {
+    iconBg: 'bg-emerald-50',
+    iconText: 'text-emerald-600',
+    hoverBorder: 'hover:border-emerald-300',
+    accent: 'group-hover:text-emerald-700',
+  },
+  amber: {
+    iconBg: 'bg-amber-50',
+    iconText: 'text-amber-600',
+    hoverBorder: 'hover:border-amber-300',
+    accent: 'group-hover:text-amber-700',
+  },
+  orange: {
+    iconBg: 'bg-orange-50',
+    iconText: 'text-orange-600',
+    hoverBorder: 'hover:border-orange-300',
+    accent: 'group-hover:text-orange-700',
+  },
+  red: {
+    iconBg: 'bg-red-50',
+    iconText: 'text-red-600',
+    hoverBorder: 'hover:border-red-300',
+    accent: 'group-hover:text-red-700',
+  },
+  purple: {
+    iconBg: 'bg-purple-50',
+    iconText: 'text-purple-600',
+    hoverBorder: 'hover:border-purple-300',
+    accent: 'group-hover:text-purple-700',
+  },
+}
 
 interface ActionCardProps {
   title: string
@@ -14,63 +81,60 @@ interface ActionCardProps {
   href: string
   badge?: string | null
   badgeVariant?: 'destructive' | 'secondary'
-  priority?: 'high' | 'medium' | 'low'
+  tone?: ActionCardTone
 }
 
 export function ActionCard({
   title,
   description,
   href,
-  icon,
+  icon: Icon,
   badge,
   badgeVariant = 'secondary',
-  priority = 'medium',
+  tone = 'slate',
 }: ActionCardProps) {
-  const priorityStyles = {
-    high: 'ring-2 ring-red-200 hover:ring-red-300',
-    medium: 'hover:ring-2 hover:ring-blue-200',
-    low: 'hover:ring-2 hover:ring-slate-200',
-  }
+  const toneClass = TONE_CLASSES[tone]
+  const badgeClass =
+    badgeVariant === 'destructive'
+      ? 'bg-red-100 text-red-800 ring-1 ring-red-200'
+      : 'bg-slate-100 text-slate-700 ring-1 ring-slate-200'
 
   return (
-    <motion.div whileHover={{ scale: 1.02, y: -2 }} whileTap={{ scale: 0.98 }} className='h-full'>
-      <Link href={href} className='block h-full'>
-        <Card
-          className={`
-          h-full border-0 shadow-sm hover:shadow-lg transition-all duration-300 
-          bg-white/70 backdrop-blur-sm hover:bg-white/90 group
-          ${priorityStyles[priority]}
-        `}
-        >
-          <CardHeader className='pb-3'>
-            <div className='flex items-start justify-between'>
-              <div className='flex items-center gap-3 flex-1'>
-                <div className='p-2 bg-slate-50 rounded-lg group-hover:bg-blue-50 transition-colors shrink-0'>
-                  {React.createElement(icon, { className: 'h-6 w-6 text-slate-700' })}
-                </div>
-                <div className='min-w-0 flex-1'>
-                  <CardTitle className='text-lg font-semibold text-slate-800 group-hover:text-blue-700 transition-colors line-clamp-2'>
-                    {title}
-                  </CardTitle>
-                  <CardDescription className='text-slate-600 text-sm mt-1 line-clamp-2'>
-                    {description}
-                  </CardDescription>
-                </div>
-              </div>
-              <ArrowRight className='h-4 w-4 text-slate-400 group-hover:text-blue-600 group-hover:translate-x-1 transition-all shrink-0 ml-2' />
-            </div>
+    <Link href={href} className='block h-full'>
+      <motion.div
+        whileHover={{ y: -2 }}
+        transition={{ type: 'tween', duration: 0.2 }}
+        className={`group relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm transition hover:shadow-md ${toneClass.hoverBorder}`}
+      >
+        <div className='flex items-start justify-between gap-3'>
+          <div
+            className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl ${toneClass.iconBg} ${toneClass.iconText}`}
+          >
+            <Icon className='h-5 w-5' />
+          </div>
+          <ArrowUpRight className='h-4 w-4 text-slate-300 transition group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-slate-600' />
+        </div>
 
-            {badge && (
-              <div className='mt-3'>
-                <Badge variant={badgeVariant} className='text-xs'>
-                  {badge}
-                </Badge>
-              </div>
-            )}
-          </CardHeader>
-        </Card>
-      </Link>
-    </motion.div>
+        <div className='mt-4 space-y-1'>
+          <h3
+            className={`text-base font-semibold leading-tight text-slate-900 transition ${toneClass.accent}`}
+          >
+            {title}
+          </h3>
+          <p className='line-clamp-2 text-sm text-slate-500'>{description}</p>
+        </div>
+
+        {badge && (
+          <div className='mt-4'>
+            <span
+              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${badgeClass}`}
+            >
+              {badge}
+            </span>
+          </div>
+        )}
+      </motion.div>
+    </Link>
   )
 }
 
@@ -78,7 +142,9 @@ interface ActionCardGroupProps {
   title: string
   description: string
   icon: LucideIcon
-  cards: ActionCardProps[]
+  /** Color tone for the group header icon chip. Defaults to slate. */
+  tone?: ActionCardTone
+  cards: (ActionCardProps & { tone?: ActionCardTone })[]
   className?: string
 }
 
@@ -86,38 +152,54 @@ export function ActionCardGroup({
   title,
   description,
   icon: Icon,
+  tone = 'slate',
   cards,
   className = '',
 }: ActionCardGroupProps) {
+  const headerTone = TONE_CLASSES[tone]
+
   return (
-    <div className={`space-y-6 ${className}`}>
+    <div className={`space-y-5 ${className}`}>
       <div className='flex items-center gap-3'>
-        <div className='p-2 bg-slate-100 rounded-lg'>
-          <Icon className='h-6 w-6 text-slate-700' />
+        <div
+          className={`flex h-10 w-10 items-center justify-center rounded-xl ${headerTone.iconBg} ${headerTone.iconText}`}
+        >
+          <Icon className='h-5 w-5' />
         </div>
         <div>
-          <h2 className='text-2xl font-bold text-slate-800'>{title}</h2>
-          <p className='text-slate-600'>{description}</p>
+          <h2 className='text-xl font-semibold text-slate-900'>{title}</h2>
+          <p className='text-sm text-slate-500'>{description}</p>
         </div>
       </div>
 
-      <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
-        {cards.map((card, index) => (
+      <motion.div
+        className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'
+        initial='hidden'
+        animate='visible'
+        variants={{
+          hidden: { opacity: 0 },
+          visible: {
+            opacity: 1,
+            transition: { staggerChildren: 0.04 },
+          },
+        }}
+      >
+        {cards.map(card => (
           <motion.div
             key={card.title}
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{
-              delay: index * 0.05,
-              type: 'spring',
-              stiffness: 100,
-              damping: 15,
+            variants={{
+              hidden: { opacity: 0, y: 12 },
+              visible: {
+                opacity: 1,
+                y: 0,
+                transition: { type: 'tween', duration: 0.3, ease: 'easeOut' },
+              },
             }}
           >
             <ActionCard {...card} />
           </motion.div>
         ))}
-      </div>
+      </motion.div>
     </div>
   )
 }

--- a/src/app/admin/components/AdminNav.tsx
+++ b/src/app/admin/components/AdminNav.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import { useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { UserRole } from '@prisma/client'
@@ -31,8 +31,8 @@ import {
   Wallet,
   Tag,
   Image as ImageIcon,
+  ShieldCheck,
 } from 'lucide-react'
-import { Button } from '@/components/ui/shadcnui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -61,47 +61,19 @@ const navGroups: NavGroup[] = [
     title: "Vue d'ensemble",
     icon: TrendingUp,
     items: [
-      {
-        title: 'Dashboard',
-        href: '/admin',
-        icon: BarChart2,
-      },
-      {
-        title: 'Aperçu Rapide',
-        href: '/admin/overview',
-        icon: TrendingUp,
-      },
+      { title: 'Dashboard', href: '/admin', icon: BarChart2 },
+      { title: 'Aperçu Rapide', href: '/admin/overview', icon: TrendingUp },
     ],
   },
   {
     title: 'Contenus',
     icon: Shield,
     items: [
-      {
-        title: 'Validation',
-        href: '/admin/validation',
-        icon: ClipboardCheck,
-      },
-      {
-        title: 'Hébergements',
-        href: '/admin/products',
-        icon: Home,
-      },
-      {
-        title: 'Avis',
-        href: '/admin/reviews',
-        icon: MessageSquare,
-      },
-      {
-        title: 'Évaluations utilisateurs',
-        href: '/admin/user-ratings',
-        icon: Star,
-      },
-      {
-        title: 'Refus',
-        href: '/admin/rejections',
-        icon: XCircle,
-      },
+      { title: 'Validation', href: '/admin/validation', icon: ClipboardCheck },
+      { title: 'Hébergements', href: '/admin/products', icon: Home },
+      { title: 'Avis', href: '/admin/reviews', icon: MessageSquare },
+      { title: 'Évaluations utilisateurs', href: '/admin/user-ratings', icon: Star },
+      { title: 'Refus', href: '/admin/rejections', icon: XCircle },
     ],
   },
   {
@@ -128,12 +100,7 @@ const navGroups: NavGroup[] = [
     icon: Users,
     requiredRoles: ['ADMIN'],
     items: [
-      {
-        title: 'Comptes',
-        href: '/admin/users',
-        icon: Users,
-        requiredRoles: ['ADMIN'],
-      },
+      { title: 'Comptes', href: '/admin/users', icon: Users, requiredRoles: ['ADMIN'] },
     ],
   },
   {
@@ -154,7 +121,7 @@ const navGroups: NavGroup[] = [
         requiredRoles: ['ADMIN'],
       },
       {
-        title: 'Reservations',
+        title: 'Réservations',
         href: '/admin/reservations',
         icon: CalendarDays,
         requiredRoles: ['ADMIN'],
@@ -177,58 +144,26 @@ const navGroups: NavGroup[] = [
         icon: Settings,
         requiredRoles: ['ADMIN'],
       },
-    ],
-  },
-  {
-    title: 'Configuration',
-    icon: Settings,
-    items: [
-      {
-        title: 'Services inclus',
-        href: '/admin/included-services',
-        icon: Package,
-      },
-      {
-        title: 'Extras',
-        href: '/admin/extras',
-        icon: Plus,
-      },
-      {
-        title: 'Points forts',
-        href: '/admin/highlights',
-        icon: Highlighter,
-      },
-      {
-        title: 'Équipements',
-        href: '/admin/equipments',
-        icon: Settings,
-      },
-      {
-        title: 'Repas',
-        href: '/admin/meals',
-        icon: Settings,
-      },
-      {
-        title: 'Sécurité',
-        href: '/admin/security',
-        icon: Shield,
-      },
-      {
-        title: 'Types de location',
-        href: '/admin/typeRent',
-        icon: Home,
-      },
-      {
-        title: 'Images Homepage',
-        href: '/admin/homepage',
-        icon: ImageIcon,
-      },
       {
         title: 'Retraits',
         href: '/admin/withdrawals',
         icon: Wallet,
         requiredRoles: ['ADMIN', 'HOST_MANAGER'],
       },
+    ],
+  },
+  {
+    title: 'Configuration',
+    icon: Settings,
+    items: [
+      { title: 'Services inclus', href: '/admin/included-services', icon: Package },
+      { title: 'Extras', href: '/admin/extras', icon: Plus },
+      { title: 'Points forts', href: '/admin/highlights', icon: Highlighter },
+      { title: 'Équipements', href: '/admin/equipments', icon: Settings },
+      { title: 'Repas', href: '/admin/meals', icon: Settings },
+      { title: 'Sécurité', href: '/admin/security', icon: Shield },
+      { title: 'Types de location', href: '/admin/typeRent', icon: Home },
+      { title: 'Images Homepage', href: '/admin/homepage', icon: ImageIcon },
     ],
   },
 ]
@@ -240,140 +175,191 @@ export function AdminNav() {
 
   const userRole = session?.user?.roles
 
-  // Filter function to check if user has required role
   const hasRequiredRole = (requiredRoles?: UserRole[]): boolean => {
     if (!requiredRoles || requiredRoles.length === 0) {
-      // No specific roles required, allow ADMIN and HOST_MANAGER
       return userRole === 'ADMIN' || userRole === 'HOST_MANAGER'
     }
     return userRole ? requiredRoles.includes(userRole) : false
   }
 
-  // Filter nav groups and items based on user role
   const filteredNavGroups = navGroups
     .filter(group => hasRequiredRole(group.requiredRoles))
     .map(group => ({
       ...group,
       items: group.items.filter(item => hasRequiredRole(item.requiredRoles)),
     }))
-    .filter(group => group.items.length > 0) // Remove groups with no visible items
+    .filter(group => group.items.length > 0)
 
   const isActiveGroup = (group: NavGroup) => {
-    return group.items.some(item => pathname === item.href)
+    if (group.items.some(item => item.href === '/admin' && pathname === '/admin')) {
+      return true
+    }
+    return group.items.some(item => item.href !== '/admin' && pathname.startsWith(item.href))
   }
 
   const isActiveItem = (href: string) => {
-    return pathname === href
+    if (href === '/admin') return pathname === '/admin'
+    return pathname === href || pathname.startsWith(href + '/')
   }
 
   return (
-    <nav className='sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur-md shadow-sm'>
-      <div className='flex h-16 items-center justify-between px-4 md:px-6'>
-        {/* Logo/Home Link */}
-        <Link
-          href='/admin'
-          className='flex items-center gap-2 font-semibold text-slate-800 hover:text-blue-600 transition-colors'
-        >
-          <Shield className='h-6 w-6' />
-          <span className='hidden md:inline'>Admin Panel</span>
+    <nav className='sticky top-0 z-50 w-full border-b border-slate-200/80 bg-white/80 backdrop-blur-md'>
+      <div className='mx-auto flex h-16 max-w-7xl items-center justify-between px-4 md:px-6'>
+        {/* Logo */}
+        <Link href='/admin' className='group flex items-center gap-3'>
+          <div className='flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-blue-600 to-indigo-600 shadow-sm transition group-hover:shadow-md'>
+            <ShieldCheck className='h-5 w-5 text-white' />
+          </div>
+          <div className='hidden md:flex md:flex-col md:leading-tight'>
+            <span className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+              Hosteed
+            </span>
+            <span className='text-sm font-bold text-slate-900'>Admin Panel</span>
+          </div>
         </Link>
 
         {/* Desktop Navigation */}
-        <div className='hidden lg:flex items-center space-x-1'>
+        <div className='hidden items-center gap-1 lg:flex'>
           {filteredNavGroups.map(group => {
             const isGroupActive = isActiveGroup(group)
+            const GroupIcon = group.icon
 
             return (
               <DropdownMenu key={group.title}>
                 <DropdownMenuTrigger asChild>
-                  <Button
-                    variant='ghost'
+                  <button
                     className={cn(
-                      'flex items-center gap-2 px-3 py-2 text-sm font-medium transition-colors hover:text-blue-600 hover:bg-blue-50',
-                      isGroupActive ? 'text-blue-600 bg-blue-50' : 'text-slate-600'
+                      'relative inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition',
+                      isGroupActive
+                        ? 'text-blue-700'
+                        : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
                     )}
                   >
-                    <group.icon className='h-4 w-4' />
+                    <GroupIcon className='h-4 w-4' />
                     <span>{group.title}</span>
-                    <ChevronDown className='h-3 w-3 opacity-50' />
-                  </Button>
+                    <ChevronDown className='h-3 w-3 opacity-60' />
+                    {isGroupActive && (
+                      <motion.span
+                        layoutId='admin-nav-active'
+                        className='absolute inset-x-2 -bottom-[1px] h-0.5 rounded-full bg-gradient-to-r from-blue-600 to-indigo-600'
+                        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                      />
+                    )}
+                  </button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align='start' className='w-48'>
-                  <DropdownMenuLabel className='text-xs text-slate-500 uppercase tracking-wide'>
+                <DropdownMenuContent
+                  align='start'
+                  className='w-56 rounded-xl border border-slate-200 p-1.5 shadow-lg'
+                >
+                  <DropdownMenuLabel className='px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400'>
                     {group.title}
                   </DropdownMenuLabel>
-                  <DropdownMenuSeparator />
-                  {group.items.map(item => (
-                    <DropdownMenuItem key={item.href} asChild>
-                      <Link
-                        href={item.href}
-                        className={cn(
-                          'flex items-center gap-2 w-full cursor-pointer',
-                          isActiveItem(item.href)
-                            ? 'text-blue-600 bg-blue-50'
-                            : 'text-slate-700 hover:text-blue-600'
-                        )}
+                  <DropdownMenuSeparator className='bg-slate-100' />
+                  {group.items.map(item => {
+                    const ItemIcon = item.icon
+                    const active = isActiveItem(item.href)
+                    return (
+                      <DropdownMenuItem
+                        key={item.href}
+                        asChild
+                        className='rounded-lg px-2 py-1.5 focus:bg-blue-50 focus:text-blue-700'
                       >
-                        <item.icon className='h-4 w-4' />
-                        {item.title}
-                      </Link>
-                    </DropdownMenuItem>
-                  ))}
+                        <Link
+                          href={item.href}
+                          className={cn(
+                            'flex w-full cursor-pointer items-center gap-2.5 text-sm',
+                            active
+                              ? 'font-semibold text-blue-700'
+                              : 'text-slate-700 hover:text-slate-900'
+                          )}
+                        >
+                          <span
+                            className={cn(
+                              'flex h-7 w-7 items-center justify-center rounded-md',
+                              active ? 'bg-blue-100 text-blue-700' : 'bg-slate-100 text-slate-600'
+                            )}
+                          >
+                            <ItemIcon className='h-3.5 w-3.5' />
+                          </span>
+                          <span className='flex-1'>{item.title}</span>
+                        </Link>
+                      </DropdownMenuItem>
+                    )
+                  })}
                 </DropdownMenuContent>
               </DropdownMenu>
             )
           })}
         </div>
 
-        {/* Mobile Navigation Toggle */}
-        <Button
-          variant='ghost'
-          size='sm'
-          className='lg:hidden'
+        {/* Mobile toggle */}
+        <button
+          className='inline-flex h-9 w-9 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 hover:text-slate-900 lg:hidden'
           onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+          aria-label='Toggle navigation menu'
         >
           {mobileMenuOpen ? <X className='h-5 w-5' /> : <Menu className='h-5 w-5' />}
-        </Button>
+        </button>
       </div>
 
-      {/* Mobile Navigation Menu */}
-      {mobileMenuOpen && (
-        <motion.div
-          initial={{ opacity: 0, height: 0 }}
-          animate={{ opacity: 1, height: 'auto' }}
-          exit={{ opacity: 0, height: 0 }}
-          className='lg:hidden border-t bg-white'
-        >
-          <div className='px-4 py-4 space-y-4'>
-            {filteredNavGroups.map(group => (
-              <div key={group.title} className='space-y-2'>
-                <div className='flex items-center gap-2 text-sm font-medium text-slate-800 px-2 py-1'>
-                  <group.icon className='h-4 w-4' />
-                  {group.title}
-                </div>
-                <div className='pl-6 space-y-1'>
-                  {group.items.map(item => (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      className={cn(
-                        'flex items-center gap-2 px-2 py-2 text-sm rounded-md transition-colors',
-                        isActiveItem(item.href)
-                          ? 'text-blue-600 bg-blue-50'
-                          : 'text-slate-600 hover:text-blue-600 hover:bg-slate-50'
-                      )}
-                      onClick={() => setMobileMenuOpen(false)}
-                    >
-                      <item.icon className='h-4 w-4' />
-                      {item.title}
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </motion.div>
-      )}
+      {/* Mobile menu */}
+      <AnimatePresence initial={false}>
+        {mobileMenuOpen && (
+          <motion.div
+            key='mobile-menu'
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+            className='border-t border-slate-200/80 bg-white/95 backdrop-blur-md lg:hidden'
+          >
+            <div className='mx-auto max-w-7xl space-y-6 px-4 py-5'>
+              {filteredNavGroups.map(group => {
+                const GroupIcon = group.icon
+                return (
+                  <div key={group.title} className='space-y-2'>
+                    <div className='flex items-center gap-2 px-2 text-xs font-semibold uppercase tracking-wide text-slate-400'>
+                      <GroupIcon className='h-3.5 w-3.5' />
+                      {group.title}
+                    </div>
+                    <div className='space-y-1'>
+                      {group.items.map(item => {
+                        const ItemIcon = item.icon
+                        const active = isActiveItem(item.href)
+                        return (
+                          <Link
+                            key={item.href}
+                            href={item.href}
+                            onClick={() => setMobileMenuOpen(false)}
+                            className={cn(
+                              'flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition',
+                              active
+                                ? 'bg-blue-50 font-semibold text-blue-700'
+                                : 'text-slate-700 hover:bg-slate-50 hover:text-slate-900'
+                            )}
+                          >
+                            <span
+                              className={cn(
+                                'flex h-8 w-8 items-center justify-center rounded-md',
+                                active
+                                  ? 'bg-blue-100 text-blue-700'
+                                  : 'bg-slate-100 text-slate-600'
+                              )}
+                            >
+                              <ItemIcon className='h-4 w-4' />
+                            </span>
+                            {item.title}
+                          </Link>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </nav>
   )
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -5,8 +5,8 @@ import { useEffect, useState } from 'react'
 import { useAuth } from '@/hooks/useAuth'
 import { motion, Variants } from 'framer-motion'
 import { isAdmin, isFullAdmin } from '@/hooks/useAdminAuth'
-import { Separator } from '@/components/ui/shadcnui/separator'
 import {
+  ShieldCheck,
   ClipboardCheck,
   Users,
   BarChart2,
@@ -18,47 +18,59 @@ import {
   Calendar,
   TrendingUp,
   Shield,
-  CheckCircle2,
-  Clock,
   Cctv,
   Soup,
   BrushCleaning,
   Calculator,
   Wallet,
   Image as ImageIcon,
+  Banknote,
+  UserPlus,
+  CalendarCheck,
+  ClipboardList,
+  Loader2,
+  RefreshCw,
 } from 'lucide-react'
-import { StatsOverview } from './components/StatsOverview'
+import { Button } from '@/components/ui/shadcnui/button'
+import { Separator } from '@/components/ui/shadcnui/separator'
 import { ActionCardGroup } from './components/ActionCardGroup'
-import { getAdminStatsYearly } from '@/lib/services/stats.service'
+import {
+  getAdminDashboardStats,
+  type AdminDashboardStats,
+} from '@/lib/services/stats.service'
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard, KpiMetric } from '@/components/admin/ui/KpiCard'
+import { PriorityList } from '@/components/admin/ui/PriorityList'
 
 const containerVariants: Variants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.1,
+      staggerChildren: 0.08,
     },
   },
 }
 
 const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
+  hidden: { opacity: 0, y: 16 },
   visible: {
     opacity: 1,
     y: 0,
     transition: {
-      type: 'spring',
-      stiffness: 100,
-      damping: 15,
+      type: 'tween',
+      duration: 0.4,
+      ease: 'easeOut',
     },
   },
 }
 
-interface Stats {
-  users: number
-  product: number
-  productWaiting: number
-  rent: number
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(amount)
 }
 
 export default function AdminDashboard() {
@@ -68,8 +80,9 @@ export default function AdminDashboard() {
     isAuthenticated,
   } = useAuth({ required: true, redirectTo: '/auth' })
   const router = useRouter()
-  const [stats, setStats] = useState<Stats | null>(null)
+  const [stats, setStats] = useState<AdminDashboardStats | null>(null)
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
 
   useEffect(() => {
     if (isAuthenticated && (!session?.user?.roles || !isAdmin(session.user.roles))) {
@@ -77,80 +90,143 @@ export default function AdminDashboard() {
     }
   }, [isAuthenticated, session, router])
 
-  useEffect(() => {
-    const fetchStats = async () => {
-      try {
-        const data = await getAdminStatsYearly()
-        setStats(data)
-      } catch (error) {
-        console.error('Erreur lors du chargement des statistiques:', error)
-      } finally {
-        setLoading(false)
-      }
+  const fetchStats = async (opts?: { silent?: boolean }) => {
+    const silent = opts?.silent ?? false
+    try {
+      if (silent) setRefreshing(true)
+      else setLoading(true)
+      const data = await getAdminDashboardStats()
+      setStats(data)
+    } catch (error) {
+      console.error('Erreur lors du chargement des statistiques:', error)
+    } finally {
+      if (silent) setRefreshing(false)
+      else setLoading(false)
     }
+  }
 
+  useEffect(() => {
     fetchStats()
   }, [])
 
-  // Quick stats cards for dashboard overview - filtered by role
-  const allQuickStats = [
+  const isAdminFull = isFullAdmin(session?.user?.roles)
+
+  // Hero KPI row — tailored to the user's role
+  const heroKpis = [
     {
-      title: 'Utilisateurs',
-      value: stats?.users || 0,
+      label: 'À valider',
+      value: stats?.productsWaiting ?? 0,
+      hint:
+        (stats?.productsWaiting ?? 0) > 0
+          ? 'annonces en attente d’action'
+          : 'aucune annonce en attente',
+      icon: ClipboardList,
+      tone: 'amber' as const,
+      href: '/admin/validation',
+      show: true,
+    },
+    {
+      label: 'Réservations (mois)',
+      value: stats?.rentsThisMonth ?? 0,
+      hint: 'ce mois-ci',
+      icon: CalendarCheck,
+      tone: 'blue' as const,
+      href: '/admin/reservations',
+      show: isAdminFull,
+    },
+    {
+      label: 'Revenus (mois)',
+      value: formatCurrency(stats?.revenueThisMonth ?? 0),
+      hint: 'volume total encaissé',
+      icon: Banknote,
+      tone: 'emerald' as const,
+      href: '/admin/stats',
+      show: isAdminFull,
+    },
+    {
+      label: 'Nouveaux utilisateurs',
+      value: stats?.newUsersThisWeek ?? 0,
+      hint: 'sur les 7 derniers jours',
+      icon: UserPlus,
+      tone: 'purple' as const,
+      href: '/admin/users',
+      show: isAdminFull,
+    },
+  ].filter(k => k.show)
+
+  // Secondary metrics — context
+  const secondaryMetrics = [
+    {
+      label: 'annonces actives',
+      value: stats?.productsActive ?? 0,
+      icon: Home,
+      tone: 'slate' as const,
+      href: '/admin/products',
+      show: true,
+    },
+    {
+      label: 'utilisateurs au total',
+      value: stats?.usersTotal ?? 0,
       icon: Users,
-      color: 'text-blue-600',
-      bgColor: 'bg-blue-50',
-      adminOnly: true, // Hide from HOST_MANAGER
+      tone: 'slate' as const,
+      href: '/admin/users',
+      show: isAdminFull,
     },
     {
-      title: 'Produits actifs',
-      value: stats?.product || 0,
-      icon: CheckCircle2,
-      color: 'text-green-600',
-      bgColor: 'bg-green-50',
-      adminOnly: false,
-    },
-    {
-      title: 'En attente',
-      value: stats?.productWaiting || 0,
-      icon: Clock,
-      color: 'text-orange-600',
-      bgColor: 'bg-orange-50',
-      adminOnly: false,
-    },
-    {
-      title: 'Locations',
-      value: stats?.rent || 0,
+      label: 'réservations sur l’année',
+      value: stats?.rentsYearly ?? 0,
       icon: Calendar,
-      color: 'text-purple-600',
-      bgColor: 'bg-purple-50',
-      adminOnly: true, // Hide business metrics from HOST_MANAGER
+      tone: 'slate' as const,
+      href: '/admin/reservations',
+      show: isAdminFull,
+    },
+  ].filter(m => m.show)
+
+  // Priority list — only items that actually need action appear
+  const priorities = [
+    {
+      icon: ClipboardCheck,
+      title: 'Annonces à valider',
+      description: 'Nouvelles soumissions et révisions demandées',
+      count: stats?.productsWaitingValidation ?? 0,
+      href: '/admin/validation',
+      tone: 'amber' as const,
+    },
+    {
+      icon: Wallet,
+      title: 'Retraits en attente',
+      description: 'Demandes de retrait des hôtes à traiter',
+      count: stats?.withdrawalsPending ?? 0,
+      href: '/admin/withdrawals',
+      tone: 'purple' as const,
+    },
+    {
+      icon: MessageSquare,
+      title: 'Avis à modérer',
+      description: 'Avis utilisateurs en attente d’approbation',
+      count: stats?.reviewsPendingModeration ?? 0,
+      href: '/admin/reviews',
+      tone: 'blue' as const,
     },
   ]
 
-  // Filter stats based on user role
-  const quickStats = allQuickStats.filter(stat => {
-    if (stat.adminOnly) {
-      return isFullAdmin(session?.user?.roles)
-    }
-    return true
-  })
-
-  // Grouped navigation cards - filtered by role
+  // Grouped navigation cards at the bottom — role-filtered
   const allCardGroups = [
     {
       title: 'Gestion des Contenus',
       description: 'Gérez les annonces, validations et modérations',
       icon: Shield,
+      tone: 'blue' as const,
       cards: [
         {
           title: 'Validation des annonces',
           description: 'Valider les nouvelles annonces',
           icon: ClipboardCheck,
           href: '/admin/validation',
+          tone: 'amber' as const,
           badge:
-            stats?.productWaiting && stats.productWaiting > 0
-              ? `${stats.productWaiting} en attente`
+            stats?.productsWaitingValidation && stats.productsWaitingValidation > 0
+              ? `${stats.productsWaitingValidation} en attente`
               : null,
           badgeVariant: 'destructive' as const,
         },
@@ -159,7 +235,8 @@ export default function AdminDashboard() {
           description: 'Voir et gérer tous les hébergements',
           icon: Home,
           href: '/admin/products',
-          badge: `${stats?.product || 0} actifs`,
+          tone: 'blue' as const,
+          badge: `${stats?.productsActive ?? 0} actifs`,
           badgeVariant: 'secondary' as const,
         },
         {
@@ -167,12 +244,19 @@ export default function AdminDashboard() {
           description: 'Modérer les avis utilisateurs',
           icon: MessageSquare,
           href: '/admin/reviews',
+          tone: 'purple' as const,
+          badge:
+            stats?.reviewsPendingModeration && stats.reviewsPendingModeration > 0
+              ? `${stats.reviewsPendingModeration} à modérer`
+              : null,
+          badgeVariant: 'destructive' as const,
         },
         {
           title: 'Refus de location',
           description: 'Gérer les litiges et refus',
           icon: XCircle,
           href: '/admin/rejections',
+          tone: 'red' as const,
         },
       ],
     },
@@ -180,14 +264,16 @@ export default function AdminDashboard() {
       title: 'Gestion des Utilisateurs',
       description: 'Administration des comptes et rôles',
       icon: Users,
-      adminOnly: true, // Hide from HOST_MANAGER
+      tone: 'indigo' as const,
+      adminOnly: true,
       cards: [
         {
           title: 'Utilisateurs',
           description: 'Gérer les comptes utilisateurs',
           icon: Users,
           href: '/admin/users',
-          badge: `${stats?.users || 0} inscrits`,
+          tone: 'indigo' as const,
+          badge: `${stats?.usersTotal ?? 0} inscrits`,
           badgeVariant: 'secondary' as const,
         },
         {
@@ -195,7 +281,8 @@ export default function AdminDashboard() {
           description: 'Voir toutes les réservations',
           icon: Calendar,
           href: '/admin/reservations',
-          badge: `${stats?.rent || 0} cette année`,
+          tone: 'blue' as const,
+          badge: `${stats?.rentsYearly ?? 0} cette année`,
           badgeVariant: 'secondary' as const,
         },
       ],
@@ -204,158 +291,226 @@ export default function AdminDashboard() {
       title: 'Business & Analytics',
       description: 'Statistiques, paiements et promotions',
       icon: TrendingUp,
-      adminOnly: true, // Hide from HOST_MANAGER
+      tone: 'emerald' as const,
+      adminOnly: true,
       cards: [
         {
           title: 'Statistiques',
           description: 'Analytics et performances',
           icon: BarChart2,
           href: '/admin/stats',
+          tone: 'emerald' as const,
         },
         {
           title: 'Paiements',
           description: 'Gestion des transactions',
           icon: CreditCard,
           href: '/admin/payment',
+          tone: 'emerald' as const,
         },
         {
           title: 'Annonces sponsorisées',
           description: 'Gérer les mises en avant',
           icon: Star,
           href: '/admin/promoted',
+          tone: 'amber' as const,
         },
         {
           title: 'Configuration des commissions',
           description: 'Gérer les taux de commission par type de logement',
           icon: Calculator,
           href: '/admin/commissions',
+          tone: 'slate' as const,
         },
         {
           title: 'Gestion des retraits',
           description: 'Gérer les demandes de retrait des hôtes',
           icon: Wallet,
           href: '/admin/withdrawals',
+          tone: 'purple' as const,
+          badge:
+            stats?.withdrawalsPending && stats.withdrawalsPending > 0
+              ? `${stats.withdrawalsPending} en attente`
+              : null,
+          badgeVariant: 'destructive' as const,
         },
       ],
     },
     {
-      title: 'Gestion des Options',
-      description: 'Configuration des équipements, repas et sécurité',
+      title: 'Configuration & Options',
+      description: 'Taxonomies, équipements, sécurité et homepage',
       icon: Shield,
+      tone: 'slate' as const,
       cards: [
         {
           title: 'Gestion des options de sécurité',
           description: 'Voir et gérer toutes les options de sécurité',
           icon: Cctv,
           href: '/admin/security',
+          tone: 'red' as const,
         },
         {
           title: 'Gestion des options de repas',
           description: 'Voir et gérer toutes les options de repas',
           icon: Soup,
           href: '/admin/meals',
+          tone: 'orange' as const,
         },
         {
           title: "Gestion des options d'équipements",
           description: "Voir et gérer toutes les options d'équipements",
           icon: BrushCleaning,
           href: '/admin/equipments',
+          tone: 'slate' as const,
         },
         {
           title: 'Gestion des types de logements',
           description: 'Voir et gérer tous les types de logements',
           icon: Home,
           href: '/admin/typeRent',
+          tone: 'blue' as const,
         },
         {
           title: "Images de la page d'accueil",
-          description: 'Configurer les images de la homepage',
+          description: 'Configurer les images de la homepage et de l’auth',
           icon: ImageIcon,
           href: '/admin/homepage',
+          tone: 'indigo' as const,
         },
       ],
     },
   ]
 
-  // Filter card groups based on user role
   const cardGroups = allCardGroups.filter(group => {
-    if (group.adminOnly) {
-      return isFullAdmin(session?.user?.roles)
-    }
+    if (group.adminOnly) return isAdminFull
     return true
   })
 
   if (isAuthLoading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
         </div>
       </div>
     )
   }
 
-  if (!session) {
-    return null
-  }
+  if (!session) return null
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
       <motion.div
-        className='max-w-7xl mx-auto p-6 space-y-8'
+        className='mx-auto max-w-7xl space-y-10 p-6'
         variants={containerVariants}
         initial='hidden'
         animate='visible'
       >
-        {/* Header Section */}
-        <motion.div className='text-center space-y-4' variants={itemVariants}>
-          <div className='inline-flex items-center gap-2 px-4 py-2 bg-blue-100 text-blue-700 rounded-full text-sm font-medium'>
-            <Shield className='h-4 w-4' />
-            Panel Administrateur
-          </div>
-          <h1 className='text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-800 via-blue-700 to-indigo-700'>
-            Dashboard Administrateur
-          </h1>
-          <p className='text-slate-600 max-w-2xl mx-auto text-lg'>
-            Gérez efficacement votre plateforme avec une interface claire et organisée
-          </p>
+        {/* Header */}
+        <motion.div variants={itemVariants}>
+          <PageHeader
+            eyebrow='Espace administrateur'
+            eyebrowIcon={ShieldCheck}
+            title='Tableau de bord'
+            subtitle='Une vue d’ensemble de votre plateforme. Les actions urgentes sont mises en avant ci-dessous.'
+            actions={
+              <Button
+                onClick={() => fetchStats({ silent: true })}
+                disabled={refreshing || loading}
+                variant='outline'
+                className='gap-2 border-slate-200 bg-white/80 text-slate-700 shadow-sm hover:bg-slate-50'
+              >
+                {refreshing ? (
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                ) : (
+                  <RefreshCw className='h-4 w-4' />
+                )}
+                {refreshing ? 'Actualisation…' : 'Actualiser'}
+              </Button>
+            }
+          />
         </motion.div>
 
-        {/* Quick Stats Overview */}
-        {!loading && stats && (
-          <motion.div variants={itemVariants}>
-            <StatsOverview stats={quickStats} />
-          </motion.div>
-        )}
-
-        {/* Loading State for Stats */}
-        {loading && (
-          <motion.div variants={itemVariants}>
-            <StatsOverview stats={[]} loading={true} />
-          </motion.div>
-        )}
-
-        {/* Grouped Admin Sections */}
-        <div className='space-y-8'>
-          {cardGroups.map((group, groupIndex) => (
-            <motion.div
-              key={group.title}
-              variants={itemVariants}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: groupIndex * 0.2 }}
-            >
-              <ActionCardGroup
-                title={group.title}
-                description={group.description}
-                icon={group.icon}
-                cards={group.cards ?? []}
+        {/* Hero KPI row */}
+        <motion.div variants={itemVariants}>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {heroKpis.map(kpi => (
+              <KpiCard
+                key={kpi.label}
+                label={kpi.label}
+                value={kpi.value}
+                hint={kpi.hint}
+                icon={kpi.icon}
+                tone={kpi.tone}
+                href={kpi.href}
+                loading={loading}
               />
-              {groupIndex < cardGroups.length - 1 && <Separator className='my-8 bg-slate-200' />}
-            </motion.div>
-          ))}
-        </div>
+            ))}
+          </div>
+        </motion.div>
+
+        {/* Two-column: priorities + secondary metrics */}
+        <motion.div variants={itemVariants}>
+          <div className='grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]'>
+            <PriorityList items={priorities} loading={loading} />
+            <div className='space-y-3'>
+              <h2 className='px-1 text-sm font-semibold uppercase tracking-wide text-slate-500'>
+                Vue d’ensemble
+              </h2>
+              <div className='space-y-3'>
+                {secondaryMetrics.map(m => (
+                  <KpiMetric
+                    key={m.label}
+                    label={m.label}
+                    value={m.value}
+                    icon={m.icon}
+                    tone={m.tone}
+                    href={m.href}
+                    loading={loading}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        </motion.div>
+
+        {/* All admin sections */}
+        <motion.div variants={itemVariants}>
+          <div className='mb-6 flex items-center justify-between'>
+            <h2 className='text-xl font-semibold text-slate-900'>Toutes les sections</h2>
+            <span className='text-sm text-slate-500'>
+              {cardGroups.length} catégorie{cardGroups.length > 1 ? 's' : ''}
+            </span>
+          </div>
+          <div className='space-y-8'>
+            {cardGroups.map((group, groupIndex) => (
+              <div key={group.title}>
+                <ActionCardGroup
+                  title={group.title}
+                  description={group.description}
+                  icon={group.icon}
+                  tone={group.tone}
+                  cards={group.cards ?? []}
+                />
+                {groupIndex < cardGroups.length - 1 && (
+                  <Separator className='my-8 bg-slate-200' />
+                )}
+              </div>
+            ))}
+          </div>
+        </motion.div>
       </motion.div>
     </div>
   )

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -24,8 +24,11 @@ export async function GET(request: NextRequest) {
 
       posts = await getPostsByAuthor(authorId)
     } else {
-      // Get all posts (public access)
-      posts = await getPost()
+      // Get all posts (public access). `getPost()` now returns a paginated
+      // shape `{ posts, pagination }` for internal use — the public
+      // `/api/posts` contract stays a plain array, so we unwrap here.
+      const paginated = await getPost({ limit: 1000 })
+      posts = paginated?.posts ?? null
     }
 
     if (!posts) {

--- a/src/components/admin/ui/KpiCard.tsx
+++ b/src/components/admin/ui/KpiCard.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { LucideIcon } from 'lucide-react'
+
+/**
+ * Color palette used by the primary KpiCard variant.
+ * Each tone provides a matching icon background and text color.
+ */
+export type KpiTone =
+  | 'slate'
+  | 'blue'
+  | 'indigo'
+  | 'emerald'
+  | 'amber'
+  | 'orange'
+  | 'red'
+  | 'purple'
+
+const TONE_CLASSES: Record<KpiTone, { bg: string; text: string; ring: string }> = {
+  slate: { bg: 'bg-slate-100', text: 'text-slate-700', ring: 'hover:ring-slate-200' },
+  blue: { bg: 'bg-blue-50', text: 'text-blue-600', ring: 'hover:ring-blue-200' },
+  indigo: { bg: 'bg-indigo-50', text: 'text-indigo-600', ring: 'hover:ring-indigo-200' },
+  emerald: {
+    bg: 'bg-emerald-50',
+    text: 'text-emerald-600',
+    ring: 'hover:ring-emerald-200',
+  },
+  amber: { bg: 'bg-amber-50', text: 'text-amber-600', ring: 'hover:ring-amber-200' },
+  orange: {
+    bg: 'bg-orange-50',
+    text: 'text-orange-600',
+    ring: 'hover:ring-orange-200',
+  },
+  red: { bg: 'bg-red-50', text: 'text-red-600', ring: 'hover:ring-red-200' },
+  purple: {
+    bg: 'bg-purple-50',
+    text: 'text-purple-600',
+    ring: 'hover:ring-purple-200',
+  },
+}
+
+interface KpiCardProps {
+  label: string
+  value: number | string
+  hint?: string
+  icon: LucideIcon
+  tone?: KpiTone
+  /** If provided, the card becomes a link to this href. */
+  href?: string
+  /** Loading state — renders a skeleton. */
+  loading?: boolean
+}
+
+/**
+ * Primary KpiCard — large card with big number, icon, and label.
+ * Used for the hero KPI row on admin dashboards.
+ */
+export function KpiCard({
+  label,
+  value,
+  hint,
+  icon: Icon,
+  tone = 'slate',
+  href,
+  loading = false,
+}: KpiCardProps) {
+  const toneClass = TONE_CLASSES[tone]
+
+  if (loading) {
+    return (
+      <div className='relative overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm'>
+        <div className='flex items-start justify-between gap-4'>
+          <div className='flex-1 space-y-2'>
+            <div className='h-4 w-24 animate-pulse rounded bg-slate-200' />
+            <div className='h-9 w-16 animate-pulse rounded bg-slate-200' />
+            <div className='h-3 w-32 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='h-12 w-12 animate-pulse rounded-xl bg-slate-200' />
+        </div>
+      </div>
+    )
+  }
+
+  const content = (
+    <div
+      className={`relative overflow-hidden rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm ring-1 ring-transparent transition hover:shadow-md ${toneClass.ring}`}
+    >
+      <div className='flex items-start justify-between gap-4'>
+        <div className='space-y-1'>
+          <p className='text-sm font-medium text-slate-500'>{label}</p>
+          <p className={`text-4xl font-bold tracking-tight tabular-nums ${toneClass.text}`}>
+            {value}
+          </p>
+          {hint && <p className='text-xs text-slate-500'>{hint}</p>}
+        </div>
+        <div
+          className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-xl ${toneClass.bg} ${toneClass.text}`}
+        >
+          <Icon className='h-6 w-6' />
+        </div>
+      </div>
+    </div>
+  )
+
+  if (href) {
+    return (
+      <Link href={href} className='block'>
+        {content}
+      </Link>
+    )
+  }
+  return content
+}
+
+interface KpiMetricProps {
+  label: string
+  value: number | string
+  icon: LucideIcon
+  tone?: 'slate' | 'emerald' | 'red' | 'blue'
+  href?: string
+  loading?: boolean
+}
+
+const SECONDARY_TONE: Record<
+  NonNullable<KpiMetricProps['tone']>,
+  string
+> = {
+  slate: 'text-slate-600',
+  emerald: 'text-emerald-600',
+  red: 'text-red-600',
+  blue: 'text-blue-600',
+}
+
+/**
+ * Secondary metric chip — compact horizontal row with icon + value + label.
+ * Used for context metrics alongside the primary KpiCard row.
+ */
+export function KpiMetric({
+  label,
+  value,
+  icon: Icon,
+  tone = 'slate',
+  href,
+  loading = false,
+}: KpiMetricProps) {
+  const toneClass = SECONDARY_TONE[tone]
+
+  if (loading) {
+    return (
+      <div className='flex items-center gap-3 rounded-xl border border-slate-200/80 bg-white/60 px-4 py-3 backdrop-blur-sm'>
+        <div className='h-5 w-5 animate-pulse rounded bg-slate-200' />
+        <div className='flex flex-1 items-center gap-2'>
+          <div className='h-6 w-10 animate-pulse rounded bg-slate-200' />
+          <div className='h-4 w-24 animate-pulse rounded bg-slate-200' />
+        </div>
+      </div>
+    )
+  }
+
+  const content = (
+    <div className='flex items-center gap-3 rounded-xl border border-slate-200/80 bg-white/60 px-4 py-3 backdrop-blur-sm transition hover:bg-white'>
+      <div className={toneClass}>
+        <Icon className='h-5 w-5' />
+      </div>
+      <div className='flex items-baseline gap-2'>
+        <span className={`text-2xl font-semibold tabular-nums ${toneClass}`}>{value}</span>
+        <span className='text-sm font-medium text-slate-600'>{label}</span>
+      </div>
+    </div>
+  )
+
+  if (href) {
+    return (
+      <Link href={href} className='block'>
+        {content}
+      </Link>
+    )
+  }
+  return content
+}

--- a/src/components/admin/ui/PageHeader.tsx
+++ b/src/components/admin/ui/PageHeader.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+import { ArrowLeft, LucideIcon } from 'lucide-react'
+import { Button } from '@/components/ui/shadcnui/button'
+
+interface PageHeaderProps {
+  /** Small uppercase pill shown above the title (e.g. "Espace administrateur"). */
+  eyebrow?: string
+  /** Optional icon displayed inside the eyebrow pill. */
+  eyebrowIcon?: LucideIcon
+  /** Main page title. Rendered with a gradient. */
+  title: string
+  /** Optional subtitle / description under the title. */
+  subtitle?: string
+  /** Optional breadcrumb back link shown above the header. */
+  backHref?: string
+  /** Label for the back link. Defaults to "Retour". */
+  backLabel?: string
+  /** Right-side actions slot (buttons, etc.). */
+  actions?: React.ReactNode
+}
+
+/**
+ * Unified page header for admin pages.
+ *
+ * Layout:
+ *   [ ← back link                                           ]
+ *   [ eyebrow pill                        [right actions] ]
+ *   [ gradient title                                       ]
+ *   [ subtitle                                             ]
+ */
+export function PageHeader({
+  eyebrow,
+  eyebrowIcon: EyebrowIcon,
+  title,
+  subtitle,
+  backHref,
+  backLabel = 'Retour',
+  actions,
+}: PageHeaderProps) {
+  return (
+    <div className='space-y-4'>
+      {backHref && (
+        <motion.div
+          initial={{ opacity: 0, x: -8 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.3 }}
+        >
+          <Button
+            variant='ghost'
+            size='sm'
+            asChild
+            className='text-slate-600 hover:text-slate-900'
+          >
+            <Link href={backHref}>
+              <ArrowLeft className='mr-2 h-4 w-4' />
+              {backLabel}
+            </Link>
+          </Button>
+        </motion.div>
+      )}
+
+      <div className='flex flex-col gap-4 md:flex-row md:items-start md:justify-between'>
+        <div className='space-y-3'>
+          {eyebrow && (
+            <span className='inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-700'>
+              {EyebrowIcon && <EyebrowIcon className='h-3.5 w-3.5' />}
+              {eyebrow}
+            </span>
+          )}
+          <h1 className='bg-gradient-to-r from-slate-900 via-blue-800 to-indigo-800 bg-clip-text text-4xl font-bold tracking-tight text-transparent md:text-5xl'>
+            {title}
+          </h1>
+          {subtitle && (
+            <p className='max-w-2xl text-base text-slate-600'>{subtitle}</p>
+          )}
+        </div>
+
+        {actions && <div className='shrink-0'>{actions}</div>}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/ui/PriorityList.tsx
+++ b/src/components/admin/ui/PriorityList.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { ArrowRight, Check, LucideIcon } from 'lucide-react'
+
+interface PriorityItemProps {
+  icon: LucideIcon
+  title: string
+  description: string
+  count: number
+  href: string
+  /** Color tone for the count badge + icon. */
+  tone: 'amber' | 'blue' | 'purple' | 'emerald' | 'red'
+}
+
+const TONE: Record<
+  PriorityItemProps['tone'],
+  { iconBg: string; iconText: string; badge: string; hoverBorder: string }
+> = {
+  amber: {
+    iconBg: 'bg-amber-50',
+    iconText: 'text-amber-600',
+    badge: 'bg-amber-100 text-amber-800 ring-1 ring-amber-200',
+    hoverBorder: 'hover:border-amber-300',
+  },
+  blue: {
+    iconBg: 'bg-blue-50',
+    iconText: 'text-blue-600',
+    badge: 'bg-blue-100 text-blue-800 ring-1 ring-blue-200',
+    hoverBorder: 'hover:border-blue-300',
+  },
+  purple: {
+    iconBg: 'bg-purple-50',
+    iconText: 'text-purple-600',
+    badge: 'bg-purple-100 text-purple-800 ring-1 ring-purple-200',
+    hoverBorder: 'hover:border-purple-300',
+  },
+  emerald: {
+    iconBg: 'bg-emerald-50',
+    iconText: 'text-emerald-600',
+    badge: 'bg-emerald-100 text-emerald-800 ring-1 ring-emerald-200',
+    hoverBorder: 'hover:border-emerald-300',
+  },
+  red: {
+    iconBg: 'bg-red-50',
+    iconText: 'text-red-600',
+    badge: 'bg-red-100 text-red-800 ring-1 ring-red-200',
+    hoverBorder: 'hover:border-red-300',
+  },
+}
+
+function PriorityItem({
+  icon: Icon,
+  title,
+  description,
+  count,
+  href,
+  tone,
+}: PriorityItemProps) {
+  const toneClass = TONE[tone]
+
+  return (
+    <Link
+      href={href}
+      className={`group flex items-center gap-4 rounded-xl border border-slate-200/80 bg-white p-4 transition hover:shadow-md ${toneClass.hoverBorder}`}
+    >
+      <div
+        className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl ${toneClass.iconBg} ${toneClass.iconText}`}
+      >
+        <Icon className='h-5 w-5' />
+      </div>
+      <div className='min-w-0 flex-1'>
+        <p className='truncate text-sm font-semibold text-slate-900'>{title}</p>
+        <p className='truncate text-xs text-slate-500'>{description}</p>
+      </div>
+      <span
+        className={`inline-flex h-7 min-w-[2rem] items-center justify-center rounded-full px-2.5 text-sm font-bold tabular-nums ${toneClass.badge}`}
+      >
+        {count}
+      </span>
+      <ArrowRight className='h-4 w-4 shrink-0 text-slate-300 transition group-hover:translate-x-0.5 group-hover:text-slate-600' />
+    </Link>
+  )
+}
+
+interface PriorityListProps {
+  title?: string
+  items: PriorityItemProps[]
+  loading?: boolean
+  /** Message shown when there are no items with count > 0. */
+  emptyTitle?: string
+  emptySubtitle?: string
+}
+
+/**
+ * A vertical list of prioritized actions for the admin dashboard.
+ * Items with count === 0 are hidden by default, and if no items remain
+ * an "all clear" empty state is rendered instead.
+ */
+export function PriorityList({
+  title = 'Priorités du jour',
+  items,
+  loading = false,
+  emptyTitle = 'Tout est à jour',
+  emptySubtitle = "Aucune action urgente ne vous attend. Profitez-en pour explorer le reste du panel.",
+}: PriorityListProps) {
+  const visibleItems = items.filter(i => i.count > 0)
+
+  return (
+    <div className='rounded-2xl border border-slate-200/80 bg-white/80 p-6 shadow-sm backdrop-blur-sm'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h2 className='text-lg font-semibold text-slate-900'>{title}</h2>
+        {!loading && visibleItems.length > 0 && (
+          <span className='rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-semibold text-slate-600'>
+            {visibleItems.length} {visibleItems.length > 1 ? 'actions' : 'action'}
+          </span>
+        )}
+      </div>
+
+      {loading ? (
+        <div className='space-y-3'>
+          {[0, 1, 2].map(i => (
+            <div
+              key={i}
+              className='flex items-center gap-4 rounded-xl border border-slate-200/80 bg-white p-4'
+            >
+              <div className='h-11 w-11 animate-pulse rounded-xl bg-slate-200' />
+              <div className='flex-1 space-y-2'>
+                <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+                <div className='h-3 w-56 animate-pulse rounded bg-slate-200' />
+              </div>
+              <div className='h-7 w-10 animate-pulse rounded-full bg-slate-200' />
+            </div>
+          ))}
+        </div>
+      ) : visibleItems.length === 0 ? (
+        <div className='flex flex-col items-center justify-center rounded-xl border border-dashed border-emerald-200 bg-emerald-50/40 py-10 px-6 text-center'>
+          <div className='mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-600'>
+            <Check className='h-6 w-6' />
+          </div>
+          <h3 className='text-base font-semibold text-slate-900'>{emptyTitle}</h3>
+          <p className='mt-1 max-w-sm text-sm text-slate-500'>{emptySubtitle}</p>
+        </div>
+      ) : (
+        <div className='space-y-3'>
+          {visibleItems.map(item => (
+            <PriorityItem key={item.href} {...item} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/services/stats.service.ts
+++ b/src/lib/services/stats.service.ts
@@ -1,7 +1,118 @@
 'use server'
 
 import prisma from '@/lib/prisma'
-import { ProductValidation } from '@prisma/client'
+import { ProductValidation, PaymentStatus, WithdrawalStatus } from '@prisma/client'
+
+export interface AdminDashboardStats {
+  // Actionable — drives the "Priorités" list
+  productsWaitingValidation: number
+  reviewsPendingModeration: number
+  withdrawalsPending: number
+
+  // Monthly KPIs — the hero row
+  rentsThisMonth: number
+  revenueThisMonth: number
+  newUsersThisWeek: number
+  productsWaiting: number
+
+  // Context metrics — secondary row
+  usersTotal: number
+  productsActive: number
+  rentsYearly: number
+}
+
+/**
+ * Returns all the counts and sums needed to render the admin dashboard home
+ * in a single parallel fetch. Each individual query is cheap and indexed.
+ */
+export async function getAdminDashboardStats(): Promise<AdminDashboardStats | null> {
+  try {
+    const now = new Date()
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+    const startOfNextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1)
+    const startOfYear = new Date(now.getFullYear(), 0, 1)
+    const startOfNextYear = new Date(now.getFullYear() + 1, 0, 1)
+    const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+
+    // Any payment state beyond NOT_PAID counts as a realized booking.
+    const paidPaymentStates: PaymentStatus[] = [
+      PaymentStatus.CLIENT_PAID,
+      PaymentStatus.MID_TRANSFER_REQ,
+      PaymentStatus.MID_TRANSFER_DONE,
+      PaymentStatus.REST_TRANSFER_REQ,
+      PaymentStatus.REST_TRANSFER_DONE,
+      PaymentStatus.FULL_TRANSFER_REQ,
+      PaymentStatus.FULL_TRANSFER_DONE,
+    ]
+
+    const [
+      usersTotal,
+      newUsersThisWeek,
+      productsActive,
+      productsWaiting,
+      rentsThisMonth,
+      rentsYearly,
+      revenueThisMonthAgg,
+      reviewsPendingModeration,
+      withdrawalsPending,
+    ] = await Promise.all([
+      prisma.user.count(),
+      prisma.user.count({ where: { createdAt: { gte: sevenDaysAgo } } }),
+      prisma.product.count({
+        where: { validate: ProductValidation.Approve, isDraft: false },
+      }),
+      prisma.product.count({
+        where: {
+          isDraft: false,
+          validate: {
+            in: [ProductValidation.NotVerified, ProductValidation.RecheckRequest],
+          },
+        },
+      }),
+      prisma.rent.count({
+        where: {
+          arrivingDate: { gte: startOfMonth, lt: startOfNextMonth },
+          payment: { in: paidPaymentStates },
+        },
+      }),
+      prisma.rent.count({
+        where: {
+          arrivingDate: { gte: startOfYear, lt: startOfNextYear },
+          payment: { in: paidPaymentStates },
+        },
+      }),
+      prisma.rent.aggregate({
+        _sum: { totalAmount: true },
+        where: {
+          arrivingDate: { gte: startOfMonth, lt: startOfNextMonth },
+          payment: { in: paidPaymentStates },
+        },
+      }),
+      prisma.review.count({ where: { approved: false } }),
+      prisma.withdrawalRequest.count({
+        where: {
+          status: { in: [WithdrawalStatus.PENDING, WithdrawalStatus.ACCOUNT_VALIDATION] },
+        },
+      }),
+    ])
+
+    return {
+      productsWaitingValidation: productsWaiting,
+      reviewsPendingModeration,
+      withdrawalsPending,
+      rentsThisMonth,
+      revenueThisMonth: revenueThisMonthAgg._sum.totalAmount ?? 0,
+      newUsersThisWeek,
+      productsWaiting,
+      usersTotal,
+      productsActive,
+      rentsYearly,
+    }
+  } catch (error) {
+    console.error('Erreur lors du chargement des stats dashboard admin:', error)
+    return null
+  }
+}
 
 export async function getAdminStatsYearly() {
   try {


### PR DESCRIPTION
## Summary

**Phase 1** of the admin panel modernization. Rebuilds the `/admin` landing page around a priority-first dashboard layout, modernizes the top admin navbar and the grouped section cards, and establishes a small shared design-system under `src/components/admin/ui/` that the next phases will reuse.

Ships with a drive-by fix for a `/admin/blog` runtime crash that surfaced during manual testing.

## Phase 1 — /admin dashboard

### New shared admin UI (`src/components/admin/ui/`)
- **`PageHeader`** — breadcrumb back link, uppercase eyebrow pill (icon + label), gradient title, right-side actions slot. Will be reused by `/admin/users`, `/admin/reservations` and the taxonomy pages in the following phases.
- **`KpiCard`** — primary hero card with big number and colored icon chip, plus a compact `KpiMetric` chip for secondary rows. 8 accent tones, optional `href`, loading skeleton variant.
- **`PriorityList`** — actionable-list widget where each row has a colored icon, title, description, count badge and href. Rows with `count === 0` are filtered out; when the list is empty, a friendly "Tout est à jour" state is shown instead.

### /admin page rewrite
Three-zone layout replacing the previous flat grid:
1. **Hero KPI row** — À valider · Réservations (mois) · Revenus (mois) · Nouveaux utilisateurs (7j)
2. **Two-column zone** — `Priorités du jour` (actionable list) on the left, `Vue d'ensemble` metric chips on the right
3. **Toutes les sections** — the existing grouped cards, relocated below, with the new modern look

Also:
- Silent refresh button in the header (no full-page skeleton on manual refresh).
- Page skeleton on first load instead of a centered spinner.
- Role-filtered KPIs, priorities and groups (HOST_MANAGER sees a reduced view).

### Dashboard stats service
- New `getAdminDashboardStats()` in `src/lib/services/stats.service.ts` fetches everything in a single `Promise.all`: products waiting / active, paid rents this month and this year, revenue this month (`Rent.totalAmount` aggregate on non-NOT_PAID payment states), reviews pending moderation, withdrawals pending and new users in the last 7 days.
- Legacy `getAdminStatsYearly()` is kept intact because `/admin/stats` still depends on it.

### ActionCardGroup redesign
- Cards now accept a `tone` prop (8 color accents) used to color the icon chip and the hover border, giving each card a clear visual identity instead of the old flat grey look.
- Group headers get their own tone too (Contenus blue, Utilisateurs indigo, Business emerald, Configuration slate).
- Cards animate in with a **local** stagger that does not depend on any ancestor variant state, avoiding the motion orchestration bug hit on `/dashboard/host` and `/admin/validation`.

### AdminNav redesign
- Logo replaced with a gradient `ShieldCheck` chip and a two-line "Hosteed / Admin Panel" label.
- Dropdown triggers: gradient underline to mark the active group with a shared `layoutId` for a smooth spring transition between sections.
- Dropdown items: colored icon chip on the left, active state mirrors the dashboard design language.
- Mobile menu redesigned with section labels, better spacing and the same icon-chip pattern.
- **Removed the "Voir le site" side link**: the admin panel is embedded in the main site and the global navbar is always visible, so that link was redundant.

## Drive-by fix — /admin/blog crash

`posts.filter is not a function` at `src/app/admin/blog/page.tsx:231` was crashing the page for any `ADMIN` user visiting `/admin/blog`.

**Root cause**: `getPost()` in `src/lib/services/post.service.ts` was updated to return a paginated shape `{ posts, pagination }` for internal use, but `/api/posts` still returned that object as-is for the no-`authorId` branch. The client then called `setPosts(data)` which stored the object instead of an array, and the stats block crashed on `posts.filter(...)`.

**Two-layer fix**:
- `src/app/api/posts/route.ts` — unwrap the paginated response so the public `/api/posts` contract stays a plain array. Request a high limit (1000) to preserve the previous "return all" behavior.
- `src/app/admin/blog/page.tsx` — defensive guard on `setPosts`: if the response is an object of shape `{ posts: [...] }`, extract the inner array; otherwise fall back to empty. Protects against future upstream leaks of the wrapped shape.

## Verified manually in Chrome DevTools

- `/admin` hard reload → dashboard renders with the new layout, stats load, priority list shows "4 avis à modérer", overview metrics show correct counts.
- `/admin/blog` renders 26 articles with stats block intact, search input filters correctly.
- Lint: 0 errors. `tsc --noEmit`: clean.

## Scope explicitly out

- No changes to `/admin/stats` page (still uses the legacy `getAdminStatsYearly()`).
- No changes to `/admin/overview` — will be merged with `/admin` in a later iteration.
- User asked to **stop at staging merge** for now — no `staging → main` promotion in this PR.

## Follow-up (Phase 2+)

Per the roadmap validated with the user:
- **Phase 2**: `/admin/users` redesign (data table + filters, reusing `PageHeader` and `KpiCard`).
- **Phase 3**: `/admin/reservations` + `/admin/withdrawals` redesign (shared `DataTable`).
- **Phase 4**: Taxonomy refactor — generic `<TaxonomyManager>` component backing 7 pages.
- **Phase 5** (newly added at the user's request): Blog admin pages redesign (`/admin/blog`, `/admin/blog/edit/[id]`, `/createPost`).