### PR TITLE
feat(admin): redesign user detail page + user modals + real avatars

### DIFF
--- a/src/app/admin/users/[id]/UserDetailsClient.tsx
+++ b/src/app/admin/users/[id]/UserDetailsClient.tsx
@@ -1,16 +1,33 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
+import { motion, Variants } from 'framer-motion'
 import { useAuth } from '@/hooks/useAuth'
-import Link from 'next/link'
-import { motion } from 'framer-motion'
-import { Button } from '@/components/ui/shadcnui/button'
-import { ArrowLeft } from 'lucide-react'
+import { isFullAdmin } from '@/hooks/useAdminAuth'
+import { Shield } from 'lucide-react'
 import type { ExtendedUser } from './types'
 import { LoadingDisplay } from './components/LoadingDisplay'
 import { UserPersonalInfo } from './components/UserPersonalInfo'
 import { UserListingsAndBookings } from './components/UserListingsAndBookings'
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+
+const containerVariants: Variants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.08 },
+  },
+}
+
+const itemVariants: Variants = {
+  hidden: { opacity: 0, y: 12 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { type: 'tween', duration: 0.4, ease: 'easeOut' },
+  },
+}
 
 interface UserDetailsClientProps {
   initialData: ExtendedUser
@@ -23,17 +40,14 @@ export function UserDetailsClient({ initialData }: UserDetailsClientProps) {
     isAuthenticated,
   } = useAuth({ required: true, redirectTo: '/auth' })
   const router = useRouter()
-  const [user] = useState<ExtendedUser>(initialData)
-  const [loading] = useState(false)
 
   useEffect(() => {
-    if (isAuthenticated && (!session?.user?.roles || session.user.roles !== 'ADMIN')) {
+    if (isAuthenticated && (!session?.user?.roles || !isFullAdmin(session.user.roles))) {
       router.push('/')
-      return
     }
   }, [isAuthenticated, session, router])
 
-  if (isAuthLoading || loading) {
+  if (isAuthLoading) {
     return <LoadingDisplay />
   }
 
@@ -42,57 +56,36 @@ export function UserDetailsClient({ initialData }: UserDetailsClientProps) {
   }
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100'>
-      <div className='container mx-auto p-6 space-y-8'>
-        <motion.div
-          className='space-y-6'
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-        >
-          {/* Header avec navigation */}
-          <div className='flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border-0'>
-            <div>
-              <h1 className='text-3xl font-bold bg-gradient-to-r from-gray-900 via-blue-800 to-indigo-800 bg-clip-text text-transparent'>
-                Profil Utilisateur
-              </h1>
-              <p className='text-gray-600 mt-1'>
-                Informations détaillées et activité de l&apos;utilisateur
-              </p>
-            </div>
-            <Button
-              variant='outline'
-              asChild
-              className='rounded-xl border-gray-200 hover:bg-gray-50'
-            >
-              <Link href='/admin/users' className='flex items-center gap-2'>
-                <ArrowLeft className='h-4 w-4' />
-                <span>Retour à la liste</span>
-              </Link>
-            </Button>
-          </div>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        variants={containerVariants}
+        initial='hidden'
+        animate='visible'
+      >
+        <motion.div variants={itemVariants}>
+          <PageHeader
+            backHref='/admin/users'
+            backLabel='Retour à la liste'
+            eyebrow='Espace administrateur'
+            eyebrowIcon={Shield}
+            title='Profil utilisateur'
+            subtitle='Informations détaillées, annonces et réservations de cet utilisateur.'
+          />
+        </motion.div>
 
-          {/* Contenu principal */}
-          <div className='grid grid-cols-1 xl:grid-cols-4 gap-8'>
-            <div className='xl:col-span-1'>
-              <UserPersonalInfo user={user} />
-            </div>
-            <div className='xl:col-span-3'>
-              <UserListingsAndBookings
-                userId={user.id}
-                user={{
-                  id: user.id,
-                  name: user.name,
-                  email: user.email,
-                  role: user.roles,
-                }}
-                posts={[]}
-                bookings={[]}
-              />
-            </div>
+        <motion.div
+          variants={itemVariants}
+          className='grid gap-6 xl:grid-cols-[minmax(0,20rem)_minmax(0,1fr)]'
+        >
+          <div>
+            <UserPersonalInfo user={initialData} />
+          </div>
+          <div>
+            <UserListingsAndBookings user={initialData} />
           </div>
         </motion.div>
-      </div>
+      </motion.div>
     </div>
   )
 }

--- a/src/app/admin/users/[id]/components/UserListingsAndBookings.tsx
+++ b/src/app/admin/users/[id]/components/UserListingsAndBookings.tsx
@@ -1,247 +1,227 @@
 'use client'
 
-import { MapPin, Calendar, Euro, Home } from 'lucide-react'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import { Button } from '@/components/ui/shadcnui/button'
 import Link from 'next/link'
-import Image from 'next/image'
+import { MapPin, Calendar, Home, CalendarClock, ArrowUpRight, Receipt } from 'lucide-react'
+import { KpiCard } from '@/components/admin/ui/KpiCard'
+import type { ExtendedUser, ExtendedRent } from '../types'
+import { Product } from '@prisma/client'
 
 interface UserListingsAndBookingsProps {
-  userId: string
-  user: {
-    id: string
-    name: string | null
-    email: string
-    role: string
-  }
-  posts: Array<{
-    id: string
-    title: string
-    description: string
-    price: number
-    location: string
-    images: string[]
-    status: string
-    createdAt: Date
-    isPromoted?: boolean
-  }>
-  bookings: Array<{
-    id: string
-    product: {
-      id: string
-      title: string
-      price: number
-      location: string
-      images: string[]
-    }
-    totalPrice: number
-    startDate: Date
-    endDate: Date
-    status: string
-    createdAt: Date
-  }>
+  user: ExtendedUser
 }
 
-export function UserListingsAndBookings({ posts, bookings }: UserListingsAndBookingsProps) {
-  // Calculer les statistiques
-  const totalEarnings = bookings
-    .filter(booking => booking.status === 'CONFIRMED')
-    .reduce((sum, booking) => sum + booking.totalPrice, 0)
+const PAYMENT_PAID_STATES = new Set([
+  'CLIENT_PAID',
+  'MID_TRANSFER_REQ',
+  'MID_TRANSFER_DONE',
+  'REST_TRANSFER_REQ',
+  'REST_TRANSFER_DONE',
+  'FULL_TRANSFER_REQ',
+  'FULL_TRANSFER_DONE',
+])
 
-  const activePosts = posts.filter(post => post.status === 'APPROVED').length
-  const totalBookings = bookings.length
+const VALIDATION_LABEL: Record<string, { label: string; tone: string }> = {
+  Approve: { label: 'Validé', tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200' },
+  NotVerified: { label: 'En attente', tone: 'bg-amber-50 text-amber-700 ring-amber-200' },
+  RecheckRequest: {
+    label: 'Révision demandée',
+    tone: 'bg-orange-50 text-orange-700 ring-orange-200',
+  },
+  Refused: { label: 'Refusé', tone: 'bg-red-50 text-red-700 ring-red-200' },
+  ModificationPending: {
+    label: 'Modification en attente',
+    tone: 'bg-purple-50 text-purple-700 ring-purple-200',
+  },
+}
+
+const RENT_STATUS_LABEL: Record<string, { label: string; tone: string }> = {
+  WAITING: { label: 'En attente', tone: 'bg-amber-50 text-amber-700 ring-amber-200' },
+  RESERVED: { label: 'Réservée', tone: 'bg-blue-50 text-blue-700 ring-blue-200' },
+  CHECKIN: { label: 'Check-in', tone: 'bg-indigo-50 text-indigo-700 ring-indigo-200' },
+  CHECKOUT: { label: 'Check-out', tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200' },
+  CANCEL: { label: 'Annulée', tone: 'bg-red-50 text-red-700 ring-red-200' },
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(amount)
+}
+
+export function UserListingsAndBookings({ user }: UserListingsAndBookingsProps) {
+  const products: Product[] = user.Product ?? []
+  const rents: ExtendedRent[] = user.Rent ?? []
+
+  const paidRents = rents.filter(r => PAYMENT_PAID_STATES.has(r.payment as unknown as string))
+  const totalSpent = paidRents.reduce((sum, r) => sum + (r.totalAmount ?? 0), 0)
+
+  const activeListings = products.filter(
+    p => (p as Product).validate === 'Approve' && !(p as Product).isDraft
+  ).length
 
   return (
-    <div className='space-y-8'>
-      {/* Statistiques */}
-      <div className='grid grid-cols-1 md:grid-cols-3 gap-6'>
-        <Card className='border-0 shadow-lg bg-gradient-to-r from-blue-500 to-blue-600 text-white rounded-2xl'>
-          <CardContent className='p-6'>
-            <div className='flex items-center justify-between'>
-              <div>
-                <p className='text-blue-100 text-sm font-medium'>Revenus totaux</p>
-                <p className='text-2xl font-bold mt-1'>{totalEarnings}€</p>
-              </div>
-              <div className='bg-white/20 p-3 rounded-full'>
-                <Euro className='h-6 w-6 text-white' />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className='border-0 shadow-lg bg-gradient-to-r from-green-500 to-green-600 text-white rounded-2xl'>
-          <CardContent className='p-6'>
-            <div className='flex items-center justify-between'>
-              <div>
-                <p className='text-green-100 text-sm font-medium'>Annonces actives</p>
-                <p className='text-2xl font-bold mt-1'>{activePosts}</p>
-              </div>
-              <div className='bg-white/20 p-3 rounded-full'>
-                <Home className='h-6 w-6 text-white' />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className='border-0 shadow-lg bg-gradient-to-r from-purple-500 to-purple-600 text-white rounded-2xl'>
-          <CardContent className='p-6'>
-            <div className='flex items-center justify-between'>
-              <div>
-                <p className='text-purple-100 text-sm font-medium'>Réservations</p>
-                <p className='text-2xl font-bold mt-1'>{totalBookings}</p>
-              </div>
-              <div className='bg-white/20 p-3 rounded-full'>
-                <Calendar className='h-6 w-6 text-white' />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+    <div className='space-y-6'>
+      {/* Stats row */}
+      <div className='grid gap-4 md:grid-cols-3'>
+        <KpiCard
+          label='Dépensé total'
+          value={formatCurrency(totalSpent)}
+          hint='sur les réservations payées'
+          icon={Receipt}
+          tone='emerald'
+        />
+        <KpiCard
+          label='Annonces actives'
+          value={activeListings}
+          hint={`${products.length} au total`}
+          icon={Home}
+          tone='blue'
+        />
+        <KpiCard
+          label='Réservations'
+          value={rents.length}
+          hint={`${paidRents.length} payées`}
+          icon={Calendar}
+          tone='purple'
+        />
       </div>
 
-      {/* Annonces de l'utilisateur */}
-      <Card className='border-0 shadow-lg rounded-2xl'>
-        <CardHeader className='pb-4'>
-          <CardTitle className='text-xl font-bold text-gray-900 flex items-center gap-2'>
-            <Home className='h-5 w-5 text-blue-600' />
-            Annonces ({posts.length})
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {posts.length === 0 ? (
-            <div className='text-center py-12'>
-              <Home className='h-12 w-12 text-gray-300 mx-auto mb-4' />
-              <p className='text-gray-500'>Aucune annonce trouvée</p>
-            </div>
-          ) : (
-            <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
-              {posts.map(post => (
-                <div
-                  key={post.id}
-                  className='border border-gray-200 rounded-xl overflow-hidden hover:shadow-md transition-shadow'
-                >
-                  {post.images && post.images.length > 0 && (
-                    <div className='aspect-video bg-gray-100 relative'>
-                      <Image
-                        src={post.images[0]}
-                        alt={post.title}
-                        fill
-                        className='object-cover'
-                        unoptimized
-                      />
-                      {post.isPromoted && (
-                        <Badge className='absolute top-2 right-2 bg-yellow-500 text-white border-0'>
-                          Sponsorisé
-                        </Badge>
-                      )}
-                    </div>
-                  )}
-                  <div className='p-4'>
-                    <h3 className='font-medium text-gray-900 mb-2 line-clamp-2'>{post.title}</h3>
-                    <div className='flex items-center gap-1 text-gray-500 text-sm mb-2'>
-                      <MapPin className='h-4 w-4' />
-                      <span>{post.location}</span>
-                    </div>
-                    <div className='flex items-center justify-between'>
-                      <span className='font-bold text-blue-600'>{post.price}€/nuit</span>
-                      <Badge
-                        variant={
-                          post.status === 'APPROVED'
-                            ? 'default'
-                            : post.status === 'PENDING'
-                              ? 'secondary'
-                              : 'destructive'
-                        }
-                      >
-                        {post.status === 'APPROVED'
-                          ? 'Approuvé'
-                          : post.status === 'PENDING'
-                            ? 'En attente'
-                            : 'Rejeté'}
-                      </Badge>
-                    </div>
-                    <div className='mt-3'>
-                      <Button variant='outline' size='sm' asChild className='w-full'>
-                        <Link href={`/posts/${post.id}`}>Voir l&apos;annonce</Link>
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
+      {/* Listings */}
+      <div className='rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm'>
+        <div className='mb-4 flex items-center justify-between'>
+          <h3 className='text-lg font-semibold text-slate-900'>
+            Annonces possédées{' '}
+            <span className='text-sm font-normal text-slate-500'>({products.length})</span>
+          </h3>
+          {products.length > 0 && (
+            <Link
+              href={`/admin/products?ownerId=${user.id}`}
+              className='text-xs font-medium text-blue-600 hover:underline'
+            >
+              Voir tout
+            </Link>
           )}
-        </CardContent>
-      </Card>
+        </div>
 
-      {/* Réservations de l'utilisateur */}
-      <Card className='border-0 shadow-lg rounded-2xl'>
-        <CardHeader className='pb-4'>
-          <CardTitle className='text-xl font-bold text-gray-900 flex items-center gap-2'>
-            <Calendar className='h-5 w-5 text-purple-600' />
-            Réservations ({bookings.length})
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {bookings.length === 0 ? (
-            <div className='text-center py-12'>
-              <Calendar className='h-12 w-12 text-gray-300 mx-auto mb-4' />
-              <p className='text-gray-500'>Aucune réservation trouvée</p>
+        {products.length === 0 ? (
+          <div className='flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-200 py-10 text-center'>
+            <div className='mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 text-slate-400'>
+              <Home className='h-6 w-6' />
             </div>
-          ) : (
-            <div className='space-y-4'>
-              {bookings.map(booking => (
-                <div
-                  key={booking.id}
-                  className='border border-gray-200 rounded-xl p-4 hover:shadow-md transition-shadow'
+            <p className='text-sm font-semibold text-slate-900'>Aucune annonce</p>
+            <p className='mt-0.5 text-xs text-slate-500'>
+              Cet utilisateur n’a pas encore créé d’annonce.
+            </p>
+          </div>
+        ) : (
+          <div className='space-y-2'>
+            {products.map(product => {
+              const validation =
+                VALIDATION_LABEL[product.validate] ?? {
+                  label: product.validate,
+                  tone: 'bg-slate-100 text-slate-700 ring-slate-200',
+                }
+              return (
+                <Link
+                  key={product.id}
+                  href={`/admin/validation/${product.id}`}
+                  className='group flex items-center gap-4 rounded-xl border border-slate-200 bg-white p-3 transition hover:border-blue-200 hover:bg-blue-50/30'
                 >
-                  <div className='flex items-start gap-4'>
-                    {booking.product.images && booking.product.images.length > 0 && (
-                      <div className='w-20 h-20 bg-gray-100 rounded-lg overflow-hidden flex-shrink-0 relative'>
-                        <Image
-                          src={booking.product.images[0]}
-                          alt={booking.product.title}
-                          fill
-                          className='object-cover'
-                          unoptimized
-                        />
-                      </div>
+                  <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600'>
+                    <Home className='h-5 w-5' />
+                  </div>
+                  <div className='min-w-0 flex-1'>
+                    <p className='truncate text-sm font-semibold text-slate-900 group-hover:text-blue-700'>
+                      {product.name}
+                    </p>
+                    <p className='truncate text-xs text-slate-500'>
+                      <MapPin className='mr-1 inline h-3 w-3' />
+                      {product.address}
+                    </p>
+                  </div>
+                  <div className='flex items-center gap-3'>
+                    <span className='text-sm font-bold text-slate-900 tabular-nums'>
+                      {product.basePrice}€
+                      <span className='text-xs font-normal text-slate-500'>/nuit</span>
+                    </span>
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-semibold ring-1 ${validation.tone}`}
+                    >
+                      {validation.label}
+                    </span>
+                    <ArrowUpRight className='h-4 w-4 text-slate-300 transition group-hover:text-slate-600' />
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Bookings */}
+      <div className='rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm'>
+        <div className='mb-4 flex items-center justify-between'>
+          <h3 className='text-lg font-semibold text-slate-900'>
+            Réservations effectuées{' '}
+            <span className='text-sm font-normal text-slate-500'>({rents.length})</span>
+          </h3>
+        </div>
+
+        {rents.length === 0 ? (
+          <div className='flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-200 py-10 text-center'>
+            <div className='mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 text-slate-400'>
+              <Calendar className='h-6 w-6' />
+            </div>
+            <p className='text-sm font-semibold text-slate-900'>Aucune réservation</p>
+            <p className='mt-0.5 text-xs text-slate-500'>
+              Cet utilisateur n’a effectué aucune réservation.
+            </p>
+          </div>
+        ) : (
+          <div className='space-y-2'>
+            {rents.map(rent => {
+              const status = RENT_STATUS_LABEL[rent.status as unknown as string] ?? {
+                label: rent.status,
+                tone: 'bg-slate-100 text-slate-700 ring-slate-200',
+              }
+              return (
+                <div
+                  key={rent.id}
+                  className='flex items-center gap-4 rounded-xl border border-slate-200 bg-white p-3'
+                >
+                  <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-purple-50 text-purple-600'>
+                    <CalendarClock className='h-5 w-5' />
+                  </div>
+                  <div className='min-w-0 flex-1'>
+                    <p className='truncate text-sm font-semibold text-slate-900'>
+                      Réservation #{rent.id.slice(-6)}
+                    </p>
+                    <p className='truncate text-xs text-slate-500'>
+                      <Calendar className='mr-1 inline h-3 w-3' />
+                      {new Date(rent.arrivingDate).toLocaleDateString('fr-FR')} →{' '}
+                      {new Date(rent.leavingDate).toLocaleDateString('fr-FR')}
+                    </p>
+                  </div>
+                  <div className='flex items-center gap-3'>
+                    {rent.totalAmount != null && (
+                      <span className='text-sm font-bold text-slate-900 tabular-nums'>
+                        {formatCurrency(rent.totalAmount)}
+                      </span>
                     )}
-                    <div className='flex-1 min-w-0'>
-                      <h3 className='font-medium text-gray-900 mb-1'>{booking.product.title}</h3>
-                      <div className='flex items-center gap-1 text-gray-500 text-sm mb-2'>
-                        <MapPin className='h-4 w-4' />
-                        <span>{booking.product.location}</span>
-                      </div>
-                      <div className='text-sm text-gray-600 mb-2'>
-                        {new Date(booking.startDate).toLocaleDateString('fr-FR')} -{' '}
-                        {new Date(booking.endDate).toLocaleDateString('fr-FR')}
-                      </div>
-                      <div className='flex items-center justify-between'>
-                        <span className='font-bold text-green-600'>{booking.totalPrice}€</span>
-                        <Badge
-                          variant={
-                            booking.status === 'CONFIRMED'
-                              ? 'default'
-                              : booking.status === 'PENDING'
-                                ? 'secondary'
-                                : 'destructive'
-                          }
-                        >
-                          {booking.status === 'CONFIRMED'
-                            ? 'Confirmé'
-                            : booking.status === 'PENDING'
-                              ? 'En attente'
-                              : 'Annulé'}
-                        </Badge>
-                      </div>
-                    </div>
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-semibold ring-1 ${status.tone}`}
+                    >
+                      {status.label}
+                    </span>
                   </div>
                 </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+              )
+            })}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/app/admin/users/[id]/components/UserPersonalInfo.tsx
+++ b/src/app/admin/users/[id]/components/UserPersonalInfo.tsx
@@ -1,123 +1,162 @@
 'use client'
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/shadcnui/avatar'
-import { Button } from '@/components/ui/shadcnui/button'
-import { User as UserIcon, Mail, Calendar, Shield, Edit3 } from 'lucide-react'
+import {
+  User as UserIcon,
+  Mail,
+  Calendar,
+  ShieldCheck,
+  MailCheck,
+  MailX,
+  BadgeCheck,
+  Phone,
+} from 'lucide-react'
 import type { ExtendedUser } from '../types'
-import { RoleBadge } from '@/components/ui/RoleBadge'
+import { getUserAvatarUrl } from '@/lib/utils/userAvatar'
+
+/**
+ * Ordered list of roles with Lucide icons and accent tones.
+ * Kept in sync with the list page `RolePill`.
+ */
+const ROLE_CONFIG: Record<
+  string,
+  { label: string; accent: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  ADMIN: {
+    label: 'Administrateur',
+    accent: 'bg-purple-50 text-purple-700 ring-purple-200',
+    icon: ShieldCheck,
+  },
+  HOST_MANAGER: {
+    label: 'Gestionnaire Hôtes',
+    accent: 'bg-indigo-50 text-indigo-700 ring-indigo-200',
+    icon: ShieldCheck,
+  },
+  BLOGWRITER: {
+    label: 'Rédacteur Blog',
+    accent: 'bg-blue-50 text-blue-700 ring-blue-200',
+    icon: BadgeCheck,
+  },
+  HOST_VERIFIED: {
+    label: 'Hôte Vérifié',
+    accent: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: BadgeCheck,
+  },
+  HOST: {
+    label: 'Hôte',
+    accent: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: UserIcon,
+  },
+  USER: {
+    label: 'Utilisateur',
+    accent: 'bg-slate-100 text-slate-700 ring-slate-200',
+    icon: UserIcon,
+  },
+}
+
+interface InfoRowProps {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  value: React.ReactNode
+  tone?: 'slate' | 'emerald' | 'amber'
+}
+
+function InfoRow({ icon: Icon, label, value, tone = 'slate' }: InfoRowProps) {
+  const toneClass: Record<NonNullable<InfoRowProps['tone']>, string> = {
+    slate: 'bg-slate-100 text-slate-600',
+    emerald: 'bg-emerald-50 text-emerald-600',
+    amber: 'bg-amber-50 text-amber-600',
+  }
+  return (
+    <div className='flex items-start gap-3'>
+      <div
+        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${toneClass[tone]}`}
+      >
+        <Icon className='h-4 w-4' />
+      </div>
+      <div className='min-w-0 flex-1'>
+        <p className='text-xs font-medium uppercase tracking-wide text-slate-400'>{label}</p>
+        <div className='mt-0.5 text-sm font-medium text-slate-900'>{value}</div>
+      </div>
+    </div>
+  )
+}
 
 interface UserPersonalInfoProps {
   user: ExtendedUser
 }
 
 export function UserPersonalInfo({ user }: UserPersonalInfoProps) {
+  const displayName =
+    user.name || user.lastname
+      ? `${user.name || ''} ${user.lastname || ''}`.trim()
+      : 'Utilisateur sans nom'
+
+  const role = ROLE_CONFIG[user.roles] ?? ROLE_CONFIG.USER
+  const RoleIcon = role.icon
+
   return (
-    <div className='space-y-6'>
-      {/* Photo de profil et informations principales */}
-      <Card className='border-0 shadow-xl bg-white rounded-2xl overflow-hidden'>
-        <div className='relative h-24 bg-gradient-to-r from-blue-500 via-purple-500 to-indigo-600'>
+    <div className='space-y-4'>
+      {/* Profile header card */}
+      <div className='overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm'>
+        <div className='relative h-24 bg-gradient-to-br from-blue-500 via-indigo-500 to-purple-500'>
           <div className='absolute inset-0 bg-black/10' />
         </div>
-        <CardContent className='p-4 -mt-12 relative'>
-          <div className='flex flex-col items-center text-center space-y-3'>
-            <Avatar className='h-20 w-20 border-4 border-white shadow-lg'>
-              <AvatarImage
-                src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${user.email}`}
-                className='object-cover'
-              />
-              <AvatarFallback className='bg-gradient-to-r from-blue-500 to-indigo-600 text-white text-xl font-bold'>
-                {(user.name?.[0] || user.email[0]).toUpperCase()}
-              </AvatarFallback>
-            </Avatar>
-
-            <div className='space-y-1'>
-              <h2 className='text-xl font-bold text-gray-900'>
-                {user.name || user.lastname
-                  ? `${user.name || ''} ${user.lastname || ''}`.trim()
-                  : 'Utilisateur sans nom'}
-              </h2>
-              <p className='text-gray-500 text-sm flex items-center justify-center gap-1'>
-                <Mail className='h-3 w-3' />
-                {user.email}
-              </p>
-            </div>
-
-            <RoleBadge role={user.roles} size='sm' />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Informations détaillées */}
-      <Card className='border-0 shadow-lg bg-white rounded-2xl'>
-        <CardHeader className='pb-3'>
-          <CardTitle className='flex items-center gap-2 text-lg'>
-            <UserIcon className='h-4 w-4 text-blue-600' />
-            Informations
-          </CardTitle>
-        </CardHeader>
-        <CardContent className='space-y-4'>
-          <div className='space-y-3'>
-            <div className='flex items-center gap-3 p-3 bg-gray-50 rounded-lg'>
-              <div className='p-1.5 bg-blue-100 rounded-lg'>
-                <Calendar className='h-3.5 w-3.5 text-blue-600' />
-              </div>
-              <div className='flex-1 min-w-0'>
-                <p className='text-xs text-gray-500'>Inscription</p>
-                <p className='text-sm font-medium text-gray-900 truncate'>
-                  {new Date(user.createdAt).toLocaleDateString('fr-FR', {
-                    year: 'numeric',
-                    month: 'short',
-                    day: 'numeric',
-                  })}
-                </p>
-              </div>
-            </div>
-
-            <div className='flex items-center gap-3 p-3 bg-gray-50 rounded-lg'>
-              <div className='p-1.5 bg-green-100 rounded-lg'>
-                <Shield className='h-3.5 w-3.5 text-green-600' />
-              </div>
-              <div className='flex-1 min-w-0'>
-                <p className='text-xs text-gray-500'>Email</p>
-                <div className='flex items-center gap-2'>
-                  <span className='text-sm font-medium text-gray-900'>
-                    {user.emailVerified ? 'Vérifié' : 'Non vérifié'}
-                  </span>
-                  <div
-                    className={`h-1.5 w-1.5 rounded-full ${user.emailVerified ? 'bg-green-500' : 'bg-orange-500'}`}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Actions rapides */}
-      <Card className='border-0 shadow-lg bg-white rounded-2xl'>
-        <CardHeader className='pb-3'>
-          <CardTitle className='text-lg'>Actions</CardTitle>
-        </CardHeader>
-        <CardContent className='space-y-2'>
-          <Button variant='outline' size='sm' className='w-full justify-start rounded-lg text-sm'>
-            <Edit3 className='h-3.5 w-3.5 mr-2' />
-            Modifier
-          </Button>
-          <Button variant='outline' size='sm' className='w-full justify-start rounded-lg text-sm'>
-            <Mail className='h-3.5 w-3.5 mr-2' />
-            Email
-          </Button>
-          <Button
-            variant='outline'
-            size='sm'
-            className='w-full justify-start rounded-lg text-sm text-red-600 hover:text-red-700 hover:bg-red-50'
+        <div className='relative -mt-12 flex flex-col items-center px-6 pb-6 text-center'>
+          <Avatar className='h-24 w-24 border-4 border-white shadow-lg'>
+            <AvatarImage src={getUserAvatarUrl(user)} alt={displayName} />
+            <AvatarFallback className='bg-gradient-to-br from-indigo-500 to-purple-500 text-2xl font-bold text-white'>
+              {(user.name?.[0] || user.email[0]).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <h2 className='mt-4 text-xl font-bold text-slate-900'>{displayName}</h2>
+          <p className='mt-0.5 flex items-center gap-1.5 text-sm text-slate-500'>
+            <Mail className='h-3.5 w-3.5' />
+            <span className='truncate max-w-[220px]'>{user.email}</span>
+          </p>
+          <span
+            className={`mt-3 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold ring-1 ${role.accent}`}
           >
-            <Shield className='h-3.5 w-3.5 mr-2' />
-            Suspendre
-          </Button>
-        </CardContent>
-      </Card>
+            <RoleIcon className='h-3 w-3' />
+            {role.label}
+          </span>
+        </div>
+      </div>
+
+      {/* Info card */}
+      <div className='rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm'>
+        <h3 className='mb-4 text-sm font-semibold uppercase tracking-wide text-slate-500'>
+          Informations
+        </h3>
+        <div className='space-y-4'>
+          <InfoRow
+            icon={Calendar}
+            label='Inscrit le'
+            value={new Date(user.createdAt).toLocaleDateString('fr-FR', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          />
+          <InfoRow
+            icon={user.emailVerified ? MailCheck : MailX}
+            label='Email'
+            tone={user.emailVerified ? 'emerald' : 'amber'}
+            value={
+              <span
+                className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-semibold ${
+                  user.emailVerified
+                    ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
+                    : 'bg-amber-50 text-amber-700 ring-1 ring-amber-200'
+                }`}
+              >
+                {user.emailVerified ? 'Vérifié' : 'Non vérifié'}
+              </span>
+            }
+          />
+          {user.info && <InfoRow icon={Phone} label='Bio' value={user.info} />}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/app/admin/users/components/ConfirmDeleteUserDialog.tsx
+++ b/src/app/admin/users/components/ConfirmDeleteUserDialog.tsx
@@ -9,7 +9,15 @@ import {
   DialogTitle,
 } from '@/components/ui/shadcnui/dialog'
 import { Button } from '@/components/ui/shadcnui/button'
-import { Loader2, Trash2, AlertTriangle, Package, CalendarDays } from 'lucide-react'
+import {
+  Loader2,
+  Trash2,
+  AlertTriangle,
+  Package,
+  CalendarDays,
+  ShieldAlert,
+  CalendarClock,
+} from 'lucide-react'
 
 interface ActiveRent {
   id: string
@@ -40,10 +48,30 @@ interface ConfirmDeleteUserDialogProps {
 function formatStatus(status: string) {
   const labels: Record<string, string> = {
     WAITING: 'En attente',
-    RESERVED: 'Reservee',
+    RESERVED: 'Réservée',
     CHECKIN: 'Check-in',
+    CHECKOUT: 'Check-out',
+    CANCEL: 'Annulée',
   }
   return labels[status] || status
+}
+
+function ActiveRentRow({ rent, showGuest }: { rent: ActiveRent; showGuest?: boolean }) {
+  return (
+    <li className='flex items-start gap-3 rounded-xl border border-red-100 bg-red-50/60 p-3'>
+      <div className='mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-white text-red-600 shadow-sm'>
+        <CalendarClock className='h-3.5 w-3.5' />
+      </div>
+      <div className='min-w-0 flex-1'>
+        <p className='truncate text-sm font-semibold text-slate-900'>{rent.product.name}</p>
+        <p className='text-xs text-slate-600'>
+          {formatStatus(rent.status)} · {new Date(rent.arrivingDate).toLocaleDateString('fr-FR')}{' '}
+          → {new Date(rent.leavingDate).toLocaleDateString('fr-FR')}
+          {showGuest && rent.user && ` · ${rent.user.name || rent.user.email}`}
+        </p>
+      </div>
+    </li>
+  )
 }
 
 export function ConfirmDeleteUserDialog({
@@ -55,79 +83,101 @@ export function ConfirmDeleteUserDialog({
 }: ConfirmDeleteUserDialogProps) {
   if (!deletionInfo) return null
 
-  const { user, ownedProductCount, rentCount, activeRentsAsGuest, activeRentsAsHost, hasActiveReservations } = deletionInfo
+  const {
+    user,
+    ownedProductCount,
+    rentCount,
+    activeRentsAsGuest,
+    activeRentsAsHost,
+    hasActiveReservations,
+  } = deletionInfo
   const displayName = [user.name, user.lastname].filter(Boolean).join(' ') || user.email
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className='sm:max-w-[520px]'>
+      <DialogContent className='sm:max-w-[560px]'>
         <DialogHeader>
-          <DialogTitle className='flex items-center gap-2'>
-            <AlertTriangle className='h-5 w-5 text-red-600' />
-            Supprimer l&apos;utilisateur
-          </DialogTitle>
-          <DialogDescription>
-            {hasActiveReservations
-              ? `Impossible de supprimer "${displayName}" car il a des reservations actives.`
-              : `Etes-vous sur de vouloir supprimer definitivement "${displayName}" ? Cette action est irreversible.`}
-          </DialogDescription>
+          <div className='flex items-start gap-3'>
+            <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-red-50 text-red-600 ring-1 ring-red-100'>
+              <AlertTriangle className='h-5 w-5' />
+            </div>
+            <div className='min-w-0 flex-1 space-y-1'>
+              <DialogTitle className='text-lg'>
+                {hasActiveReservations
+                  ? 'Suppression impossible'
+                  : "Supprimer l'utilisateur"}
+              </DialogTitle>
+              <DialogDescription className='text-sm text-slate-600'>
+                {hasActiveReservations ? (
+                  <>
+                    <span className='font-semibold text-slate-900'>{displayName}</span> a des
+                    réservations actives et ne peut pas être supprimé pour le moment.
+                  </>
+                ) : (
+                  <>
+                    Cette action supprimera définitivement{' '}
+                    <span className='font-semibold text-slate-900'>{displayName}</span> et toutes
+                    ses données associées. Elle est <strong>irréversible</strong>.
+                  </>
+                )}
+              </DialogDescription>
+            </div>
+          </div>
         </DialogHeader>
 
+        {/* Impact summary */}
         <div className='space-y-4 py-2'>
-          <div className='flex gap-4 text-sm text-gray-600'>
-            <div className='flex items-center gap-1.5'>
-              <Package className='h-4 w-4' />
-              <span>{ownedProductCount} hebergement{ownedProductCount > 1 ? 's' : ''}</span>
+          <div className='grid grid-cols-2 gap-3'>
+            <div className='flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50/60 px-3 py-2.5'>
+              <div className='flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600'>
+                <Package className='h-4 w-4' />
+              </div>
+              <div className='min-w-0'>
+                <p className='text-xs text-slate-500'>Hébergements</p>
+                <p className='text-sm font-semibold text-slate-900'>
+                  {ownedProductCount} possédé{ownedProductCount > 1 ? 's' : ''}
+                </p>
+              </div>
             </div>
-            <div className='flex items-center gap-1.5'>
-              <CalendarDays className='h-4 w-4' />
-              <span>{rentCount} reservation{rentCount > 1 ? 's' : ''} (total)</span>
+            <div className='flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50/60 px-3 py-2.5'>
+              <div className='flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-purple-50 text-purple-600'>
+                <CalendarDays className='h-4 w-4' />
+              </div>
+              <div className='min-w-0'>
+                <p className='text-xs text-slate-500'>Réservations</p>
+                <p className='text-sm font-semibold text-slate-900'>
+                  {rentCount} au total
+                </p>
+              </div>
             </div>
           </div>
 
           {hasActiveReservations && (
-            <div className='space-y-3'>
+            <div className='space-y-3 rounded-xl border border-red-200 bg-red-50/40 p-4'>
+              <div className='flex items-center gap-2 text-sm font-semibold text-red-700'>
+                <ShieldAlert className='h-4 w-4' />
+                Réservations actives bloquantes
+              </div>
               {activeRentsAsGuest.length > 0 && (
-                <div>
-                  <p className='text-sm font-medium text-gray-900 mb-2'>
-                    Reservations actives (en tant que voyageur) :
+                <div className='space-y-2'>
+                  <p className='text-xs font-medium uppercase tracking-wide text-slate-500'>
+                    En tant que voyageur ({activeRentsAsGuest.length})
                   </p>
-                  <ul className='space-y-1.5'>
+                  <ul className='space-y-2'>
                     {activeRentsAsGuest.map(rent => (
-                      <li
-                        key={rent.id}
-                        className='text-sm bg-red-50 border border-red-100 rounded-lg px-3 py-2'
-                      >
-                        <span className='font-medium'>{rent.product.name}</span>
-                        <span className='text-gray-500'>
-                          {' '}&mdash; {formatStatus(rent.status)} &mdash;{' '}
-                          {new Date(rent.arrivingDate).toLocaleDateString('fr-FR')} au{' '}
-                          {new Date(rent.leavingDate).toLocaleDateString('fr-FR')}
-                        </span>
-                      </li>
+                      <ActiveRentRow key={rent.id} rent={rent} />
                     ))}
                   </ul>
                 </div>
               )}
               {activeRentsAsHost.length > 0 && (
-                <div>
-                  <p className='text-sm font-medium text-gray-900 mb-2'>
-                    Reservations actives (en tant qu&apos;hote) :
+                <div className='space-y-2'>
+                  <p className='text-xs font-medium uppercase tracking-wide text-slate-500'>
+                    En tant qu’hôte ({activeRentsAsHost.length})
                   </p>
-                  <ul className='space-y-1.5'>
+                  <ul className='space-y-2'>
                     {activeRentsAsHost.map(rent => (
-                      <li
-                        key={rent.id}
-                        className='text-sm bg-red-50 border border-red-100 rounded-lg px-3 py-2'
-                      >
-                        <span className='font-medium'>{rent.product.name}</span>
-                        <span className='text-gray-500'>
-                          {' '}&mdash; {formatStatus(rent.status)} &mdash;{' '}
-                          {new Date(rent.arrivingDate).toLocaleDateString('fr-FR')} au{' '}
-                          {new Date(rent.leavingDate).toLocaleDateString('fr-FR')}
-                          {rent.user && ` (${rent.user.name || rent.user.email})`}
-                        </span>
-                      </li>
+                      <ActiveRentRow key={rent.id} rent={rent} showGuest />
                     ))}
                   </ul>
                 </div>
@@ -136,10 +186,14 @@ export function ConfirmDeleteUserDialog({
           )}
 
           {!hasActiveReservations && ownedProductCount > 0 && (
-            <p className='text-sm text-amber-700 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2'>
-              Attention : les {ownedProductCount} hebergement{ownedProductCount > 1 ? 's' : ''} de
-              cet utilisateur seront egalement supprimes.
-            </p>
+            <div className='flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50/60 p-3 text-sm'>
+              <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0 text-amber-600' />
+              <p className='text-amber-800'>
+                Les <strong>{ownedProductCount}</strong> hébergement
+                {ownedProductCount > 1 ? 's' : ''} de cet utilisateur seront également supprimé
+                {ownedProductCount > 1 ? 's' : ''}.
+              </p>
+            </div>
           )}
         </div>
 
@@ -148,16 +202,21 @@ export function ConfirmDeleteUserDialog({
             {hasActiveReservations ? 'Fermer' : 'Annuler'}
           </Button>
           {!hasActiveReservations && (
-            <Button variant='destructive' onClick={onConfirm} disabled={isLoading}>
+            <Button
+              variant='destructive'
+              onClick={onConfirm}
+              disabled={isLoading}
+              className='gap-2'
+            >
               {isLoading ? (
                 <>
                   <Loader2 className='h-4 w-4 animate-spin' />
-                  Suppression...
+                  Suppression…
                 </>
               ) : (
                 <>
                   <Trash2 className='h-4 w-4' />
-                  Supprimer
+                  Supprimer définitivement
                 </>
               )}
             </Button>

--- a/src/app/admin/users/components/EmailVerificationPanel.tsx
+++ b/src/app/admin/users/components/EmailVerificationPanel.tsx
@@ -12,7 +12,6 @@ import {
   DialogTrigger,
 } from '@/components/ui/shadcnui/dialog'
 import { Button } from '@/components/ui/shadcnui/button'
-import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
 import {
   Select,
   SelectContent,
@@ -21,7 +20,20 @@ import {
   SelectValue,
 } from '@/components/ui/shadcnui/select'
 import { Checkbox } from '@/components/ui/checkbox'
-import { Mail, Loader2, CheckCircle, XCircle, Users, User as UserIcon } from 'lucide-react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/shadcnui/avatar'
+import {
+  Mail,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  Users as UsersIcon,
+  User as UserIcon,
+  MailX,
+  MailCheck,
+  Send,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { getUserAvatarUrl } from '@/lib/utils/userAvatar'
 
 interface EmailVerificationPanelProps {
   users: User[]
@@ -35,9 +47,11 @@ interface SendResult {
   error?: string
 }
 
+type SendMode = 'all' | 'selected' | 'single'
+
 export function EmailVerificationPanel({ users, refreshUsers }: EmailVerificationPanelProps) {
   const [isOpen, setIsOpen] = useState(false)
-  const [mode, setMode] = useState<'all' | 'selected' | 'single'>('all')
+  const [mode, setMode] = useState<SendMode>('all')
   const [selectedUsers, setSelectedUsers] = useState<string[]>([])
   const [singleUser, setSingleUser] = useState<string>('')
   const [isLoading, setIsLoading] = useState(false)
@@ -48,87 +62,55 @@ export function EmailVerificationPanel({ users, refreshUsers }: EmailVerificatio
     failures: number
   } | null>(null)
 
-  // Filtrer les utilisateurs non vérifiés
-  const unverifiedUsers = users.filter(user => !user.emailVerified)
+  const unverifiedUsers = users.filter(u => !u.emailVerified)
 
-  const handleUserSelection = (userId: string, checked: boolean) => {
-    if (checked) {
-      setSelectedUsers([...selectedUsers, userId])
-    } else {
-      setSelectedUsers(selectedUsers.filter(id => id !== userId))
-    }
+  const toggleUser = (userId: string, checked: boolean) => {
+    setSelectedUsers(prev =>
+      checked ? [...prev, userId] : prev.filter(id => id !== userId)
+    )
   }
 
-  const handleSelectAll = (checked: boolean) => {
-    if (checked) {
-      setSelectedUsers(unverifiedUsers.map(user => user.id))
-    } else {
-      setSelectedUsers([])
-    }
+  const toggleAll = (checked: boolean) => {
+    setSelectedUsers(checked ? unverifiedUsers.map(u => u.id) : [])
   }
 
-  const handleSendEmails = async () => {
+  const handleSend = async () => {
     setIsLoading(true)
     setResults([])
     setSummary(null)
 
     try {
       let userIds: string[] = []
-
-      if (mode === 'all') {
-        userIds = unverifiedUsers.map(user => user.id)
-      } else if (mode === 'selected') {
-        userIds = selectedUsers
-      } else if (mode === 'single') {
-        userIds = [singleUser]
-      }
+      if (mode === 'all') userIds = unverifiedUsers.map(u => u.id)
+      else if (mode === 'selected') userIds = selectedUsers
+      else if (mode === 'single' && singleUser) userIds = [singleUser]
 
       if (userIds.length === 0) {
-        console.error('Aucun utilisateur sélectionné')
+        toast.error('Aucun utilisateur sélectionné')
         return
       }
 
       const response = await fetch('/api/admin/users/send-verification', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          userIds,
-          mode,
-        }),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userIds, mode }),
       })
 
       const data = await response.json()
-
       if (response.ok) {
         setResults(data.results || [])
         setSummary(data.summary || null)
-
-        // Afficher un toast de succès
         const successCount = data.summary?.success || 0
-        const failureCount = data.summary?.failures || 0
-
         if (successCount > 0) {
-          console.log(`${successCount} email(s) envoyé(s) avec succès`)
+          toast.success(`${successCount} email${successCount > 1 ? 's' : ''} envoyé${successCount > 1 ? 's' : ''}`)
         }
-        if (failureCount > 0) {
-          console.warn(`${failureCount} échec(s) lors de l'envoi`)
-        }
-
-        // Rafraîchir la liste des utilisateurs après envoi
-        setTimeout(() => {
-          refreshUsers()
-        }, 1000)
+        setTimeout(() => refreshUsers(), 1000)
       } else {
-        console.error('Erreur:', data.error)
-        // Afficher un toast d'erreur
-        console.error("Erreur lors de l'envoi des emails")
+        toast.error(data.error || "Erreur lors de l'envoi des emails")
       }
     } catch (error) {
-      console.error("Erreur lors de l'envoi des emails:", error)
-      // Afficher un toast d'erreur
-      console.error("Erreur de connexion lors de l'envoi des emails")
+      console.error("Erreur lors de l'envoi:", error)
+      toast.error('Erreur technique lors de l’envoi')
     } finally {
       setIsLoading(false)
     }
@@ -147,115 +129,173 @@ export function EmailVerificationPanel({ users, refreshUsers }: EmailVerificatio
     resetForm()
   }
 
+  const canSubmit =
+    !isLoading &&
+    ((mode === 'all' && unverifiedUsers.length > 0) ||
+      (mode === 'selected' && selectedUsers.length > 0) ||
+      (mode === 'single' && !!singleUser))
+
+  const selectedCount =
+    mode === 'all'
+      ? unverifiedUsers.length
+      : mode === 'selected'
+        ? selectedUsers.length
+        : singleUser
+          ? 1
+          : 0
+
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
-        <Button variant='outline' className='gap-2' disabled={unverifiedUsers.length === 0}>
+        <Button
+          variant='outline'
+          className='gap-2 border-slate-200 bg-white/80 text-slate-700 shadow-sm hover:bg-slate-50'
+          disabled={unverifiedUsers.length === 0}
+        >
           <Mail className='h-4 w-4' />
           Renvoyer emails de vérification
           {unverifiedUsers.length > 0 && (
-            <span className='ml-1 px-2 py-1 text-xs bg-orange-100 text-orange-800 rounded-full'>
+            <span className='ml-1 inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800'>
               {unverifiedUsers.length}
             </span>
           )}
         </Button>
       </DialogTrigger>
 
-      <DialogContent className='max-w-2xl max-h-[80vh] overflow-y-auto'>
+      <DialogContent className='max-h-[85vh] overflow-y-auto sm:max-w-2xl'>
         <DialogHeader>
-          <DialogTitle>Renvoyer les emails de vérification</DialogTitle>
-          <DialogDescription>
-            Choisissez les utilisateurs à qui renvoyer l&apos;email de vérification de compte. Seuls
-            les comptes non vérifiés sont concernés ({unverifiedUsers.length} comptes).
-          </DialogDescription>
+          <div className='flex items-start gap-3'>
+            <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 ring-1 ring-blue-100'>
+              <Mail className='h-5 w-5' />
+            </div>
+            <div className='min-w-0 flex-1 space-y-1'>
+              <DialogTitle className='text-lg'>Renvoyer les emails de vérification</DialogTitle>
+              <DialogDescription className='text-sm text-slate-600'>
+                Seuls les comptes non vérifiés sont concernés.{' '}
+                <strong>{unverifiedUsers.length}</strong> compte
+                {unverifiedUsers.length > 1 ? 's' : ''} en attente.
+              </DialogDescription>
+            </div>
+          </div>
         </DialogHeader>
 
-        <div className='space-y-4'>
-          {/* Mode de sélection */}
-          <div>
-            <label className='text-sm font-medium'>Mode d&apos;envoi</label>
-            <Select
-              value={mode}
-              onValueChange={(value: 'all' | 'selected' | 'single') => setMode(value)}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value='all'>
-                  <div className='flex items-center gap-2'>
-                    <Users className='h-4 w-4' />
-                    Tous les comptes non vérifiés ({unverifiedUsers.length})
+        <div className='space-y-5 py-2'>
+          {/* Mode selection as icon cards */}
+          <div className='grid gap-2 sm:grid-cols-3'>
+            {[
+              {
+                value: 'all' as SendMode,
+                icon: UsersIcon,
+                title: 'Tous les non vérifiés',
+                subtitle: `${unverifiedUsers.length} compte${unverifiedUsers.length > 1 ? 's' : ''}`,
+              },
+              {
+                value: 'selected' as SendMode,
+                icon: UsersIcon,
+                title: 'Sélection',
+                subtitle: 'Choix manuel',
+              },
+              {
+                value: 'single' as SendMode,
+                icon: UserIcon,
+                title: 'Un utilisateur',
+                subtitle: 'Compte unique',
+              },
+            ].map(opt => {
+              const Icon = opt.icon
+              const active = mode === opt.value
+              return (
+                <button
+                  key={opt.value}
+                  type='button'
+                  onClick={() => setMode(opt.value)}
+                  className={`flex flex-col items-start gap-1 rounded-xl border p-3 text-left transition ${
+                    active
+                      ? 'border-blue-300 bg-blue-50/60 ring-2 ring-blue-100'
+                      : 'border-slate-200 bg-white hover:border-slate-300'
+                  }`}
+                >
+                  <div
+                    className={`flex h-8 w-8 items-center justify-center rounded-lg ${
+                      active ? 'bg-blue-100 text-blue-600' : 'bg-slate-100 text-slate-600'
+                    }`}
+                  >
+                    <Icon className='h-4 w-4' />
                   </div>
-                </SelectItem>
-                <SelectItem value='selected'>
-                  <div className='flex items-center gap-2'>
-                    <Users className='h-4 w-4' />
-                    Comptes sélectionnés
-                  </div>
-                </SelectItem>
-                <SelectItem value='single'>
-                  <div className='flex items-center gap-2'>
-                    <UserIcon className='h-4 w-4' />
-                    Un seul compte
-                  </div>
-                </SelectItem>
-              </SelectContent>
-            </Select>
+                  <p className='text-sm font-semibold text-slate-900'>{opt.title}</p>
+                  <p className='text-xs text-slate-500'>{opt.subtitle}</p>
+                </button>
+              )
+            })}
           </div>
 
-          {/* Sélection multiple */}
+          {/* Mode: selected — checkbox list */}
           {mode === 'selected' && (
-            <div className='space-y-3'>
-              <div className='flex items-center gap-2'>
-                <Checkbox
-                  checked={selectedUsers.length === unverifiedUsers.length}
-                  onCheckedChange={handleSelectAll}
-                />
-                <label className='text-sm'>Sélectionner tout</label>
+            <div className='space-y-3 rounded-xl border border-slate-200 bg-slate-50/40 p-3'>
+              <div className='flex items-center justify-between gap-3 border-b border-slate-200 pb-3'>
+                <label className='flex items-center gap-2 text-sm font-medium text-slate-700'>
+                  <Checkbox
+                    checked={
+                      selectedUsers.length === unverifiedUsers.length &&
+                      unverifiedUsers.length > 0
+                    }
+                    onCheckedChange={toggleAll}
+                  />
+                  Tout sélectionner
+                </label>
+                <span className='text-xs text-slate-500'>
+                  {selectedUsers.length} / {unverifiedUsers.length}
+                </span>
               </div>
-
-              <div className='max-h-48 overflow-y-auto border rounded p-3 space-y-2'>
-                {unverifiedUsers.map(user => (
-                  <div key={user.id} className='flex items-center gap-2'>
-                    <Checkbox
-                      checked={selectedUsers.includes(user.id)}
-                      onCheckedChange={(checked: boolean) => handleUserSelection(user.id, checked)}
-                    />
-                    <div className='flex-1'>
-                      <div className='text-sm font-medium'>
-                        {user.name} {user.lastname}
+              <div className='max-h-60 space-y-1.5 overflow-y-auto'>
+                {unverifiedUsers.map(user => {
+                  const isChecked = selectedUsers.includes(user.id)
+                  return (
+                    <label
+                      key={user.id}
+                      className={`flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2 transition ${
+                        isChecked ? 'bg-blue-50/80' : 'hover:bg-white'
+                      }`}
+                    >
+                      <Checkbox
+                        checked={isChecked}
+                        onCheckedChange={(checked: boolean) => toggleUser(user.id, checked)}
+                      />
+                      <Avatar className='h-8 w-8 shrink-0'>
+                        <AvatarImage src={getUserAvatarUrl(user)} alt={user.name || user.email} />
+                        <AvatarFallback className='bg-gradient-to-br from-indigo-500 to-purple-500 text-[10px] font-semibold text-white'>
+                          {(user.name?.[0] || user.email[0]).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className='min-w-0 flex-1'>
+                        <p className='truncate text-sm font-medium text-slate-900'>
+                          {[user.name, user.lastname].filter(Boolean).join(' ') || 'Sans nom'}
+                        </p>
+                        <p className='truncate text-xs text-slate-500'>{user.email}</p>
                       </div>
-                      <div className='text-xs text-gray-500'>{user.email}</div>
-                    </div>
-                  </div>
-                ))}
+                    </label>
+                  )
+                })}
               </div>
-
-              {selectedUsers.length > 0 && (
-                <div className='text-sm text-blue-600'>
-                  {selectedUsers.length} compte(s) sélectionné(s)
-                </div>
-              )}
             </div>
           )}
 
-          {/* Sélection unique */}
+          {/* Mode: single — select */}
           {mode === 'single' && (
-            <div>
-              <label className='text-sm font-medium'>Utilisateur</label>
+            <div className='space-y-2'>
+              <label className='text-sm font-medium text-slate-700'>Utilisateur</label>
               <Select value={singleUser} onValueChange={setSingleUser}>
                 <SelectTrigger>
-                  <SelectValue placeholder='Choisir un utilisateur' />
+                  <SelectValue placeholder='Choisir un utilisateur…' />
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent className='max-h-72'>
                   {unverifiedUsers.map(user => (
                     <SelectItem key={user.id} value={user.id}>
-                      <div>
-                        <div className='font-medium'>
-                          {user.name} {user.lastname}
-                        </div>
-                        <div className='text-xs text-gray-500'>{user.email}</div>
+                      <div className='flex flex-col'>
+                        <span className='font-medium'>
+                          {[user.name, user.lastname].filter(Boolean).join(' ') || user.email}
+                        </span>
+                        <span className='text-xs text-slate-500'>{user.email}</span>
                       </div>
                     </SelectItem>
                   ))}
@@ -264,33 +304,52 @@ export function EmailVerificationPanel({ users, refreshUsers }: EmailVerificatio
             </div>
           )}
 
-          {/* Résultats */}
+          {/* Results summary */}
           {summary && (
-            <Alert>
-              <CheckCircle className='h-4 w-4' />
-              <AlertDescription>
-                <div className='font-medium'>Envoi terminé</div>
-                <div className='text-sm'>
-                  {summary.success} emails envoyés avec succès, {summary.failures} échecs sur{' '}
-                  {summary.total} total
+            <div className='rounded-xl border border-slate-200 bg-white p-4'>
+              <div className='mb-3 flex items-center justify-between'>
+                <p className='text-sm font-semibold text-slate-900'>Résultat de l’envoi</p>
+                <span className='text-xs text-slate-500'>
+                  {summary.total} email{summary.total > 1 ? 's' : ''} traité
+                  {summary.total > 1 ? 's' : ''}
+                </span>
+              </div>
+              <div className='grid grid-cols-2 gap-3'>
+                <div className='flex items-center gap-2 rounded-lg bg-emerald-50 px-3 py-2 text-emerald-700 ring-1 ring-emerald-100'>
+                  <MailCheck className='h-4 w-4' />
+                  <span className='text-sm font-semibold tabular-nums'>{summary.success}</span>
+                  <span className='text-xs'>envoyés</span>
                 </div>
-              </AlertDescription>
-            </Alert>
+                <div className='flex items-center gap-2 rounded-lg bg-red-50 px-3 py-2 text-red-700 ring-1 ring-red-100'>
+                  <MailX className='h-4 w-4' />
+                  <span className='text-sm font-semibold tabular-nums'>{summary.failures}</span>
+                  <span className='text-xs'>échecs</span>
+                </div>
+              </div>
+            </div>
           )}
 
+          {/* Per-email result list */}
           {results.length > 0 && (
             <div className='space-y-2'>
-              <h4 className='text-sm font-medium'>Détails des envois :</h4>
-              <div className='max-h-32 overflow-y-auto space-y-1'>
+              <h4 className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                Détails
+              </h4>
+              <div className='max-h-40 space-y-1 overflow-y-auto rounded-xl border border-slate-200 bg-white p-2'>
                 {results.map((result, index) => (
-                  <div key={index} className='flex items-center gap-2 text-xs'>
+                  <div
+                    key={`${result.userId}-${index}`}
+                    className='flex items-center gap-2 rounded-md px-2 py-1.5 text-xs'
+                  >
                     {result.success ? (
-                      <CheckCircle className='h-3 w-3 text-green-500' />
+                      <CheckCircle2 className='h-3.5 w-3.5 shrink-0 text-emerald-500' />
                     ) : (
-                      <XCircle className='h-3 w-3 text-red-500' />
+                      <XCircle className='h-3.5 w-3.5 shrink-0 text-red-500' />
                     )}
-                    <span className='flex-1'>{result.email}</span>
-                    {!result.success && <span className='text-red-500'>{result.error}</span>}
+                    <span className='flex-1 truncate text-slate-700'>{result.email}</span>
+                    {!result.success && result.error && (
+                      <span className='truncate text-red-500'>{result.error}</span>
+                    )}
                   </div>
                 ))}
               </div>
@@ -298,24 +357,19 @@ export function EmailVerificationPanel({ users, refreshUsers }: EmailVerificatio
           )}
         </div>
 
-        <DialogFooter>
-          <Button variant='outline' onClick={handleClose}>
+        <DialogFooter className='gap-2'>
+          <Button variant='outline' onClick={handleClose} disabled={isLoading}>
             Fermer
           </Button>
           <Button
-            onClick={handleSendEmails}
-            disabled={
-              isLoading ||
-              (mode === 'selected' && selectedUsers.length === 0) ||
-              (mode === 'single' && !singleUser)
-            }
+            onClick={handleSend}
+            disabled={!canSubmit}
+            className='gap-2 bg-blue-600 text-white hover:bg-blue-700'
           >
-            {isLoading ? (
-              <Loader2 className='h-4 w-4 animate-spin mr-2' />
-            ) : (
-              <Mail className='h-4 w-4 mr-2' />
-            )}
-            {isLoading ? 'Envoi en cours...' : 'Envoyer les emails'}
+            {isLoading ? <Loader2 className='h-4 w-4 animate-spin' /> : <Send className='h-4 w-4' />}
+            {isLoading
+              ? 'Envoi…'
+              : `Envoyer ${selectedCount > 0 ? `(${selectedCount})` : ''}`.trim()}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -69,6 +69,7 @@ import { PageHeader } from '@/components/admin/ui/PageHeader'
 import { KpiCard, KpiMetric, type KpiTone } from '@/components/admin/ui/KpiCard'
 import { FilterBar } from '@/components/admin/ui/FilterBar'
 import { DataTable, type DataTableColumn, type DataTableSort } from '@/components/admin/ui/DataTable'
+import { getUserAvatarUrl } from '@/lib/utils/userAvatar'
 
 /**
  * Ordered list of roles known to the admin panel.
@@ -326,10 +327,7 @@ export default function UsersPage() {
       render: user => (
         <div className='flex min-w-0 items-center gap-3'>
           <Avatar className='h-9 w-9 shrink-0 border-2 border-white shadow-sm'>
-            <AvatarImage
-              src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${user.email}`}
-              alt={user.name || user.email}
-            />
+            <AvatarImage src={getUserAvatarUrl(user)} alt={user.name || user.email} />
             <AvatarFallback className='bg-gradient-to-br from-indigo-500 to-purple-500 text-xs font-semibold text-white'>
               {(user.name?.[0] || user.email[0]).toUpperCase()}
             </AvatarFallback>
@@ -735,9 +733,7 @@ export default function UsersPage() {
             <div className='space-y-6 py-4'>
               <div className='flex items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 p-4'>
                 <Avatar className='h-10 w-10'>
-                  <AvatarImage
-                    src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${editingUser?.email}`}
-                  />
+                  {editingUser && <AvatarImage src={getUserAvatarUrl(editingUser)} />}
                   <AvatarFallback className='bg-gradient-to-br from-indigo-500 to-purple-500 text-sm font-semibold text-white'>
                     {(editingUser?.name?.[0] || editingUser?.email?.[0] || 'U').toUpperCase()}
                   </AvatarFallback>

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -54,7 +54,11 @@ export async function GET(request: NextRequest) {
 
     const offset = (page - 1) * limit
 
-    // Execute optimized single query with Promise.all for better performance
+    // Execute optimized single query with Promise.all for better performance.
+    // We include the three profile picture fields so the admin list can render
+    // the user's real avatar via `getUserAvatarUrl()`. `profilePictureBase64`
+    // can be heavy, but this endpoint is admin-only and capped at 50 rows per
+    // page, so the trade-off is acceptable.
     const [users, totalItems] = await Promise.all([
       prisma.user.findMany({
         where: whereClause,
@@ -66,6 +70,9 @@ export async function GET(request: NextRequest) {
           roles: true,
           createdAt: true,
           emailVerified: true,
+          image: true,
+          profilePicture: true,
+          profilePictureBase64: true,
         },
         orderBy: [{ createdAt: 'desc' }, { email: 'asc' }],
         skip: offset,

--- a/src/lib/utils/userAvatar.ts
+++ b/src/lib/utils/userAvatar.ts
@@ -1,0 +1,38 @@
+/**
+ * User-like shape the avatar helper needs to work with. Permissive on purpose
+ * so callers can pass any User subtype (from Prisma, from session, from a DTO).
+ */
+export interface UserAvatarSource {
+  email: string
+  image?: string | null
+  profilePicture?: string | null
+  profilePictureBase64?: string | null
+}
+
+/**
+ * Returns the best available URL to use as the user's avatar image.
+ *
+ * Priority:
+ *   1. `user.image`                  — NextAuth standard field (OAuth providers)
+ *   2. `user.profilePicture`         — Custom uploaded profile picture path/URL
+ *   3. `user.profilePictureBase64`   — Base64 data URL fallback
+ *   4. Dicebear placeholder seeded with the user's email
+ *
+ * If no real profile picture is defined, the returned Dicebear URL is a
+ * deterministic placeholder that still avoids the generic fallback initials
+ * pattern.
+ */
+export function getUserAvatarUrl(user: UserAvatarSource): string {
+  if (user.image) return user.image
+  if (user.profilePicture) return user.profilePicture
+  if (user.profilePictureBase64) return user.profilePictureBase64
+  return `https://api.dicebear.com/7.x/avataaars/svg?seed=${encodeURIComponent(user.email)}`
+}
+
+/**
+ * Convenience helper that returns `true` when the user has a real, user-uploaded
+ * profile picture (i.e. not the Dicebear fallback).
+ */
+export function hasRealProfilePicture(user: UserAvatarSource): boolean {
+  return Boolean(user.image || user.profilePicture || user.profilePictureBase64)
+}


### PR DESCRIPTION
## Summary

Extension of Phase 2 to cover what was missed in the first pass:

1. The **user detail page** at `/admin/users/[id]`
2. The two **user-related modals** (`ConfirmDeleteUserDialog` and `EmailVerificationPanel`)
3. A uniform **avatar resolution** that actually uses the user's real profile picture when one is defined

Verified on Cathy's profile where `profilePictureBase64` is set — her real picture now loads everywhere instead of the Dicebear fallback.

## New shared helper

### `src/lib/utils/userAvatar.ts`
`getUserAvatarUrl(user)` picks the best available image URL with priority:
1. `user.image` (NextAuth standard — OAuth providers)
2. `user.profilePicture` (custom uploaded path/URL)
3. `user.profilePictureBase64` (base64 data URL fallback)
4. Dicebear placeholder seeded on the email (existing behavior)

`hasRealProfilePicture()` tells whether the user has any real uploaded picture.

## `/admin/users` list page
- Data table avatars use `getUserAvatarUrl()` instead of the hardcoded Dicebear URL
- Edit-role dialog header avatar now shows the real picture of the user being edited

## `/admin/users/[id]` detail page (full rewrite)

### `UserDetailsClient`
- Uses the Phase 1 `PageHeader` with "Retour à la liste" back link, "Espace administrateur" eyebrow, gradient title, subtitle
- Two-column grid (profile column + stats/listings/bookings column) on `xl`, single column on smaller screens

### `UserPersonalInfo` (rebuilt)
- Profile card with gradient header banner, 24-high avatar via `getUserAvatarUrl()`, auto-colored role pill matching the list page tones
- Informations card with icon chips and email verification status as a colored badge (emerald / amber)

### `UserListingsAndBookings` (rebuilt **and wired to real data**)
Previously hardcoded to `posts: []` / `bookings: []`. Now consumes the user's real `Product[]` and `Rent[]` from the server page's `initialData`.
- Stats row uses shared `KpiCard`:
  - Dépensé total — sum of `totalAmount` on paid rents (emerald)
  - Annonces actives — approved + non-draft products (blue)
  - Réservations — all rents + "X payées" hint (purple)
- Listings rendered as compact rows with a colored validation pill (Approve / NotVerified / RecheckRequest / Refused / ModificationPending) and a link to the validation detail page
- Bookings rendered as compact rows with a colored rent status pill (WAITING / RESERVED / CHECKIN / CHECKOUT / CANCEL), localized dates and `totalAmount`

## `ConfirmDeleteUserDialog` (rebuilt)
- Header with red icon chip + larger title + clearer destructive language
- Impact summary as two info chips (Hébergements / Réservations) instead of an inline text row
- Active reservations grouped by "voyageur" / "hôte" with colored status + date range in distinct rows
- Destructive button reads "Supprimer définitivement" with a loader state
- Amber warning banner for the cascade-delete case
- French typography fixed (proper accents)

## `EmailVerificationPanel` (rebuilt)
- Header with blue icon chip + larger title
- Mode selection rebuilt as **three clickable icon cards** ("Tous les non vérifiés" / "Sélection" / "Un utilisateur") instead of a plain `<Select>`
- Multi-select list shows rows with the user's real avatar, name and email
- Results summary displays two color chips (Envoyés emerald, Échecs red) and a per-email detail list
- Toasts wired up with `sonner` (previously only `console.log`)
- "Envoyer" button shows the selected count dynamically

## Test plan (verified locally on Cathy's profile)

- [x] `/admin/users` — avatars in the table use real profile pictures when available
- [x] `/admin/users/[cathy-id]` — real `profilePictureBase64` loads in the profile card
- [x] KPI cards show correct numbers (1 830 € spent, 0 listings, 4 reservations, 3 paid)
- [x] Réservations effectuées list renders 4 actual rents with correct dates / amounts / status pills
- [x] Empty state for listings ("Aucune annonce")
- [x] Lint: 0 errors
- [x] `tsc --noEmit`: clean

## Scope

This is still **pure presentation** — no API or permission changes, no behavior change beyond:
- Detail page now actually renders real user data (bug fix)
- Avatars now prefer real profile pictures over the generic Dicebear placeholder

## Follow-up

Phase 3: `/admin/reservations` + `/admin/withdrawals` using the now-available `DataTable` + `FilterBar` + `KpiCard`.