### PR TITLE
feat(admin): redesign reservations, withdrawals, payment + reservation detail

### DIFF
--- a/src/app/admin/payment/[id]/page.tsx
+++ b/src/app/admin/payment/[id]/page.tsx
@@ -9,6 +9,40 @@ import {
   requestPaymentInfo,
 } from '@/lib/services/payment.service'
 import { PaymentStatus, PaymentMethod, PaymentReqStatus } from '@prisma/client'
+import { formatCurrency } from '@/lib/utils/formatNumber'
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard } from '@/components/admin/ui/KpiCard'
+import { Button } from '@/components/ui/shadcnui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/shadcnui/dialog'
+import {
+  Shield,
+  Banknote,
+  Percent,
+  Coins,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  MessageSquare,
+  Loader2,
+  CreditCard,
+  User as UserIcon,
+  Mail,
+  Home,
+  MapPin,
+  Calendar,
+  History,
+  AlertTriangle,
+  Wallet,
+  FileText,
+  Send,
+} from 'lucide-react'
 
 interface PayRequestDetails {
   id: string
@@ -34,7 +68,6 @@ interface PayRequestDetails {
     checkOut: string
     totalPrice: number
   }
-  // Historique des actions (à implémenter dans le service)
   history?: Array<{
     id: string
     action: string
@@ -49,7 +82,250 @@ interface PayRequestDetails {
 
 type ActionType = 'approve' | 'reject' | 'request_info'
 
-export default function PaymentDetailsPage({ params }: { params: Promise<{ id: string }> }) {
+const PAYMENT_METHOD_LABELS: Record<PaymentMethod, string> = {
+  SEPA_VIREMENT: 'Virement SEPA',
+  PRIPEO: 'Pripeo',
+  MOBILE_MONEY: 'Mobile Money',
+  PAYPAL: 'PayPal',
+  MONEYGRAM: 'MoneyGram',
+  TAPTAP: 'Taptap',
+  INTERNATIONAL: 'Virement International',
+  OTHER: 'Autre',
+}
+
+const REQUEST_TYPE_CONFIG: Partial<
+  Record<
+    PaymentStatus,
+    {
+      label: string
+      tone: string
+      icon: React.ComponentType<{ className?: string }>
+    }
+  >
+> = {
+  FULL_TRANSFER_REQ: {
+    label: 'Paiement intégral',
+    tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: Banknote,
+  },
+  MID_TRANSFER_REQ: {
+    label: 'Paiement 50%',
+    tone: 'bg-blue-50 text-blue-700 ring-blue-200',
+    icon: Percent,
+  },
+  REST_TRANSFER_REQ: {
+    label: 'Solde restant',
+    tone: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: Coins,
+  },
+}
+
+const STATUS_CONFIG: Record<
+  PaymentReqStatus,
+  {
+    label: string
+    tone: string
+    icon: React.ComponentType<{ className?: string }>
+  }
+> = {
+  RECEIVED: {
+    label: 'En attente',
+    tone: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: Clock,
+  },
+  DONE: {
+    label: 'Terminée',
+    tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: CheckCircle2,
+  },
+  REFUSED: {
+    label: 'Refusée',
+    tone: 'bg-red-50 text-red-700 ring-red-200',
+    icon: XCircle,
+  },
+}
+
+const ACTION_CONFIG: Record<
+  ActionType,
+  {
+    title: string
+    description: string
+    buttonLabel: string
+    icon: React.ComponentType<{ className?: string }>
+    iconBg: string
+    iconText: string
+    submitButtonClass: string
+  }
+> = {
+  approve: {
+    title: 'Approuver la demande',
+    description:
+      "Le paiement sera approuvé et l'hôte sera notifié par email.",
+    buttonLabel: 'Approuver',
+    icon: CheckCircle2,
+    iconBg: 'bg-emerald-50',
+    iconText: 'text-emerald-600',
+    submitButtonClass: 'bg-emerald-600 hover:bg-emerald-700 text-white',
+  },
+  reject: {
+    title: 'Refuser la demande',
+    description:
+      "Cette action ne peut pas être annulée. L'hôte sera notifié par email.",
+    buttonLabel: 'Refuser',
+    icon: XCircle,
+    iconBg: 'bg-red-50',
+    iconText: 'text-red-600',
+    submitButtonClass: 'bg-red-600 hover:bg-red-700 text-white',
+  },
+  request_info: {
+    title: 'Demander des informations',
+    description:
+      "L'hôte recevra un email avec votre demande d'informations supplémentaires.",
+    buttonLabel: 'Envoyer la demande',
+    icon: MessageSquare,
+    iconBg: 'bg-blue-50',
+    iconText: 'text-blue-600',
+    submitButtonClass: 'bg-blue-600 hover:bg-blue-700 text-white',
+  },
+}
+
+function RequestTypePill({ type }: { type: PaymentStatus }) {
+  const config = REQUEST_TYPE_CONFIG[type]
+  if (!config) {
+    return (
+      <span className='inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200'>
+        {type}
+      </span>
+    )
+  }
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.label}
+    </span>
+  )
+}
+
+function RequestStatusPill({ status }: { status: PaymentReqStatus }) {
+  const config = STATUS_CONFIG[status]
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3.5 w-3.5' />
+      {config.label}
+    </span>
+  )
+}
+
+const INFO_TILE_TONE: Record<
+  'blue' | 'indigo' | 'emerald' | 'amber' | 'red' | 'slate',
+  { bg: string; text: string }
+> = {
+  blue: { bg: 'bg-blue-50', text: 'text-blue-600' },
+  indigo: { bg: 'bg-indigo-50', text: 'text-indigo-600' },
+  emerald: { bg: 'bg-emerald-50', text: 'text-emerald-600' },
+  amber: { bg: 'bg-amber-50', text: 'text-amber-600' },
+  red: { bg: 'bg-red-50', text: 'text-red-600' },
+  slate: { bg: 'bg-slate-100', text: 'text-slate-600' },
+}
+
+function InfoTile({
+  label,
+  value,
+  hint,
+  icon: Icon,
+  tone = 'slate',
+}: {
+  label: string
+  value: string
+  hint?: string
+  icon: React.ComponentType<{ className?: string }>
+  tone?: keyof typeof INFO_TILE_TONE
+}) {
+  const toneClass = INFO_TILE_TONE[tone]
+  return (
+    <div className='rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm'>
+      <div className='flex items-start justify-between gap-4'>
+        <div className='min-w-0 space-y-1'>
+          <p className='text-sm font-medium text-slate-500'>{label}</p>
+          <p
+            className={`text-lg font-semibold leading-tight ${toneClass.text}`}
+          >
+            {value}
+          </p>
+          {hint && <p className='text-xs text-slate-500'>{hint}</p>}
+        </div>
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${toneClass.bg} ${toneClass.text}`}
+        >
+          <Icon className='h-5 w-5' />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SectionCard({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string
+  icon: React.ComponentType<{ className?: string }>
+  children: React.ReactNode
+}) {
+  return (
+    <div className='rounded-2xl border border-slate-200/80 bg-white shadow-sm'>
+      <div className='flex items-center gap-3 border-b border-slate-100 px-6 py-4'>
+        <div className='flex h-9 w-9 items-center justify-center rounded-lg bg-slate-100 text-slate-600'>
+          <Icon className='h-4 w-4' />
+        </div>
+        <h2 className='text-sm font-semibold uppercase tracking-wide text-slate-500'>
+          {title}
+        </h2>
+      </div>
+      <div className='p-6'>{children}</div>
+    </div>
+  )
+}
+
+function InfoRow({
+  label,
+  value,
+}: {
+  label: string
+  value: React.ReactNode
+}) {
+  return (
+    <div>
+      <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+        {label}
+      </p>
+      <div className='mt-1 text-sm text-slate-900'>{value}</div>
+    </div>
+  )
+}
+
+function formatDateTime(dateString: string) {
+  return new Date(dateString).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export default function PaymentDetailsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
   const router = useRouter()
   const resolvedParams = use(params)
   const [payRequest, setPayRequest] = useState<PayRequestDetails | null>(null)
@@ -58,12 +334,11 @@ export default function PaymentDetailsPage({ params }: { params: Promise<{ id: s
   const [showModal, setShowModal] = useState(false)
   const [actionType, setActionType] = useState<ActionType>('approve')
   const [actionNote, setActionNote] = useState('')
+  const [noteError, setNoteError] = useState<string | null>(null)
 
   const fetchPayRequestDetails = useCallback(async () => {
     try {
       setLoading(true)
-      // Pour l'instant, on utilise getAllPaymentRequest et on filtre
-      // TODO: Créer une fonction getPaymentRequestById dans le service
       const result = await getPaymentRequestById(resolvedParams.id)
       setPayRequest(result)
     } catch (error) {
@@ -80,16 +355,31 @@ export default function PaymentDetailsPage({ params }: { params: Promise<{ id: s
   const openModal = (action: ActionType) => {
     setActionType(action)
     setActionNote('')
+    setNoteError(null)
     setShowModal(true)
   }
 
   const closeModal = () => {
+    if (updating) return
     setShowModal(false)
     setActionNote('')
+    setNoteError(null)
   }
 
   const handleAction = async () => {
     if (!payRequest) return
+
+    if (
+      (actionType === 'reject' || actionType === 'request_info') &&
+      !actionNote.trim()
+    ) {
+      setNoteError(
+        actionType === 'reject'
+          ? 'Veuillez fournir une raison pour le refus.'
+          : 'Veuillez spécifier quelles informations sont nécessaires.'
+      )
+      return
+    }
 
     try {
       setUpdating(true)
@@ -97,131 +387,43 @@ export default function PaymentDetailsPage({ params }: { params: Promise<{ id: s
       if (actionType === 'approve') {
         await approvePaymentRequest(payRequest.id)
       } else if (actionType === 'reject') {
-        if (!actionNote.trim()) {
-          alert('Veuillez fournir une raison pour le refus')
-          return
-        }
         await rejectPaymentRequest(payRequest.id, actionNote)
       } else if (actionType === 'request_info') {
-        if (!actionNote.trim()) {
-          alert('Veuillez spécifier quelles informations sont nécessaires')
-          return
-        }
         await requestPaymentInfo(payRequest.id, actionNote)
       }
 
       await fetchPayRequestDetails()
-      closeModal()
+      setShowModal(false)
+      setActionNote('')
+      setNoteError(null)
     } catch (error) {
       console.error("Erreur lors de l'action:", error)
-      alert("Une erreur s'est produite lors du traitement de la demande")
+      setNoteError("Une erreur s'est produite lors du traitement de la demande.")
     } finally {
       setUpdating(false)
     }
   }
 
-  const goBack = () => {
-    router.push('/admin/payment')
-  }
-
-  const getPaymentMethodLabel = (method: PaymentMethod) => {
-    const labels: Record<PaymentMethod, string> = {
-      SEPA_VIREMENT: 'Virement SEPA',
-      PRIPEO: 'Pripeo',
-      MOBILE_MONEY: 'Mobile Money',
-      PAYPAL: 'PayPal',
-      MONEYGRAM: 'MoneyGram',
-      TAPTAP: 'Taptap',
-      INTERNATIONAL: 'Virement International',
-      OTHER: 'Autre',
-    }
-    return labels[method] || method
-  }
-
-  const getPaymentRequestLabel = (type: PaymentStatus) => {
-    const labels: Partial<Record<PaymentStatus, string>> = {
-      FULL_TRANSFER_REQ: 'Paiement intégral',
-      MID_TRANSFER_REQ: 'Paiement de 50%',
-      REST_TRANSFER_REQ: 'Solde restant',
-    }
-    return labels[type] || type
-  }
-
-  const getStatusBadge = (type: PaymentStatus) => {
-    switch (type) {
-      case PaymentStatus.FULL_TRANSFER_REQ:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800'>
-            💰 {getPaymentRequestLabel(type)}
-          </span>
-        )
-      case PaymentStatus.MID_TRANSFER_REQ:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800'>
-            📊 {getPaymentRequestLabel(type)}
-          </span>
-        )
-      case PaymentStatus.REST_TRANSFER_REQ:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-orange-100 text-orange-800'>
-            💳 {getPaymentRequestLabel(type)}
-          </span>
-        )
-      default:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800'>
-            {getPaymentRequestLabel(type)}
-          </span>
-        )
-    }
-  }
-
-  const getRequestStatusBadge = (status: PaymentReqStatus) => {
-    switch (status) {
-      case PaymentReqStatus.RECEIVED:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800'>
-            ⏳ Reçu
-          </span>
-        )
-      case PaymentReqStatus.DONE:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800'>
-            ✅ Terminé
-          </span>
-        )
-      case PaymentReqStatus.REFUSED:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800'>
-            ❌ Refusé
-          </span>
-        )
-      default:
-        return (
-          <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-800'>
-            {status}
-          </span>
-        )
-    }
-  }
-
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('fr-FR', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-  }
-
   if (loading) {
     return (
-      <div className='min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6'>
-        <div className='flex items-center justify-center min-h-[calc(100vh-4rem)]'>
-          <div className='text-center'>
-            <div className='animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4'></div>
-            <p className='text-gray-600'>Chargement des détails de la demande...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-6xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='grid gap-6 lg:grid-cols-3'>
+            <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white lg:col-span-2' />
+            <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
           </div>
         </div>
       </div>
@@ -230,485 +432,457 @@ export default function PaymentDetailsPage({ params }: { params: Promise<{ id: s
 
   if (!payRequest) {
     return (
-      <div className='min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6'>
-        <div className='max-w-4xl mx-auto'>
-          <div className='bg-white rounded-xl shadow-sm p-8 text-center'>
-            <div className='text-6xl mb-4'>❌</div>
-            <h2 className='text-xl font-bold text-gray-900 mb-2'>Demande introuvable</h2>
-            <p className='text-gray-600 mt-1'>
-              Cette réservation n&apos;existe pas ou a été supprimée.
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-4xl space-y-8 p-6'>
+          <PageHeader
+            backHref='/admin/payment'
+            backLabel='Retour aux demandes'
+            eyebrow='Espace administrateur'
+            title='Demande introuvable'
+            subtitle='Cette demande de paiement n’existe pas ou a été supprimée.'
+          />
+          <div className='rounded-2xl border border-slate-200/80 bg-white p-12 text-center shadow-sm'>
+            <div className='mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 text-red-600'>
+              <AlertTriangle className='h-8 w-8' />
+            </div>
+            <h2 className='mt-4 text-lg font-bold text-slate-900'>
+              Demande introuvable
+            </h2>
+            <p className='mt-2 text-sm text-slate-500'>
+              Vérifiez l’identifiant de la demande ou revenez à la liste.
             </p>
-            <button
-              onClick={goBack}
-              className='px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors'
+            <Button
+              onClick={() => router.push('/admin/payment')}
+              className='mt-6'
             >
               Retour à la liste
-            </button>
+            </Button>
           </div>
         </div>
       </div>
     )
   }
 
+  const amount = Number(payRequest.prices || 0)
+  const shortId = payRequest.id.slice(-6).toUpperCase()
+  const actionConfig = ACTION_CONFIG[actionType]
+  const ActionIcon = actionConfig.icon
+  const isPending = payRequest.status === PaymentReqStatus.RECEIVED
+
   return (
-    <div className='min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6'>
-      <div className='max-w-6xl mx-auto'>
-        {/* Header */}
-        <div className='mb-8 flex items-center justify-between'>
-          <div className='flex items-center gap-4'>
-            <button
-              onClick={goBack}
-              className='p-2 rounded-lg bg-white shadow-sm hover:shadow-md transition-shadow border border-gray-200'
-            >
-              <svg
-                className='w-5 h-5 text-gray-600'
-                fill='none'
-                stroke='currentColor'
-                viewBox='0 0 24 24'
-              >
-                <path
-                  strokeLinecap='round'
-                  strokeLinejoin='round'
-                  strokeWidth={2}
-                  d='M10 19l-7-7m0 0l7-7m-7 7h18'
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <div className='mx-auto max-w-6xl space-y-8 p-6'>
+        <PageHeader
+          backHref='/admin/payment'
+          backLabel='Retour aux demandes'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title={`Demande #${shortId}`}
+          subtitle='Consultez les détails de la demande de paiement et validez, refusez ou demandez des informations complémentaires.'
+          actions={<RequestStatusPill status={payRequest.status} />}
+        />
+
+        {/* KPI summary row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Montant'
+            value={formatCurrency(amount)}
+            hint='à verser à l’hôte'
+            icon={Wallet}
+            tone='emerald'
+          />
+          <InfoTile
+            label='Type'
+            value={
+              REQUEST_TYPE_CONFIG[payRequest.PaymentRequest]?.label ??
+              payRequest.PaymentRequest
+            }
+            hint='nature du versement'
+            icon={CreditCard}
+            tone='blue'
+          />
+          <InfoTile
+            label='Méthode'
+            value={PAYMENT_METHOD_LABELS[payRequest.method] ?? payRequest.method}
+            hint='canal de paiement'
+            icon={Banknote}
+            tone='indigo'
+          />
+          <InfoTile
+            label='Statut'
+            value={STATUS_CONFIG[payRequest.status].label}
+            hint={isPending ? 'à traiter en priorité' : 'demande clôturée'}
+            icon={STATUS_CONFIG[payRequest.status].icon}
+            tone={
+              payRequest.status === PaymentReqStatus.DONE
+                ? 'emerald'
+                : payRequest.status === PaymentReqStatus.REFUSED
+                  ? 'red'
+                  : 'amber'
+            }
+          />
+        </div>
+
+        {/* Main grid */}
+        <div className='grid gap-6 lg:grid-cols-3'>
+          {/* Left column */}
+          <div className='space-y-6 lg:col-span-2'>
+            {/* Request info */}
+            <SectionCard title='Informations de la demande' icon={FileText}>
+              <div className='grid gap-5 sm:grid-cols-2'>
+                <InfoRow
+                  label='Type de paiement'
+                  value={<RequestTypePill type={payRequest.PaymentRequest} />}
                 />
-              </svg>
-            </button>
-            <div>
-              <h1 className='text-3xl font-bold text-gray-900'>
-                Détails de la demande de paiement
-              </h1>
-              <p className='text-gray-600 mt-1'>
-                Demande #{payRequest.id.slice(0, 8)}... • Date non disponible
-              </p>
-            </div>
-          </div>
-          <div className='flex items-center gap-3'>{getRequestStatusBadge(payRequest.status)}</div>
-        </div>
-
-        {/* Main Content Grid */}
-        <div className='grid grid-cols-1 lg:grid-cols-3 gap-8'>
-          {/* Informations principales */}
-          <div className='lg:col-span-2 space-y-6'>
-            {/* Détails de la demande */}
-            <div className='bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden'>
-              <div className='bg-gradient-to-r from-blue-50 to-indigo-50 px-6 py-4 border-b border-gray-200'>
-                <h2 className='text-lg font-semibold text-gray-900'>Informations de la demande</h2>
-              </div>
-              <div className='p-6 space-y-4'>
-                <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
-                  <div>
-                    <label className='text-sm font-medium text-gray-500'>Type de paiement</label>
-                    <div className='mt-1'>{getStatusBadge(payRequest.PaymentRequest)}</div>
-                  </div>
-                  <div>
-                    <label className='text-sm font-medium text-gray-500'>Montant</label>
-                    <div className='mt-1 text-2xl font-bold text-green-600'>
-                      {Number(payRequest.prices).toLocaleString('fr-FR', {
-                        style: 'currency',
-                        currency: 'EUR',
-                      })}
-                    </div>
-                  </div>
-                  <div>
-                    <label className='text-sm font-medium text-gray-500'>Méthode de paiement</label>
-                    <div className='mt-1 text-gray-900'>
-                      {getPaymentMethodLabel(payRequest.method)}
-                    </div>
-                  </div>
-                  <div>
-                    <label className='text-sm font-medium text-gray-500'>Statut</label>
-                    <div className='mt-1'>{getRequestStatusBadge(payRequest.status)}</div>
-                  </div>
-                </div>
-                {payRequest.notes && (
-                  <div>
-                    <label className='text-sm font-medium text-gray-500'>
-                      Notes de l&apos;hôte
-                    </label>
-                    <div className='mt-1 p-3 bg-gray-50 rounded-lg border'>
-                      <p className='text-gray-900'>{payRequest.notes}</p>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Informations de l'hôte */}
-            <div className='bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden'>
-              <div className='bg-gradient-to-r from-green-50 to-emerald-50 px-6 py-4 border-b border-gray-200'>
-                <h2 className='text-lg font-semibold text-gray-900'>Informations de l&apos;hôte</h2>
-              </div>
-              <div className='p-6'>
-                <div className='flex items-start gap-4'>
-                  <div className='bg-blue-100 p-3 rounded-lg'>
-                    <svg
-                      className='w-6 h-6 text-blue-600'
-                      fill='none'
-                      stroke='currentColor'
-                      viewBox='0 0 24 24'
-                    >
-                      <path
-                        strokeLinecap='round'
-                        strokeLinejoin='round'
-                        strokeWidth={2}
-                        d='M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z'
-                      />
-                    </svg>
-                  </div>
-                  <div className='flex-1'>
-                    <h3 className='text-lg font-semibold text-gray-900'>
-                      {payRequest.user.name || 'Sans nom'}
-                    </h3>
-                    <p className='text-gray-600'>{payRequest.user.email}</p>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Informations de la réservation */}
-            <div className='bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden'>
-              <div className='bg-gradient-to-r from-purple-50 to-pink-50 px-6 py-4 border-b border-gray-200'>
-                <h2 className='text-lg font-semibold text-gray-900'>Détails de la réservation</h2>
-              </div>
-              <div className='p-6'>
-                <div className='space-y-4'>
-                  <div>
-                    <label className='text-sm font-medium text-gray-500'>Propriété</label>
-                    <div className='mt-1 text-gray-900 font-medium'>
-                      {payRequest.rent.product.name}
-                    </div>
-                    <div className='text-sm text-gray-600'>{payRequest.rent.product.address}</div>
-                  </div>
-                  <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
-                    <div>
-                      <label className='text-sm font-medium text-gray-500'>Check-in</label>
-                      <div className='mt-1 text-gray-900'>
-                        {new Date(payRequest.rent.checkIn).toLocaleDateString('fr-FR')}
-                      </div>
-                    </div>
-                    <div>
-                      <label className='text-sm font-medium text-gray-500'>Check-out</label>
-                      <div className='mt-1 text-gray-900'>
-                        {new Date(payRequest.rent.checkOut).toLocaleDateString('fr-FR')}
-                      </div>
-                    </div>
-                    <div>
-                      <label className='text-sm font-medium text-gray-500'>Prix total</label>
-                      <div className='mt-1 text-gray-900 font-semibold'>
-                        {payRequest.rent.totalPrice.toLocaleString('fr-FR', {
-                          style: 'currency',
-                          currency: 'EUR',
-                        })}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Historique des actions */}
-            <div className='bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden'>
-              <div className='bg-gradient-to-r from-amber-50 to-orange-50 px-6 py-4 border-b border-gray-200'>
-                <h2 className='text-lg font-semibold text-gray-900'>
-                  Historique des modifications
-                </h2>
-              </div>
-              <div className='p-6'>
-                {payRequest.history && payRequest.history.length > 0 ? (
-                  <div className='space-y-4'>
-                    {payRequest.history.map(entry => (
-                      <div
-                        key={entry.id}
-                        className='flex gap-4 pb-4 border-b border-gray-100 last:border-b-0'
-                      >
-                        <div className='bg-blue-100 p-2 rounded-lg h-fit'>
-                          <svg
-                            className='w-4 h-4 text-blue-600'
-                            fill='none'
-                            stroke='currentColor'
-                            viewBox='0 0 24 24'
-                          >
-                            <path
-                              strokeLinecap='round'
-                              strokeLinejoin='round'
-                              strokeWidth={2}
-                              d='M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'
-                            />
-                          </svg>
-                        </div>
-                        <div className='flex-1'>
-                          <div className='flex items-center justify-between'>
-                            <h4 className='font-medium text-gray-900'>{entry.action}</h4>
-                            <span className='text-sm text-gray-500'>
-                              {formatDate(entry.createdAt)}
-                            </span>
-                          </div>
-                          {entry.note && <p className='text-gray-600 mt-1'>{entry.note}</p>}
-                          {entry.adminUser && (
-                            <p className='text-sm text-gray-500 mt-1'>
-                              Par: {entry.adminUser.name || entry.adminUser.email}
-                            </p>
-                          )}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <div className='text-center py-8 text-gray-500'>
-                    <svg
-                      className='w-12 h-12 mx-auto mb-3 text-gray-300'
-                      fill='none'
-                      stroke='currentColor'
-                      viewBox='0 0 24 24'
-                    >
-                      <path
-                        strokeLinecap='round'
-                        strokeLinejoin='round'
-                        strokeWidth={2}
-                        d='M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'
-                      />
-                    </svg>
-                    <p>Aucun historique de modifications disponible</p>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-
-          {/* Actions sidebar */}
-          <div className='space-y-6'>
-            {/* Actions rapides */}
-            <div className='bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden'>
-              <div className='bg-gradient-to-r from-indigo-50 to-blue-50 px-6 py-4 border-b border-gray-200'>
-                <h2 className='text-lg font-semibold text-gray-900'>Actions</h2>
-              </div>
-              <div className='p-6 space-y-3'>
-                {payRequest.status === PaymentReqStatus.RECEIVED && (
-                  <>
-                    <button
-                      onClick={() => openModal('approve')}
-                      disabled={updating}
-                      className='w-full px-4 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2'
-                    >
-                      <span>✅</span>
-                      <span>Approuver la demande</span>
-                    </button>
-                    <button
-                      onClick={() => openModal('reject')}
-                      disabled={updating}
-                      className='w-full px-4 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2'
-                    >
-                      <span>❌</span>
-                      <span>Refuser la demande</span>
-                    </button>
-                    <button
-                      onClick={() => openModal('request_info')}
-                      disabled={updating}
-                      className='w-full px-4 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2'
-                    >
-                      <span>ℹ️</span>
-                      <span>Demander des infos</span>
-                    </button>
-                  </>
-                )}
-                {payRequest.status === PaymentReqStatus.DONE && (
-                  <div className='p-4 bg-green-50 rounded-lg border border-green-200'>
-                    <div className='flex items-center gap-2 text-green-800'>
-                      <span>✅</span>
-                      <span className='font-medium'>Demande approuvée</span>
-                    </div>
-                    <p className='text-sm text-green-700 mt-1'>
-                      Cette demande de paiement a été approuvée et traitée.
-                    </p>
-                  </div>
-                )}
-                {payRequest.status === PaymentReqStatus.REFUSED && (
-                  <div className='p-4 bg-red-50 rounded-lg border border-red-200'>
-                    <div className='flex items-center gap-2 text-red-800'>
-                      <span>❌</span>
-                      <span className='font-medium'>Demande refusée</span>
-                    </div>
-                    <p className='text-sm text-red-700 mt-1'>
-                      Cette demande de paiement a été refusée.
-                    </p>
-                  </div>
-                )}
-                <button
-                  onClick={goBack}
-                  className='w-full px-4 py-3 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors flex items-center justify-center gap-2'
-                >
-                  <span>↩️</span>
-                  <span>Retour à la liste</span>
-                </button>
-              </div>
-            </div>
-
-            {/* Résumé */}
-            <div className='bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden'>
-              <div className='bg-gradient-to-r from-gray-50 to-slate-50 px-6 py-4 border-b border-gray-200'>
-                <h2 className='text-lg font-semibold text-gray-900'>Résumé</h2>
-              </div>
-              <div className='p-6 space-y-3'>
-                <div className='flex justify-between items-center'>
-                  <span className='text-gray-600'>Créé le:</span>
-                  <span className='font-medium text-gray-900'>Non disponible</span>
-                </div>
-                <div className='flex justify-between items-center'>
-                  <span className='text-gray-600'>Modifié le:</span>
-                  <span className='font-medium text-gray-900'>Non disponible</span>
-                </div>
-                <div className='flex justify-between items-center'>
-                  <span className='text-gray-600'>ID demande:</span>
-                  <span className='font-mono text-sm text-gray-900'>
-                    {payRequest.id.slice(0, 8)}...
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Modal pour les actions */}
-        {showModal && (
-          <div className='fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-50'>
-            <div className='bg-white rounded-2xl shadow-2xl max-w-lg w-full border border-gray-100 overflow-hidden transform transition-all'>
-              {/* Header */}
-              <div
-                className={`p-6 ${
-                  actionType === 'approve'
-                    ? 'bg-gradient-to-r from-green-600 to-green-700'
-                    : actionType === 'reject'
-                      ? 'bg-gradient-to-r from-red-600 to-red-700'
-                      : 'bg-gradient-to-r from-blue-600 to-blue-700'
-                }`}
-              >
-                <div className='flex items-center gap-3'>
-                  <div className='bg-white/20 p-3 rounded-xl'>
-                    <span className='text-2xl'>
-                      {actionType === 'reject' && '❌'}
-                      {actionType === 'request_info' && 'ℹ️'}
-                      {actionType === 'approve' && '✅'}
+                <InfoRow
+                  label='Montant'
+                  value={
+                    <span className='text-2xl font-bold tabular-nums text-emerald-600'>
+                      {formatCurrency(amount)}
                     </span>
+                  }
+                />
+                <InfoRow
+                  label='Méthode de paiement'
+                  value={
+                    PAYMENT_METHOD_LABELS[payRequest.method] ?? payRequest.method
+                  }
+                />
+                <InfoRow
+                  label='Statut'
+                  value={<RequestStatusPill status={payRequest.status} />}
+                />
+              </div>
+              {payRequest.notes && (
+                <div className='mt-6'>
+                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                    Notes de l&apos;hôte
+                  </p>
+                  <div className='mt-2 rounded-xl border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700'>
+                    {payRequest.notes}
                   </div>
-                  <div>
-                    <h3 className='text-xl font-bold text-white'>
-                      {actionType === 'reject' && 'Refuser la demande'}
-                      {actionType === 'request_info' && 'Demander des informations'}
-                      {actionType === 'approve' && 'Approuver la demande'}
-                    </h3>
-                    <p className='text-white/80 text-sm mt-1'>Action sur la demande de paiement</p>
+                </div>
+              )}
+            </SectionCard>
+
+            {/* Host info */}
+            <SectionCard title='Hôte' icon={UserIcon}>
+              <div className='flex items-start gap-4'>
+                <div className='flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-purple-500 text-lg font-bold text-white shadow-sm'>
+                  {(payRequest.user.name || payRequest.user.email)
+                    .charAt(0)
+                    .toUpperCase()}
+                </div>
+                <div className='min-w-0 flex-1'>
+                  <p className='text-base font-semibold text-slate-900'>
+                    {payRequest.user.name || 'Sans nom'}
+                  </p>
+                  <div className='mt-1 flex items-center gap-1.5 text-sm text-slate-600'>
+                    <Mail className='h-3.5 w-3.5 text-slate-400' />
+                    <a
+                      href={`mailto:${payRequest.user.email}`}
+                      className='hover:text-blue-600'
+                    >
+                      {payRequest.user.email}
+                    </a>
                   </div>
                 </div>
               </div>
+            </SectionCard>
 
-              {/* Contenu */}
-              <div className='p-6'>
-                {/* Champ de saisie pour les actions nécessitant une note */}
-                {(actionType === 'reject' || actionType === 'request_info') && (
-                  <div className='mb-6'>
-                    <label className='block text-sm font-semibold text-gray-700 mb-3'>
-                      {actionType === 'reject' ? 'Raison du refus:' : 'Informations demandées:'}
-                    </label>
-                    <textarea
-                      value={actionNote}
-                      onChange={e => setActionNote(e.target.value)}
-                      className='w-full p-4 border-2 border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 resize-none bg-gray-50 focus:bg-white'
-                      rows={4}
-                      placeholder={
-                        actionType === 'reject'
-                          ? 'Expliquez clairement pourquoi cette demande est refusée...'
-                          : 'Spécifiez quelles informations supplémentaires sont nécessaires...'
-                      }
-                    />
-                  </div>
-                )}
-
-                {/* Alerte d'information */}
-                <div
-                  className={`mb-6 p-4 rounded-xl border-l-4 ${
-                    actionType === 'approve'
-                      ? 'bg-green-50 border-green-400'
-                      : actionType === 'reject'
-                        ? 'bg-red-50 border-red-400'
-                        : 'bg-blue-50 border-blue-400'
-                  }`}
-                >
-                  <p
-                    className={`text-sm ${
-                      actionType === 'approve'
-                        ? 'text-green-700'
-                        : actionType === 'reject'
-                          ? 'text-red-700'
-                          : 'text-blue-700'
-                    }`}
-                  >
-                    {actionType === 'approve' &&
-                      'Le paiement sera approuvé et l&apos;utilisateur sera notifié par email.'}
-                    {actionType === 'reject' &&
-                      'Cette action ne peut pas être annulée. L&apos;utilisateur sera notifié par email.'}
-                    {actionType === 'request_info' &&
-                      'L&apos;utilisateur recevra un email avec votre demande d&apos;informations supplémentaires.'}
+            {/* Reservation info */}
+            <SectionCard title='Réservation associée' icon={Home}>
+              <div className='space-y-5'>
+                <div>
+                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                    Hébergement
+                  </p>
+                  <p className='mt-1 text-base font-semibold text-slate-900'>
+                    {payRequest.rent.product.name}
+                  </p>
+                  <p className='mt-1 flex items-center gap-1.5 text-sm text-slate-500'>
+                    <MapPin className='h-3.5 w-3.5' />
+                    {payRequest.rent.product.address}
                   </p>
                 </div>
+                <div className='grid gap-4 sm:grid-cols-3'>
+                  <div className='rounded-xl bg-slate-50 p-3'>
+                    <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                      Arrivée
+                    </p>
+                    <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                      <Calendar className='h-4 w-4 text-blue-600' />
+                      {new Date(payRequest.rent.checkIn).toLocaleDateString(
+                        'fr-FR',
+                        { day: '2-digit', month: 'short', year: 'numeric' }
+                      )}
+                    </p>
+                  </div>
+                  <div className='rounded-xl bg-slate-50 p-3'>
+                    <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                      Départ
+                    </p>
+                    <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                      <Calendar className='h-4 w-4 text-blue-600' />
+                      {new Date(payRequest.rent.checkOut).toLocaleDateString(
+                        'fr-FR',
+                        { day: '2-digit', month: 'short', year: 'numeric' }
+                      )}
+                    </p>
+                  </div>
+                  <div className='rounded-xl bg-slate-50 p-3'>
+                    <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                      Prix total
+                    </p>
+                    <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                      <Wallet className='h-4 w-4 text-emerald-600' />
+                      {formatCurrency(payRequest.rent.totalPrice)}
+                    </p>
+                  </div>
+                </div>
               </div>
+            </SectionCard>
 
-              {/* Footer */}
-              <div className='bg-gray-50 px-6 py-4 flex justify-end space-x-3'>
-                <button
-                  onClick={closeModal}
-                  className='px-6 py-2.5 text-gray-600 hover:text-gray-800 font-medium rounded-xl hover:bg-gray-100 transition-all duration-200 border border-gray-200'
-                >
-                  Annuler
-                </button>
-                <button
-                  onClick={handleAction}
-                  disabled={updating}
-                  className={`px-6 py-2.5 text-white font-medium rounded-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 shadow-lg hover:shadow-xl ${
-                    actionType === 'approve'
-                      ? 'bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800'
-                      : actionType === 'reject'
-                        ? 'bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800'
-                        : 'bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800'
-                  }`}
-                >
-                  {updating ? (
-                    <>
-                      <svg
-                        className='w-4 h-4 animate-spin'
-                        fill='none'
-                        stroke='currentColor'
-                        viewBox='0 0 24 24'
-                      >
-                        <path
-                          strokeLinecap='round'
-                          strokeLinejoin='round'
-                          strokeWidth={2}
-                          d='M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15'
-                        />
-                      </svg>
-                      Traitement...
-                    </>
-                  ) : (
-                    <>
-                      <span>
-                        {actionType === 'approve' && '✅'}
-                        {actionType === 'reject' && '❌'}
-                        {actionType === 'request_info' && '📤'}
-                      </span>
-                      {actionType === 'approve'
-                        ? 'Approuver'
-                        : actionType === 'reject'
-                          ? 'Refuser'
-                          : 'Envoyer la demande'}
-                    </>
-                  )}
-                </button>
+            {/* History */}
+            <SectionCard title='Historique des modifications' icon={History}>
+              {payRequest.history && payRequest.history.length > 0 ? (
+                <ul className='space-y-4'>
+                  {payRequest.history.map(entry => (
+                    <li
+                      key={entry.id}
+                      className='flex gap-4 border-b border-slate-100 pb-4 last:border-b-0 last:pb-0'
+                    >
+                      <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600'>
+                        <Clock className='h-4 w-4' />
+                      </div>
+                      <div className='min-w-0 flex-1'>
+                        <div className='flex items-start justify-between gap-3'>
+                          <p className='text-sm font-semibold text-slate-900'>
+                            {entry.action}
+                          </p>
+                          <span className='shrink-0 text-xs text-slate-500'>
+                            {formatDateTime(entry.createdAt)}
+                          </span>
+                        </div>
+                        {entry.note && (
+                          <p className='mt-1 text-sm text-slate-600'>
+                            {entry.note}
+                          </p>
+                        )}
+                        {entry.adminUser && (
+                          <p className='mt-1 text-xs text-slate-500'>
+                            Par {entry.adminUser.name || entry.adminUser.email}
+                          </p>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <div className='flex flex-col items-center justify-center py-8 text-center'>
+                  <div className='flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100 text-slate-400'>
+                    <History className='h-6 w-6' />
+                  </div>
+                  <p className='mt-3 text-sm text-slate-500'>
+                    Aucun historique disponible pour le moment
+                  </p>
+                </div>
+              )}
+            </SectionCard>
+          </div>
+
+          {/* Right column — actions + summary */}
+          <div className='space-y-6'>
+            <SectionCard title='Actions' icon={CheckCircle2}>
+              {isPending ? (
+                <div className='space-y-3'>
+                  <Button
+                    onClick={() => openModal('approve')}
+                    disabled={updating}
+                    className='w-full justify-center gap-2 bg-emerald-600 text-white hover:bg-emerald-700'
+                  >
+                    <CheckCircle2 className='h-4 w-4' />
+                    Approuver la demande
+                  </Button>
+                  <Button
+                    onClick={() => openModal('reject')}
+                    disabled={updating}
+                    variant='outline'
+                    className='w-full justify-center gap-2 border-red-200 text-red-700 hover:bg-red-50'
+                  >
+                    <XCircle className='h-4 w-4' />
+                    Refuser la demande
+                  </Button>
+                  <Button
+                    onClick={() => openModal('request_info')}
+                    disabled={updating}
+                    variant='outline'
+                    className='w-full justify-center gap-2 border-blue-200 text-blue-700 hover:bg-blue-50'
+                  >
+                    <MessageSquare className='h-4 w-4' />
+                    Demander des infos
+                  </Button>
+                </div>
+              ) : payRequest.status === PaymentReqStatus.DONE ? (
+                <div className='rounded-xl border border-emerald-200 bg-emerald-50/60 p-4'>
+                  <div className='flex items-center gap-2 text-emerald-800'>
+                    <CheckCircle2 className='h-4 w-4' />
+                    <span className='text-sm font-semibold'>
+                      Demande approuvée
+                    </span>
+                  </div>
+                  <p className='mt-1 text-xs text-emerald-700'>
+                    Cette demande de paiement a été approuvée et traitée.
+                  </p>
+                </div>
+              ) : (
+                <div className='rounded-xl border border-red-200 bg-red-50/60 p-4'>
+                  <div className='flex items-center gap-2 text-red-800'>
+                    <XCircle className='h-4 w-4' />
+                    <span className='text-sm font-semibold'>Demande refusée</span>
+                  </div>
+                  <p className='mt-1 text-xs text-red-700'>
+                    Cette demande de paiement a été refusée.
+                  </p>
+                </div>
+              )}
+            </SectionCard>
+
+            <SectionCard title='Résumé' icon={FileText}>
+              <dl className='space-y-3 text-sm'>
+                <div className='flex items-center justify-between'>
+                  <dt className='text-slate-500'>ID demande</dt>
+                  <dd className='font-mono text-xs text-slate-900'>
+                    #{shortId}
+                  </dd>
+                </div>
+                <div className='flex items-center justify-between'>
+                  <dt className='text-slate-500'>Créée le</dt>
+                  <dd className='font-medium text-slate-900'>
+                    {payRequest.createdAt
+                      ? formatDateTime(payRequest.createdAt)
+                      : '—'}
+                  </dd>
+                </div>
+                <div className='flex items-center justify-between'>
+                  <dt className='text-slate-500'>Mise à jour</dt>
+                  <dd className='font-medium text-slate-900'>
+                    {payRequest.updatedAt
+                      ? formatDateTime(payRequest.updatedAt)
+                      : '—'}
+                  </dd>
+                </div>
+              </dl>
+            </SectionCard>
+          </div>
+        </div>
+      </div>
+
+      {/* Action modal */}
+      <Dialog open={showModal} onOpenChange={open => !open && closeModal()}>
+        <DialogContent className='sm:max-w-[520px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div
+                className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl ring-1 ring-slate-100 ${actionConfig.iconBg} ${actionConfig.iconText}`}
+              >
+                <ActionIcon className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>
+                  {actionConfig.title}
+                </DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  {actionConfig.description}
+                </DialogDescription>
               </div>
             </div>
+          </DialogHeader>
+
+          <div className='space-y-4 py-2'>
+            {/* Amount recap */}
+            <div className='flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50/60 px-4 py-3'>
+              <div className='min-w-0'>
+                <p className='truncate text-sm font-semibold text-slate-900'>
+                  {payRequest.user.name || payRequest.user.email}
+                </p>
+                <p className='truncate text-xs text-slate-500'>
+                  {payRequest.rent.product.name}
+                </p>
+              </div>
+              <p className='shrink-0 text-lg font-bold tabular-nums text-slate-900'>
+                {formatCurrency(amount)}
+              </p>
+            </div>
+
+            {/* Note textarea for reject / request_info */}
+            {(actionType === 'reject' || actionType === 'request_info') && (
+              <div>
+                <label
+                  htmlFor='action-note'
+                  className='mb-2 block text-sm font-semibold text-slate-700'
+                >
+                  {actionType === 'reject'
+                    ? 'Raison du refus'
+                    : 'Informations demandées'}
+                </label>
+                <textarea
+                  id='action-note'
+                  value={actionNote}
+                  onChange={e => {
+                    setActionNote(e.target.value)
+                    if (noteError) setNoteError(null)
+                  }}
+                  rows={4}
+                  placeholder={
+                    actionType === 'reject'
+                      ? 'Expliquez clairement pourquoi cette demande est refusée…'
+                      : 'Spécifiez quelles informations supplémentaires sont nécessaires…'
+                  }
+                  className='w-full resize-none rounded-xl border border-slate-200 bg-white p-3 text-sm text-slate-900 outline-none ring-offset-0 transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20'
+                />
+                {noteError && (
+                  <p className='mt-2 flex items-center gap-1.5 text-xs font-medium text-red-600'>
+                    <AlertTriangle className='h-3.5 w-3.5' />
+                    {noteError}
+                  </p>
+                )}
+              </div>
+            )}
           </div>
-        )}
-      </div>
+
+          <DialogFooter className='gap-2'>
+            <Button
+              variant='outline'
+              onClick={closeModal}
+              disabled={updating}
+            >
+              Annuler
+            </Button>
+            <Button
+              onClick={handleAction}
+              disabled={updating}
+              className={`gap-2 ${actionConfig.submitButtonClass}`}
+            >
+              {updating ? (
+                <>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Traitement…
+                </>
+              ) : (
+                <>
+                  {actionType === 'request_info' ? (
+                    <Send className='h-4 w-4' />
+                  ) : (
+                    <ActionIcon className='h-4 w-4' />
+                  )}
+                  {actionConfig.buttonLabel}
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/src/app/admin/payment/page.tsx
+++ b/src/app/admin/payment/page.tsx
@@ -1,12 +1,36 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
+import { motion } from 'framer-motion'
 import { useAuth } from '@/hooks/useAuth'
 import { isFullAdmin } from '@/hooks/useAdminAuth'
 import { getAllPaymentRequest } from '@/lib/services/payment.service'
-import { PaymentStatus, PaymentMethod, PaymentReqStatus } from '@prisma/client'
+import { PaymentStatus, PaymentReqStatus } from '@prisma/client'
 import { formatCurrency } from '@/lib/utils/formatNumber'
+import { Button } from '@/components/ui/shadcnui/button'
+import {
+  Banknote,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  TrendingUp,
+  Wallet,
+  Shield,
+  Eye,
+  CreditCard,
+  Percent,
+  Coins,
+} from 'lucide-react'
+
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard } from '@/components/admin/ui/KpiCard'
+import { FilterBar } from '@/components/admin/ui/FilterBar'
+import {
+  DataTable,
+  type DataTableColumn,
+  type DataTableSort,
+} from '@/components/admin/ui/DataTable'
 
 interface PayRequest {
   id: string
@@ -14,7 +38,7 @@ interface PayRequest {
   PaymentRequest: PaymentStatus
   prices: string
   notes: string
-  method: PaymentMethod
+  method: string
   status: PaymentReqStatus
   user: {
     name: string | null
@@ -27,6 +51,91 @@ interface PayRequest {
   }
 }
 
+const REQUEST_TYPE_CONFIG: Partial<
+  Record<PaymentStatus, { label: string; tone: string; icon: React.ComponentType<{ className?: string }> }>
+> = {
+  FULL_TRANSFER_REQ: {
+    label: 'Paiement intégral',
+    tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: Banknote,
+  },
+  MID_TRANSFER_REQ: {
+    label: 'Paiement 50%',
+    tone: 'bg-blue-50 text-blue-700 ring-blue-200',
+    icon: Percent,
+  },
+  REST_TRANSFER_REQ: {
+    label: 'Solde restant',
+    tone: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: Coins,
+  },
+}
+
+const STATUS_CONFIG: Record<
+  PaymentReqStatus,
+  { label: string; tone: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  RECEIVED: {
+    label: 'En attente',
+    tone: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: Clock,
+  },
+  DONE: {
+    label: 'Terminé',
+    tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: CheckCircle2,
+  },
+  REFUSED: {
+    label: 'Refusé',
+    tone: 'bg-red-50 text-red-700 ring-red-200',
+    icon: XCircle,
+  },
+}
+
+const STATUS_FILTERS: Array<{
+  value: PaymentReqStatus | 'ALL'
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}> = [
+  { value: 'ALL', label: 'Toutes', icon: Wallet },
+  { value: PaymentReqStatus.RECEIVED, label: 'En attente', icon: Clock },
+  { value: PaymentReqStatus.DONE, label: 'Terminées', icon: CheckCircle2 },
+  { value: PaymentReqStatus.REFUSED, label: 'Refusées', icon: XCircle },
+]
+
+function RequestTypePill({ type }: { type: PaymentStatus }) {
+  const config = REQUEST_TYPE_CONFIG[type]
+  if (!config) {
+    return (
+      <span className='inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700 ring-1 ring-slate-200'>
+        {type}
+      </span>
+    )
+  }
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.label}
+    </span>
+  )
+}
+
+function RequestStatusPill({ status }: { status: PaymentReqStatus }) {
+  const config = STATUS_CONFIG[status]
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.label}
+    </span>
+  )
+}
+
 export default function PaymentAdminPage() {
   const {
     session,
@@ -34,12 +143,13 @@ export default function PaymentAdminPage() {
     isAuthenticated,
   } = useAuth({ required: true, redirectTo: '/auth' })
   const router = useRouter()
+
   const [payRequests, setPayRequests] = useState<PayRequest[]>([])
-  const [filteredRequests, setFilteredRequests] = useState<PayRequest[]>([])
   const [loading, setLoading] = useState(true)
   const [statusFilter, setStatusFilter] = useState<PaymentReqStatus | 'ALL'>('ALL')
+  const [searchValue, setSearchValue] = useState('')
+  const [sort, setSort] = useState<DataTableSort | null>({ key: 'amount', direction: 'desc' })
 
-  // Security check - Only ADMIN can access payment management
   useEffect(() => {
     if (isAuthenticated && (!session?.user?.roles || !isFullAdmin(session.user.roles))) {
       router.push('/')
@@ -47,302 +157,262 @@ export default function PaymentAdminPage() {
   }, [isAuthenticated, session, router])
 
   useEffect(() => {
+    const fetchPayRequests = async () => {
+      try {
+        const result = await getAllPaymentRequest()
+        setPayRequests(result.payRequest)
+      } catch (error) {
+        console.error('Erreur lors du chargement des demandes de paiement:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
     fetchPayRequests()
   }, [])
-
-  useEffect(() => {
-    // Filtrer les demandes selon le statut sélectionné
-    if (statusFilter === 'ALL') {
-      setFilteredRequests(payRequests)
-    } else {
-      setFilteredRequests(payRequests.filter(req => req.status === statusFilter))
-    }
-  }, [payRequests, statusFilter])
-
-  const fetchPayRequests = async () => {
-    try {
-      console.log('Fetching payment requests...')
-      const result = await getAllPaymentRequest()
-      console.log('Payment requests result:', result)
-      setPayRequests(result.payRequest)
-    } catch (error) {
-      console.error('Erreur lors du chargement des demandes de paiement:', error)
-    } finally {
-      setLoading(false)
-    }
-  }
 
   const handleViewDetails = (requestId: string) => {
     router.push(`/admin/payment/${requestId}`)
   }
 
-  const getPaymentRequestLabel = (type: PaymentStatus) => {
-    const labels: Partial<Record<PaymentStatus, string>> = {
-      FULL_TRANSFER_REQ: 'Paiement intégral',
-      MID_TRANSFER_REQ: 'Paiement de 50%',
-      REST_TRANSFER_REQ: 'Solde restant',
+  const filteredRequests = useMemo(() => {
+    let rows = payRequests
+    if (statusFilter !== 'ALL') {
+      rows = rows.filter(r => r.status === statusFilter)
     }
-    return labels[type] || type
-  }
+    if (searchValue.trim()) {
+      const q = searchValue.toLowerCase()
+      rows = rows.filter(
+        r =>
+          r.user.name?.toLowerCase().includes(q) ||
+          r.user.email.toLowerCase().includes(q) ||
+          r.rent?.product?.name?.toLowerCase().includes(q)
+      )
+    }
+    return rows
+  }, [payRequests, statusFilter, searchValue])
 
-  const getStatusBadge = (type: PaymentStatus) => {
-    switch (type) {
-      case PaymentStatus.FULL_TRANSFER_REQ:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800'>
-            💰 {getPaymentRequestLabel(type)}
-          </span>
-        )
-      case PaymentStatus.MID_TRANSFER_REQ:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800'>
-            📊 {getPaymentRequestLabel(type)}
-          </span>
-        )
-      case PaymentStatus.REST_TRANSFER_REQ:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800'>
-            💳 {getPaymentRequestLabel(type)}
-          </span>
-        )
-      default:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800'>
-            {getPaymentRequestLabel(type)}
-          </span>
-        )
-    }
-  }
+  const stats = useMemo(() => {
+    const total = payRequests.length
+    const pending = payRequests.filter(r => r.status === PaymentReqStatus.RECEIVED).length
+    const done = payRequests.filter(r => r.status === PaymentReqStatus.DONE).length
+    const refused = payRequests.filter(r => r.status === PaymentReqStatus.REFUSED).length
 
-  const getRequestStatusBadge = (status: PaymentReqStatus) => {
-    switch (status) {
-      case PaymentReqStatus.RECEIVED:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800'>
-            ⏳ Reçu
-          </span>
-        )
-      case PaymentReqStatus.DONE:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800'>
-            ✅ Terminé
-          </span>
-        )
-      case PaymentReqStatus.REFUSED:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800'>
-            ❌ Refusé
-          </span>
-        )
-      default:
-        return (
-          <span className='inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800'>
-            {status}
-          </span>
-        )
-    }
-  }
+    const totalAmount = payRequests
+      .filter(r => r.status !== PaymentReqStatus.REFUSED)
+      .reduce((sum, r) => sum + Number(r.prices || 0), 0)
+    const pendingAmount = payRequests
+      .filter(r => r.status === PaymentReqStatus.RECEIVED)
+      .reduce((sum, r) => sum + Number(r.prices || 0), 0)
+
+    return { total, pending, done, refused, totalAmount, pendingAmount }
+  }, [payRequests])
+
+  const columns: DataTableColumn<PayRequest>[] = [
+    {
+      key: 'type',
+      header: 'Type',
+      render: r => (
+        <div className='space-y-1'>
+          <RequestTypePill type={r.PaymentRequest} />
+          {r.notes && (
+            <p className='line-clamp-1 text-xs text-slate-500' title={r.notes}>
+              {r.notes}
+            </p>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'amount',
+      header: 'Montant',
+      sortable: true,
+      sortAccessor: r => Number(r.prices || 0),
+      align: 'right',
+      render: r => (
+        <p className='text-sm font-bold tabular-nums text-slate-900'>
+          {formatCurrency(Number(r.prices || 0))}
+        </p>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'host',
+      header: 'Hôte',
+      sortable: true,
+      sortAccessor: r => (r.user.name || r.user.email).toLowerCase(),
+      render: r => (
+        <div className='min-w-0'>
+          <p className='truncate text-sm font-semibold text-slate-900'>
+            {r.user.name || 'Sans nom'}
+          </p>
+          <p className='truncate text-xs text-slate-500'>{r.user.email}</p>
+        </div>
+      ),
+    },
+    {
+      key: 'product',
+      header: 'Hébergement',
+      render: r => (
+        <p className='truncate text-sm text-slate-700' title={r.rent?.product?.name}>
+          {r.rent?.product?.name ?? '—'}
+        </p>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Statut',
+      sortable: true,
+      sortAccessor: r => r.status,
+      render: r => <RequestStatusPill status={r.status} />,
+      cellClassName: 'whitespace-nowrap',
+    },
+  ]
 
   if (isAuthLoading || loading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
         </div>
       </div>
     )
   }
 
-  if (!session) {
-    return null
-  }
+  if (!session) return null
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-6'>
-      <div className='max-w-7xl mx-auto'>
-        {/* Header */}
-        <div className='mb-8'>
-          <h1 className='text-3xl font-bold text-gray-900 mb-2'>🏦 Gestion des Paiements</h1>
-          <p className='text-gray-600'>
-            Gérez les demandes de paiement des hôtes et effectuez les actions nécessaires
-          </p>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <PageHeader
+          backHref='/admin'
+          backLabel='Retour au panel admin'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title='Gestion des paiements'
+          subtitle='Consultez et traitez les demandes de paiement des hôtes. Cliquez sur une ligne pour voir les détails et valider ou refuser le versement.'
+        />
+
+        {/* KPI row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Total demandes'
+            value={stats.total}
+            hint='toutes statuts confondus'
+            icon={Wallet}
+            tone='blue'
+          />
+          <KpiCard
+            label='En attente'
+            value={stats.pending}
+            hint='à traiter en priorité'
+            icon={Clock}
+            tone='amber'
+          />
+          <KpiCard
+            label='Montant en attente'
+            value={formatCurrency(stats.pendingAmount)}
+            hint='demandes reçues non traitées'
+            icon={TrendingUp}
+            tone='purple'
+          />
+          <KpiCard
+            label='Montant total'
+            value={formatCurrency(stats.totalAmount)}
+            hint='hors refusées'
+            icon={CreditCard}
+            tone='emerald'
+          />
         </div>
 
-        {/* Stats */}
-        <div className='grid grid-cols-1 md:grid-cols-4 gap-6 mb-8'>
-          <div className='bg-white rounded-xl shadow-sm p-6 border border-gray-200'>
-            <div className='flex items-center'>
-              <div className='text-2xl mr-4'>📋</div>
-              <div>
-                <p className='text-sm font-medium text-gray-600'>Total</p>
-                <p className='text-2xl font-bold text-gray-900'>{payRequests.length}</p>
-              </div>
-            </div>
-          </div>
-          <div className='bg-white rounded-xl shadow-sm p-6 border border-gray-200'>
-            <div className='flex items-center'>
-              <div className='text-2xl mr-4'>⏰</div>
-              <div>
-                <p className='text-sm font-medium text-gray-600'>En attente</p>
-                <p className='text-2xl font-bold text-orange-600'>
-                  {payRequests.filter(req => req.status === PaymentReqStatus.RECEIVED).length}
-                </p>
-              </div>
-            </div>
-          </div>
-          <div className='bg-white rounded-xl shadow-sm p-6 border border-gray-200'>
-            <div className='flex items-center'>
-              <div className='text-2xl mr-4'>✅</div>
-              <div>
-                <p className='text-sm font-medium text-gray-600'>Terminé</p>
-                <p className='text-2xl font-bold text-green-600'>
-                  {payRequests.filter(req => req.status === PaymentReqStatus.DONE).length}
-                </p>
-              </div>
-            </div>
-          </div>
-          <div className='bg-white rounded-xl shadow-sm p-6 border border-gray-200'>
-            <div className='flex items-center'>
-              <div className='text-2xl mr-4'>❌</div>
-              <div>
-                <p className='text-sm font-medium text-gray-600'>Refusé</p>
-                <p className='text-2xl font-bold text-red-600'>
-                  {payRequests.filter(req => req.status === PaymentReqStatus.REFUSED).length}
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Filtres */}
-        <div className='mb-6 flex flex-wrap items-center gap-4'>
-          <div className='flex items-center gap-2'>
-            <span className='text-sm font-medium text-gray-700'>Filtrer par statut:</span>
-            <select
-              value={statusFilter}
-              onChange={e => setStatusFilter(e.target.value as PaymentReqStatus | 'ALL')}
-              className='px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm'
-            >
-              <option value='ALL'>Tous ({payRequests.length})</option>
-              <option value={PaymentReqStatus.RECEIVED}>
-                En attente (
-                {payRequests.filter(req => req.status === PaymentReqStatus.RECEIVED).length})
-              </option>
-              <option value={PaymentReqStatus.DONE}>
-                Terminé ({payRequests.filter(req => req.status === PaymentReqStatus.DONE).length})
-              </option>
-              <option value={PaymentReqStatus.REFUSED}>
-                Refusé ({payRequests.filter(req => req.status === PaymentReqStatus.REFUSED).length})
-              </option>
-            </select>
-          </div>
-          <div className='flex items-center gap-2 text-sm text-gray-600'>
-            <span>💰 Montant total visible:</span>
-            <span className='font-semibold text-gray-900'>
-              {formatCurrency(filteredRequests.reduce((sum, req) => sum + Number(req.prices), 0))}
-            </span>
-          </div>
-        </div>
-
-        {/* Debug info */}
-        <div className='mb-6 p-4 bg-blue-50 rounded-lg border border-blue-200'>
-          <p className='text-sm text-blue-800'>
-            🔍 Debug: {filteredRequests.length} demande(s) affichée(s) sur {payRequests.length} au
-            total
-          </p>
-        </div>
-
-        {/* Requests Table */}
-        <div className='bg-white rounded-xl shadow-sm overflow-hidden border border-gray-200'>
-          {filteredRequests.length === 0 ? (
-            <div className='text-center py-12'>
-              <div className='text-6xl mb-4'>📭</div>
-              <h3 className='text-lg font-medium text-gray-900 mb-2'>
-                {statusFilter === 'ALL'
-                  ? 'Aucune demande de paiement'
-                  : `Aucune demande ${
-                      statusFilter === PaymentReqStatus.RECEIVED
-                        ? 'en attente'
-                        : statusFilter === PaymentReqStatus.DONE
-                          ? 'terminée'
-                          : 'refusée'
+        {/* Status filter chips */}
+        <div className='flex flex-wrap items-center gap-2'>
+          {STATUS_FILTERS.map(f => {
+            const Icon = f.icon
+            const active = statusFilter === f.value
+            return (
+              <button
+                key={f.value}
+                onClick={() => setStatusFilter(f.value)}
+                className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+                  active
+                    ? 'bg-slate-900 text-white shadow-sm'
+                    : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50'
+                }`}
+              >
+                <Icon className='h-3 w-3' />
+                {f.label}
+                {f.value !== 'ALL' && (
+                  <span
+                    className={`ml-1 inline-flex min-w-[1.25rem] items-center justify-center rounded-full px-1 text-[10px] font-bold ${
+                      active ? 'bg-white/20' : 'bg-slate-100'
                     }`}
-              </h3>
-              <p className='text-gray-600'>
-                {statusFilter === 'ALL'
-                  ? 'Aucune demande de paiement n&apos;a encore été créée.'
-                  : 'Changez le filtre pour voir d&apos;autres demandes.'}
-              </p>
-            </div>
-          ) : (
-            <div className='overflow-x-auto'>
-              <table className='min-w-full divide-y divide-gray-200'>
-                <thead className='bg-gray-50'>
-                  <tr>
-                    <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
-                      Type & Montant
-                    </th>
-                    <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
-                      Status
-                    </th>
-                    <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
-                      Hôte
-                    </th>
-                    <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
-                      Date demande
-                    </th>
-                    <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
-                      Actions
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className='bg-white divide-y divide-gray-200'>
-                  {filteredRequests.map(request => (
-                    <tr key={request.id} className='hover:bg-gray-50 transition-colors'>
-                      <td className='px-6 py-4'>
-                        <div className='flex flex-col space-y-2'>
-                          {getStatusBadge(request.PaymentRequest)}
-                          <div className='text-lg font-semibold text-gray-900'>
-                            {formatCurrency(Number(request.prices))}
-                          </div>
-                        </div>
-                      </td>
-                      <td className='px-6 py-4'>{getRequestStatusBadge(request.status)}</td>
-                      <td className='px-6 py-4'>
-                        <div className='flex items-center'>
-                          <div className='text-lg mr-2'>👤</div>
-                          <div>
-                            <div className='text-sm font-medium text-gray-900'>
-                              {request.user.name || 'Sans nom'}
-                            </div>
-                            <div className='text-sm text-gray-500'>{request.user.email}</div>
-                          </div>
-                        </div>
-                      </td>
-                      <td className='px-6 py-4'>
-                        <div className='flex items-center'>
-                          <div className='text-lg mr-2'>📅</div>
-                          <div className='text-sm text-gray-900'>Non disponible</div>
-                        </div>
-                      </td>
-                      <td className='px-6 py-4'>
-                        <button
-                          onClick={() => handleViewDetails(request.id)}
-                          className='px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 transition-colors flex items-center space-x-2'
-                        >
-                          <span>👁️</span>
-                          <span>Voir détails</span>
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+                  >
+                    {f.value === PaymentReqStatus.RECEIVED
+                      ? stats.pending
+                      : f.value === PaymentReqStatus.DONE
+                        ? stats.done
+                        : stats.refused}
+                  </span>
+                )}
+              </button>
+            )
+          })}
         </div>
-      </div>
+
+        {/* Search */}
+        <FilterBar
+          searchValue={searchValue}
+          onSearchChange={setSearchValue}
+          searchPlaceholder='Rechercher par hôte, email ou hébergement…'
+        />
+
+        {/* Data table */}
+        <DataTable<PayRequest>
+          columns={columns}
+          rows={filteredRequests}
+          getRowId={r => r.id}
+          loading={loading}
+          sort={sort}
+          onSortChange={setSort}
+          rowActions={request => (
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => handleViewDetails(request.id)}
+              className='gap-1 text-slate-600 hover:text-slate-900'
+            >
+              <Eye className='h-4 w-4' />
+              Détails
+            </Button>
+          )}
+          emptyState={{
+            icon: Wallet,
+            title: 'Aucune demande de paiement',
+            subtitle:
+              searchValue || statusFilter !== 'ALL'
+                ? 'Essayez d’ajuster vos filtres.'
+                : 'Aucune demande n’a encore été créée.',
+          }}
+        />
+      </motion.div>
     </div>
   )
 }

--- a/src/app/admin/reservations/page.tsx
+++ b/src/app/admin/reservations/page.tsx
@@ -1,18 +1,16 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { motion } from 'framer-motion'
 import { useAuth } from '@/hooks/useAuth'
 import { isFullAdmin } from '@/hooks/useAdminAuth'
 import { useAdminReservationsPaginated } from '@/hooks/useAdminPaginated'
 import { useAdminReservationStatusChange } from '@/hooks/useAdminReservationMutations'
 import Pagination from '@/components/ui/Pagination'
-import { motion, Variants } from 'framer-motion'
-import { Card, CardContent } from '@/components/ui/shadcnui/card'
 import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/shadcnui/input'
 import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
-import { Loader2, Search, CalendarDays, XCircle } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -23,37 +21,170 @@ import {
   Label,
 } from '@/shadcnui'
 import { Textarea } from '@/components/ui/shadcnui/textarea'
-import { ReservationCard } from '@/components/reservations/ReservationCard'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/shadcnui/dropdown-menu'
+import {
+  Loader2,
+  CalendarDays,
+  Clock,
+  CheckCircle2,
+  DoorOpen,
+  DoorClosed,
+  XCircle,
+  Ban,
+  MoreHorizontal,
+  MapPin,
+  Eye,
+  Shield,
+  ArrowRight,
+  CreditCard,
+  AlertCircle,
+} from 'lucide-react'
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard, KpiMetric } from '@/components/admin/ui/KpiCard'
+import { FilterBar } from '@/components/admin/ui/FilterBar'
+import { DataTable, type DataTableColumn } from '@/components/admin/ui/DataTable'
 
-const containerVariants: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
+type RentStatus = 'WAITING' | 'RESERVED' | 'CHECKIN' | 'CHECKOUT' | 'CANCEL'
+
+type PaymentStatus =
+  | 'NOT_PAID'
+  | 'CLIENT_PAID'
+  | 'MID_TRANSFER_REQ'
+  | 'MID_TRANSFER_DONE'
+  | 'REST_TRANSFER_REQ'
+  | 'REST_TRANSFER_DONE'
+  | 'FULL_TRANSFER_REQ'
+  | 'FULL_TRANSFER_DONE'
+  | 'REFUNDED'
+  | 'DISPUTE'
+
+interface AdminReservationRow {
+  id: string
+  arrivingDate: string
+  leavingDate: string
+  status: RentStatus
+  payment: PaymentStatus
+  totalAmount: number | null
+  numberOfNights: number | null
+  numberPeople: number | null
+  createdAt: string
+  accepted: boolean
+  confirmed: boolean
+  product: {
+    id: string
+    name: string
+    address: string
+    owner: { id: string; name: string | null; email: string }
+  }
+  user: {
+    id: string
+    name: string | null
+    lastname: string | null
+    email: string
+  }
+}
+
+const STATUS_LABEL: Record<
+  RentStatus,
+  { label: string; tone: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  WAITING: {
+    label: 'En attente',
+    tone: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: Clock,
+  },
+  RESERVED: {
+    label: 'Confirmée',
+    tone: 'bg-blue-50 text-blue-700 ring-blue-200',
+    icon: CheckCircle2,
+  },
+  CHECKIN: {
+    label: 'Check-in',
+    tone: 'bg-indigo-50 text-indigo-700 ring-indigo-200',
+    icon: DoorOpen,
+  },
+  CHECKOUT: {
+    label: 'Check-out',
+    tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: DoorClosed,
+  },
+  CANCEL: {
+    label: 'Annulée',
+    tone: 'bg-red-50 text-red-700 ring-red-200',
+    icon: Ban,
   },
 }
 
-const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.5,
-    },
-  },
+const PAYMENT_LABEL: Record<PaymentStatus, { label: string; tone: string }> = {
+  NOT_PAID: { label: 'Non payé', tone: 'bg-slate-100 text-slate-700' },
+  CLIENT_PAID: { label: 'Payé', tone: 'bg-emerald-50 text-emerald-700' },
+  MID_TRANSFER_REQ: { label: '50% demandé', tone: 'bg-amber-50 text-amber-700' },
+  MID_TRANSFER_DONE: { label: '50% versé', tone: 'bg-blue-50 text-blue-700' },
+  REST_TRANSFER_REQ: { label: 'Solde demandé', tone: 'bg-amber-50 text-amber-700' },
+  REST_TRANSFER_DONE: { label: 'Soldé', tone: 'bg-emerald-50 text-emerald-700' },
+  FULL_TRANSFER_REQ: { label: '100% demandé', tone: 'bg-amber-50 text-amber-700' },
+  FULL_TRANSFER_DONE: { label: '100% versé', tone: 'bg-emerald-50 text-emerald-700' },
+  REFUNDED: { label: 'Remboursé', tone: 'bg-red-50 text-red-700' },
+  DISPUTE: { label: 'Litige', tone: 'bg-red-50 text-red-700' },
 }
 
-const STATS_CARDS = [
-  { key: 'total', label: 'Total', gradient: 'from-blue-500 to-blue-600', textMuted: 'text-blue-100', iconColor: 'text-blue-200' },
-  { key: 'WAITING', label: 'En attente', gradient: 'from-yellow-400 to-yellow-500', textMuted: 'text-yellow-100', iconColor: 'text-yellow-200' },
-  { key: 'RESERVED', label: 'Confirmées', gradient: 'from-blue-400 to-indigo-500', textMuted: 'text-blue-100', iconColor: 'text-blue-200' },
-  { key: 'CHECKIN', label: 'Check-in', gradient: 'from-green-400 to-green-500', textMuted: 'text-green-100', iconColor: 'text-green-200' },
-  { key: 'CHECKOUT', label: 'Check-out', gradient: 'from-gray-400 to-gray-500', textMuted: 'text-gray-100', iconColor: 'text-gray-200' },
-  { key: 'CANCEL', label: 'Annulées', gradient: 'from-red-400 to-red-500', textMuted: 'text-red-100', iconColor: 'text-red-200' },
+const STATUS_FILTERS: Array<{
+  value: '' | RentStatus
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}> = [
+  { value: '', label: 'Toutes', icon: CalendarDays },
+  { value: 'WAITING', label: 'En attente', icon: Clock },
+  { value: 'RESERVED', label: 'Confirmées', icon: CheckCircle2 },
+  { value: 'CHECKIN', label: 'Check-in', icon: DoorOpen },
+  { value: 'CHECKOUT', label: 'Check-out', icon: DoorClosed },
+  { value: 'CANCEL', label: 'Annulées', icon: Ban },
 ]
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(amount)
+}
+
+function formatDate(date: string | Date): string {
+  return new Date(date).toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+function StatusPill({ status }: { status: RentStatus }) {
+  const config = STATUS_LABEL[status]
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.label}
+    </span>
+  )
+}
+
+function PaymentPill({ payment }: { payment: PaymentStatus }) {
+  const config = PAYMENT_LABEL[payment]
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${config.tone}`}>
+      {config.label}
+    </span>
+  )
+}
 
 export default function AdminReservationsPage() {
   const {
@@ -68,7 +199,6 @@ export default function AdminReservationsPage() {
     stats,
     pagination,
     loading,
-    isFetching,
     error: hookError,
     searchTerm,
     statusFilter,
@@ -89,11 +219,15 @@ export default function AdminReservationsPage() {
     }
   }, [isAuthenticated, session, router])
 
-  const handleStatusAction = (rentId: string, status: 'RESERVED' | 'CHECKIN' | 'CHECKOUT' | 'CANCEL') => {
+  const openCancelDialog = (rentId: string) => {
+    setCancelTargetId(rentId)
+    setCancelReason('')
+    setCancelDialogOpen(true)
+  }
+
+  const handleStatusAction = (rentId: string, status: Exclude<RentStatus, 'WAITING'>) => {
     if (status === 'CANCEL') {
-      setCancelTargetId(rentId)
-      setCancelReason('')
-      setCancelDialogOpen(true)
+      openCancelDialog(rentId)
       return
     }
     statusMutation.mutate({ rentId, status })
@@ -113,12 +247,145 @@ export default function AdminReservationsPage() {
     )
   }
 
+  const totalRevenue = useMemo(
+    () =>
+      (reservations as AdminReservationRow[])
+        .filter(
+          r =>
+            r.payment !== 'NOT_PAID' &&
+            r.payment !== 'REFUNDED' &&
+            r.payment !== 'DISPUTE' &&
+            r.status !== 'CANCEL'
+        )
+        .reduce((sum, r) => sum + (r.totalAmount ?? 0), 0),
+    [reservations]
+  )
+
+  const columns: DataTableColumn<AdminReservationRow>[] = [
+    {
+      key: 'reference',
+      header: 'Référence',
+      sortable: true,
+      sortAccessor: r => new Date(r.createdAt),
+      render: r => (
+        <div className='min-w-0'>
+          <p className='text-sm font-semibold text-slate-900'>#{r.id.slice(-6).toUpperCase()}</p>
+          <p className='truncate text-xs text-slate-500'>Créée le {formatDate(r.createdAt)}</p>
+        </div>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'guest',
+      header: 'Voyageur',
+      sortable: true,
+      sortAccessor: r => (r.user.name || r.user.email).toLowerCase(),
+      render: r => {
+        const displayName = [r.user.name, r.user.lastname].filter(Boolean).join(' ') || '—'
+        return (
+          <div className='min-w-0'>
+            <p className='truncate text-sm font-medium text-slate-900'>{displayName}</p>
+            <p className='truncate text-xs text-slate-500'>{r.user.email}</p>
+          </div>
+        )
+      },
+    },
+    {
+      key: 'product',
+      header: 'Hébergement',
+      render: r => (
+        <Link
+          href={`/admin/validation/${r.product.id}`}
+          className='group block min-w-0'
+        >
+          <p className='truncate text-sm font-medium text-slate-900 group-hover:text-blue-700'>
+            {r.product.name}
+          </p>
+          <p className='flex items-center gap-1 truncate text-xs text-slate-500'>
+            <MapPin className='h-3 w-3' />
+            {r.product.address}
+          </p>
+        </Link>
+      ),
+    },
+    {
+      key: 'host',
+      header: 'Hôte',
+      render: r => {
+        const hostName = r.product.owner.name || r.product.owner.email
+        return (
+          <p className='truncate text-sm text-slate-700' title={r.product.owner.email}>
+            {hostName}
+          </p>
+        )
+      },
+    },
+    {
+      key: 'stay',
+      header: 'Séjour',
+      sortable: true,
+      sortAccessor: r => new Date(r.arrivingDate),
+      render: r => (
+        <div className='min-w-0'>
+          <p className='flex items-center gap-1 text-xs text-slate-900 whitespace-nowrap'>
+            {formatDate(r.arrivingDate)}
+            <ArrowRight className='h-3 w-3 text-slate-400' />
+            {formatDate(r.leavingDate)}
+          </p>
+          <p className='text-xs text-slate-500'>
+            {r.numberOfNights ?? '—'} nuits · {r.numberPeople ?? '—'} voyageur
+            {(r.numberPeople ?? 0) > 1 ? 's' : ''}
+          </p>
+        </div>
+      ),
+    },
+    {
+      key: 'amount',
+      header: 'Montant',
+      sortable: true,
+      sortAccessor: r => r.totalAmount ?? 0,
+      align: 'right',
+      render: r => (
+        <div className='text-right'>
+          <p className='text-sm font-bold tabular-nums text-slate-900'>
+            {r.totalAmount != null ? formatCurrency(r.totalAmount) : '—'}
+          </p>
+          <div className='mt-0.5 flex justify-end'>
+            <PaymentPill payment={r.payment} />
+          </div>
+        </div>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'status',
+      header: 'Statut',
+      sortable: true,
+      sortAccessor: r => r.status,
+      render: r => <StatusPill status={r.status} />,
+      cellClassName: 'whitespace-nowrap',
+    },
+  ]
+
   if (isAuthLoading || loading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin' />
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-16 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
+          <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
         </div>
       </div>
     )
@@ -126,210 +393,285 @@ export default function AdminReservationsPage() {
 
   if (!session) return null
 
-  if (hookError) {
-    return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive' className='rounded-2xl'>
+  return (
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <PageHeader
+          backHref='/admin'
+          backLabel='Retour au panel admin'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title='Gestion des réservations'
+          subtitle='Consultez, filtrez et gérez toutes les réservations de la plateforme. Les actions d’approbation, de check-in et d’annulation sont disponibles depuis le menu de chaque ligne.'
+        />
+
+        {hookError && (
+          <Alert variant='destructive'>
             <AlertDescription>
               {hookError.message || 'Erreur lors du chargement des réservations'}
             </AlertDescription>
           </Alert>
+        )}
+
+        {/* KPI row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Total'
+            value={stats.total || 0}
+            hint='réservations au total'
+            icon={CalendarDays}
+            tone='blue'
+            loading={loading}
+          />
+          <KpiCard
+            label='À traiter'
+            value={(stats.WAITING || 0) as number}
+            hint='en attente de confirmation'
+            icon={Clock}
+            tone='amber'
+            loading={loading}
+          />
+          <KpiCard
+            label='Confirmées'
+            value={(stats.RESERVED || 0) as number}
+            hint='prêtes pour le check-in'
+            icon={CheckCircle2}
+            tone='indigo'
+            loading={loading}
+          />
+          <KpiCard
+            label='Revenus (page)'
+            value={formatCurrency(totalRevenue)}
+            hint='sur la page actuelle, hors annulées'
+            icon={CreditCard}
+            tone='emerald'
+            loading={loading}
+          />
         </div>
-      </div>
-    )
-  }
 
-  return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100'>
-      <div className='container mx-auto p-6 space-y-8'>
-        {/* Header */}
-        <motion.div
-          className='text-center space-y-4'
-          variants={containerVariants}
-          initial='hidden'
-          animate='visible'
-        >
-          <motion.div
-            variants={itemVariants}
-            className='inline-flex items-center justify-center w-16 h-16 rounded-full bg-gradient-to-r from-blue-500 to-indigo-600 shadow-lg mb-4'
-          >
-            <CalendarDays className='w-8 h-8 text-white' />
-          </motion.div>
-          <motion.h1
-            variants={itemVariants}
-            className='text-4xl font-bold bg-gradient-to-r from-gray-900 via-blue-800 to-indigo-800 bg-clip-text text-transparent'
-          >
-            Gestion des Réservations
-          </motion.h1>
-          <motion.p variants={itemVariants} className='text-gray-600 text-lg max-w-2xl mx-auto'>
-            Consultez, filtrez et gérez toutes les réservations de la plateforme
-          </motion.p>
-        </motion.div>
+        {/* Secondary metrics */}
+        <div className='grid gap-3 sm:grid-cols-3'>
+          <KpiMetric
+            label='check-in'
+            value={(stats.CHECKIN || 0) as number}
+            icon={DoorOpen}
+            tone='slate'
+          />
+          <KpiMetric
+            label='check-out'
+            value={(stats.CHECKOUT || 0) as number}
+            icon={DoorClosed}
+            tone='slate'
+          />
+          <KpiMetric
+            label='annulées'
+            value={(stats.CANCEL || 0) as number}
+            icon={Ban}
+            tone='red'
+          />
+        </div>
 
-        {/* Stats Cards */}
-        <motion.div
-          variants={containerVariants}
-          initial='hidden'
-          animate='visible'
-          className='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4'
-        >
-          {STATS_CARDS.map(({ key, label, gradient, textMuted, iconColor }) => {
-            const isActive = (key === 'total' && !statusFilter) || statusFilter === key
+        {/* Status filter chips */}
+        <div className='flex flex-wrap items-center gap-2'>
+          {STATUS_FILTERS.map(filter => {
+            const Icon = filter.icon
+            const active =
+              (filter.value === '' && !statusFilter) || statusFilter === filter.value
             return (
-              <motion.div key={key} variants={itemVariants}>
-                <Card
-                  className={`border-0 shadow-lg cursor-pointer transition-all duration-300 hover:shadow-xl ${
-                    key === 'total' || isActive
-                      ? `bg-gradient-to-r ${gradient} text-white`
-                      : 'bg-white/80 backdrop-blur-sm hover:scale-[1.02]'
-                  }`}
-                  onClick={() => handleStatusFilter(key === 'total' ? '' : statusFilter === key ? '' : key)}
-                >
-                  <CardContent className='p-4'>
-                    <div className='flex items-center justify-between'>
-                      <div>
-                        <p className={`text-xs font-medium ${key === 'total' || isActive ? textMuted : 'text-gray-500'}`}>
-                          {label}
-                          {isActive && key !== 'total' && ' (Filtré)'}
-                        </p>
-                        <p className={`text-2xl font-bold ${key === 'total' || isActive ? '' : 'text-gray-900'}`}>
-                          {stats[key] || 0}
-                        </p>
-                      </div>
-                      <CalendarDays className={`h-6 w-6 ${key === 'total' || isActive ? iconColor : 'text-gray-300'}`} />
-                    </div>
-                  </CardContent>
-                </Card>
-              </motion.div>
+              <button
+                key={filter.value || 'all'}
+                onClick={() => handleStatusFilter(active ? '' : filter.value)}
+                className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+                  active
+                    ? 'bg-slate-900 text-white shadow-sm'
+                    : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50'
+                }`}
+              >
+                <Icon className='h-3 w-3' />
+                {filter.label}
+              </button>
             )
           })}
-        </motion.div>
-
-        {/* Search */}
-        <motion.div
-          variants={containerVariants}
-          initial='hidden'
-          animate='visible'
-          className='bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border-0'
-        >
-          <motion.div variants={itemVariants} className='relative max-w-md'>
-            {isFetching ? (
-              <Loader2 className='absolute left-3 top-1/2 transform -translate-y-1/2 text-blue-500 h-4 w-4 animate-spin' />
-            ) : (
-              <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4' />
-            )}
-            <Input
-              type='text'
-              placeholder='Rechercher par voyageur, hôte, hébergement...'
-              value={searchTerm}
-              onChange={e => handleSearch(e.target.value)}
-              className='pl-10 py-3 border-0 bg-gray-50 focus:bg-white transition-colors rounded-xl'
-            />
-          </motion.div>
-        </motion.div>
-
-        {/* Reservation Cards Grid */}
-        <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
-          {reservations.map((reservation, index) => (
-            <ReservationCard
-              key={reservation.id}
-              reservation={reservation}
-              index={index}
-              onStatusAction={handleStatusAction}
-            />
-          ))}
         </div>
 
-        {/* Empty State */}
-        {reservations.length === 0 && !loading && (
-          <motion.div variants={itemVariants} className='text-center py-12'>
-            <CalendarDays className='h-12 w-12 text-gray-400 mx-auto mb-4' />
-            <h3 className='text-lg font-medium text-gray-900 mb-2'>Aucune réservation trouvée</h3>
-            <p className='text-gray-500'>
-              Essayez de modifier votre recherche ou vos filtres.
+        {/* Filter bar */}
+        <FilterBar
+          searchValue={searchTerm}
+          onSearchChange={handleSearch}
+          searchPlaceholder='Rechercher par voyageur, hôte, hébergement…'
+        />
+
+        {/* Data table */}
+        <DataTable<AdminReservationRow>
+          columns={columns}
+          rows={reservations as unknown as AdminReservationRow[]}
+          getRowId={r => r.id}
+          loading={loading}
+          rowActions={reservation => {
+            const canConfirm = reservation.status === 'WAITING'
+            const canCheckIn = reservation.status === 'RESERVED'
+            const canCheckOut = reservation.status === 'CHECKIN'
+            const canCancel = !['CANCEL', 'CHECKOUT'].includes(reservation.status)
+            return (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant='ghost'
+                    size='sm'
+                    className='h-8 w-8 p-0'
+                    aria-label='Actions réservation'
+                  >
+                    <MoreHorizontal className='h-4 w-4' />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end' className='w-52'>
+                  <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem asChild>
+                    <Link
+                      href={`/reservations/${reservation.id}`}
+                      className='flex items-center gap-2'
+                    >
+                      <Eye className='h-4 w-4' />
+                      Voir le détail
+                    </Link>
+                  </DropdownMenuItem>
+                  {canConfirm && (
+                    <DropdownMenuItem
+                      onClick={() => handleStatusAction(reservation.id, 'RESERVED')}
+                      className='flex items-center gap-2 text-blue-700'
+                    >
+                      <CheckCircle2 className='h-4 w-4' />
+                      Confirmer
+                    </DropdownMenuItem>
+                  )}
+                  {canCheckIn && (
+                    <DropdownMenuItem
+                      onClick={() => handleStatusAction(reservation.id, 'CHECKIN')}
+                      className='flex items-center gap-2 text-indigo-700'
+                    >
+                      <DoorOpen className='h-4 w-4' />
+                      Marquer check-in
+                    </DropdownMenuItem>
+                  )}
+                  {canCheckOut && (
+                    <DropdownMenuItem
+                      onClick={() => handleStatusAction(reservation.id, 'CHECKOUT')}
+                      className='flex items-center gap-2 text-emerald-700'
+                    >
+                      <DoorClosed className='h-4 w-4' />
+                      Marquer check-out
+                    </DropdownMenuItem>
+                  )}
+                  {canCancel && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onClick={() => openCancelDialog(reservation.id)}
+                        className='flex items-center gap-2 text-red-600 focus:text-red-600'
+                      >
+                        <XCircle className='h-4 w-4' />
+                        Annuler la réservation
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )
+          }}
+          emptyState={{
+            icon: CalendarDays,
+            title: 'Aucune réservation trouvée',
+            subtitle:
+              searchTerm || statusFilter
+                ? 'Essayez d’ajuster votre recherche ou vos filtres.'
+                : 'Aucune réservation n’a encore été effectuée sur la plateforme.',
+          }}
+        />
+
+        {/* Footer: summary + pagination */}
+        {!loading && reservations.length > 0 && (
+          <div className='flex flex-col items-center gap-3 md:flex-row md:justify-between'>
+            <p className='text-sm text-slate-500'>
+              Affichage de {(pagination.currentPage - 1) * pagination.itemsPerPage + 1} à{' '}
+              {Math.min(
+                pagination.currentPage * pagination.itemsPerPage,
+                pagination.totalItems
+              )}{' '}
+              sur {pagination.totalItems} réservations
             </p>
-          </motion.div>
-        )}
-
-        {/* Pagination */}
-        {pagination.totalPages > 1 && (
-          <div className='mt-8 flex justify-center'>
-            <Pagination
-              currentPage={pagination.currentPage}
-              totalPages={pagination.totalPages}
-              onPageChange={goToPage}
-              showPrevNext={true}
-              showNumbers={true}
-              maxVisiblePages={5}
-            />
+            {pagination.totalPages > 1 && (
+              <Pagination
+                currentPage={pagination.currentPage}
+                totalPages={pagination.totalPages}
+                onPageChange={goToPage}
+                showPrevNext={true}
+                showNumbers={true}
+                maxVisiblePages={5}
+              />
+            )}
           </div>
         )}
 
-        {/* Results summary */}
-        {reservations.length > 0 && (
-          <div className='mt-4 text-center text-sm text-gray-500'>
-            Affichage de {(pagination.currentPage - 1) * pagination.itemsPerPage + 1} à{' '}
-            {Math.min(pagination.currentPage * pagination.itemsPerPage, pagination.totalItems)} sur{' '}
-            {pagination.totalItems} réservations
-          </div>
-        )}
-
-        {/* Cancel Dialog */}
+        {/* Cancel dialog */}
         <Dialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
-          <DialogContent className='sm:max-w-md rounded-2xl'>
+          <DialogContent className='sm:max-w-md'>
             <DialogHeader>
-              <DialogTitle className='flex items-center gap-2 text-xl'>
-                <XCircle className='h-5 w-5 text-red-600' />
-                Annuler la réservation
-              </DialogTitle>
-              <DialogDescription>
-                Cette action annulera la réservation et effectuera un remboursement Stripe si applicable.
-              </DialogDescription>
+              <div className='flex items-start gap-3'>
+                <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-red-50 text-red-600 ring-1 ring-red-100'>
+                  <AlertCircle className='h-5 w-5' />
+                </div>
+                <div className='space-y-1'>
+                  <DialogTitle className='text-lg'>Annuler la réservation</DialogTitle>
+                  <DialogDescription className='text-sm text-slate-600'>
+                    Cette action annulera la réservation et effectuera un remboursement Stripe si
+                    applicable. L’hôte et le voyageur seront notifiés.
+                  </DialogDescription>
+                </div>
+              </div>
             </DialogHeader>
-            <div className='space-y-4 py-4'>
+            <div className='space-y-4 py-2'>
               <div className='space-y-2'>
                 <Label htmlFor='cancelReason'>Raison (optionnel)</Label>
                 <Textarea
                   id='cancelReason'
-                  placeholder="Indiquez la raison de l'annulation..."
+                  placeholder='Expliquez la raison de l’annulation…'
                   value={cancelReason}
                   onChange={e => setCancelReason(e.target.value)}
-                  className='rounded-xl'
                   rows={3}
                 />
               </div>
             </div>
-            <DialogFooter>
+            <DialogFooter className='gap-2'>
               <Button
                 variant='outline'
                 onClick={() => setCancelDialogOpen(false)}
                 disabled={statusMutation.isPending}
-                className='rounded-xl'
               >
                 Retour
               </Button>
               <Button
+                variant='destructive'
                 onClick={handleConfirmCancel}
                 disabled={statusMutation.isPending}
-                className='bg-red-600 hover:bg-red-700 text-white rounded-xl'
+                className='gap-2'
               >
                 {statusMutation.isPending ? (
-                  <>
-                    <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                    Annulation...
-                  </>
+                  <Loader2 className='h-4 w-4 animate-spin' />
                 ) : (
-                  <>
-                    <XCircle className='h-4 w-4 mr-2' />
-                    Confirmer l&apos;annulation
-                  </>
+                  <XCircle className='h-4 w-4' />
                 )}
+                Confirmer l’annulation
               </Button>
             </DialogFooter>
           </DialogContent>
         </Dialog>
-      </div>
+      </motion.div>
     </div>
   )
 }

--- a/src/app/admin/withdrawals/page.tsx
+++ b/src/app/admin/withdrawals/page.tsx
@@ -1,19 +1,19 @@
 'use client'
 
 /**
- * Page Admin - Gestion des retraits
- * /admin/withdrawals
+ * Admin page — Withdrawal requests management.
  *
- * Permet aux admin/host_manager de :
- * - Voir toutes les demandes de retrait
- * - Approuver/rejeter des demandes
- * - Marquer comme payé
- * - Valider des comptes de paiement
- * - Créer des demandes pour les hôtes
+ * Allows ADMIN and HOST_MANAGER to:
+ *  - View all withdrawal requests with filters
+ *  - Approve / reject pending requests
+ *  - Mark approved requests as paid
+ *  - Validate payment accounts
+ *  - Create a new withdrawal request on behalf of a host
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
+import { motion } from 'framer-motion'
 import { useAuth } from '@/hooks/useAuth'
 import { toast } from 'sonner'
 import {
@@ -23,19 +23,62 @@ import {
   type PaymentAccount,
 } from '@prisma/client'
 
-// Type étendu avec les relations
+import { Button } from '@/components/ui/shadcnui/button'
+import { Input } from '@/components/ui/shadcnui/input'
+import { Label } from '@/components/ui/shadcnui/label'
+import { Textarea } from '@/components/ui/shadcnui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/shadcnui/select'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/shadcnui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/shadcnui/dropdown-menu'
+import {
+  Wallet,
+  Clock,
+  CheckCircle2,
+  Banknote,
+  XCircle,
+  ShieldCheck,
+  Shield,
+  MoreHorizontal,
+  Loader2,
+  UserPlus,
+  ArrowRight,
+  TrendingUp,
+  ShieldAlert,
+} from 'lucide-react'
+
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard, KpiMetric } from '@/components/admin/ui/KpiCard'
+import { FilterBar } from '@/components/admin/ui/FilterBar'
+import {
+  DataTable,
+  type DataTableColumn,
+  type DataTableSort,
+} from '@/components/admin/ui/DataTable'
+
 type WithdrawalRequest = PrismaWithdrawalRequest & {
-  user: {
-    id: string
-    name: string | null
-    email: string
-  }
+  user: { id: string; name: string | null; email: string }
   paymentAccount: PaymentAccount | null
-  processor: {
-    id: string
-    name: string | null
-    email: string
-  } | null
+  processor: { id: string; name: string | null; email: string } | null
 }
 
 type Host = {
@@ -54,6 +97,75 @@ type HostBalance = {
   amount100Percent: number
 }
 
+const STATUS_CONFIG: Record<
+  WithdrawalStatus,
+  { label: string; tone: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  PENDING: { label: 'En attente', tone: 'bg-amber-50 text-amber-700 ring-amber-200', icon: Clock },
+  ACCOUNT_VALIDATION: {
+    label: 'Validation compte',
+    tone: 'bg-orange-50 text-orange-700 ring-orange-200',
+    icon: ShieldAlert,
+  },
+  APPROVED: {
+    label: 'Approuvée',
+    tone: 'bg-blue-50 text-blue-700 ring-blue-200',
+    icon: CheckCircle2,
+  },
+  PAID: { label: 'Payée', tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200', icon: Banknote },
+  REJECTED: { label: 'Rejetée', tone: 'bg-red-50 text-red-700 ring-red-200', icon: XCircle },
+  CANCELLED: {
+    label: 'Annulée',
+    tone: 'bg-slate-100 text-slate-700 ring-slate-200',
+    icon: XCircle,
+  },
+}
+
+const STATUS_FILTERS: Array<{
+  value: WithdrawalStatus | 'ALL'
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}> = [
+  { value: 'ALL', label: 'Toutes', icon: Wallet },
+  { value: 'PENDING', label: 'En attente', icon: Clock },
+  { value: 'ACCOUNT_VALIDATION', label: 'Validation compte', icon: ShieldAlert },
+  { value: 'APPROVED', label: 'Approuvées', icon: CheckCircle2 },
+  { value: 'PAID', label: 'Payées', icon: Banknote },
+  { value: 'REJECTED', label: 'Rejetées', icon: XCircle },
+]
+
+const PAYMENT_METHOD_LABEL: Record<PaymentMethod, string> = {
+  SEPA_VIREMENT: 'SEPA',
+  PRIPEO: 'Pripeo',
+  MOBILE_MONEY: 'Mobile Money',
+  PAYPAL: 'PayPal',
+  MONEYGRAM: 'MoneyGram',
+  TAPTAP: 'TapTap',
+  INTERNATIONAL: 'International',
+  OTHER: 'Autre',
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 2,
+  }).format(amount)
+}
+
+function StatusPill({ status }: { status: WithdrawalStatus }) {
+  const config = STATUS_CONFIG[status]
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.label}
+    </span>
+  )
+}
+
 export default function AdminWithdrawalsPage() {
   const {
     session,
@@ -65,20 +177,22 @@ export default function AdminWithdrawalsPage() {
   const [requests, setRequests] = useState<WithdrawalRequest[]>([])
   const [hosts, setHosts] = useState<Host[]>([])
   const [loading, setLoading] = useState(true)
-  const [filter, setFilter] = useState<WithdrawalStatus | 'ALL'>('ALL')
+  const [searchValue, setSearchValue] = useState('')
+  const [statusFilter, setStatusFilter] = useState<WithdrawalStatus | 'ALL'>('ALL')
+  const [sort, setSort] = useState<DataTableSort | null>({ key: 'createdAt', direction: 'desc' })
+
+  // Create-withdrawal modal state
+  const [showCreateModal, setShowCreateModal] = useState(false)
   const [selectedHost, setSelectedHost] = useState<string>('')
   const [hostBalance, setHostBalance] = useState<HostBalance | null>(null)
-  const [showCreateModal, setShowCreateModal] = useState(false)
+  const [isCreating, setIsCreating] = useState(false)
 
-  // Form state for withdrawal creation
   const [withdrawalForm, setWithdrawalForm] = useState({
     amount: '',
     withdrawalType: 'PARTIAL_50' as 'PARTIAL_50' | 'FULL_100',
     paymentMethod: 'SEPA_VIREMENT' as PaymentMethod,
     notes: '',
   })
-
-  // Payment details for each method
   const [paymentDetails, setPaymentDetails] = useState({
     accountHolderName: '',
     iban: '',
@@ -93,70 +207,41 @@ export default function AdminWithdrawalsPage() {
     moneygramPhone: '',
   })
 
-  useEffect(() => {
-    if (isAuthenticated) {
-      // Vérifier les permissions
-      if (!session?.user.roles || !['ADMIN', 'HOST_MANAGER'].includes(session.user.roles)) {
-        toast.error('Accès non autorisé')
-        router.push('/dashboard')
-        return
-      }
+  const canManage =
+    session?.user.roles && ['ADMIN', 'HOST_MANAGER'].includes(session.user.roles as string)
 
-      fetchRequests()
-      fetchHosts()
+  useEffect(() => {
+    if (isAuthenticated && !canManage) {
+      toast.error('Accès non autorisé')
+      router.push('/')
     }
-  }, [isAuthenticated, router, session])
+  }, [isAuthenticated, canManage, router])
 
   const fetchRequests = async () => {
-    console.log('🔄 [fetchRequests] Début du chargement des demandes')
-    console.log('📊 [fetchRequests] Filtre actuel:', filter)
-    console.log('📋 [fetchRequests] Nombre de demandes avant:', requests.length)
-
     try {
       setLoading(true)
       const url =
-        filter === 'ALL' ? '/api/admin/withdrawals' : `/api/admin/withdrawals?status=${filter}`
-
-      console.log('🌐 [fetchRequests] URL appelée:', url)
-
-      const response = await fetch(url, {
-        cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      })
-
-      console.log('📡 [fetchRequests] Réponse reçue, status:', response.status)
-
+        statusFilter === 'ALL'
+          ? '/api/admin/withdrawals'
+          : `/api/admin/withdrawals?status=${statusFilter}`
+      const response = await fetch(url, { cache: 'no-store' })
       if (response.ok) {
         const data = await response.json()
-        console.log('✅ [fetchRequests] Données reçues:', data.requests.length, 'demandes')
-        console.log(
-          '📝 [fetchRequests] Détails des demandes:',
-          data.requests.map((r: WithdrawalRequest) => ({ id: r.id, status: r.status }))
-        )
         setRequests(data.requests)
-        console.log('💾 [fetchRequests] State mis à jour')
       } else {
-        console.error('❌ [fetchRequests] Erreur HTTP:', response.status)
+        toast.error('Erreur lors du chargement des demandes')
       }
     } catch (error) {
-      console.error('❌ [fetchRequests] Erreur lors du chargement:', error)
+      console.error('Error fetching requests:', error)
       toast.error('Erreur lors du chargement des demandes')
     } finally {
       setLoading(false)
-      console.log('🏁 [fetchRequests] Chargement terminé')
     }
   }
 
   const fetchHosts = async () => {
     try {
-      const response = await fetch('/api/admin/hosts', {
-        cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      })
+      const response = await fetch('/api/admin/hosts', { cache: 'no-store' })
       if (response.ok) {
         const data = await response.json()
         setHosts(data.hosts)
@@ -170,9 +255,6 @@ export default function AdminWithdrawalsPage() {
     try {
       const response = await fetch(`/api/admin/withdrawals/balance/${hostId}`, {
         cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
       })
       if (response.ok) {
         const data = await response.json()
@@ -184,224 +266,13 @@ export default function AdminWithdrawalsPage() {
     }
   }
 
-  const handleApprove = async (requestId: string) => {
-    console.log("✅ [handleApprove] Début de l'approbation pour:", requestId)
-    if (!confirm('Approuver cette demande de retrait ?')) {
-      console.log("⏸️ [handleApprove] Annulé par l'utilisateur")
-      return
-    }
-
-    try {
-      console.log('📤 [handleApprove] Envoi de la requête PUT...')
-      const response = await fetch(`/api/admin/withdrawals/${requestId}/approve`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ adminNotes: 'Approuvé' }),
-      })
-
-      console.log('📥 [handleApprove] Réponse reçue, status:', response.status)
-
-      if (response.ok) {
-        console.log('✅ [handleApprove] Approbation réussie')
-        toast.success('Demande approuvée')
-        console.log('🔄 [handleApprove] Appel de fetchRequests()...')
-        await fetchRequests()
-        console.log('✅ [handleApprove] fetchRequests() terminé')
-      } else {
-        const error = await response.json()
-        console.error('❌ [handleApprove] Erreur:', error)
-        toast.error(error.error || "Erreur lors de l'approbation")
-      }
-    } catch (error) {
-      console.error('❌ [handleApprove] Exception:', error)
-      toast.error("Erreur lors de l'approbation")
-    }
-  }
-
-  const handleReject = async (requestId: string) => {
-    console.log('❌ [handleReject] Début du rejet pour:', requestId)
-    const reason = prompt('Raison du refus :')
-    if (!reason) {
-      console.log("⏸️ [handleReject] Annulé par l'utilisateur")
-      return
-    }
-
-    try {
-      console.log('📤 [handleReject] Envoi de la requête PUT...')
-      const response = await fetch(`/api/admin/withdrawals/${requestId}/reject`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ rejectionReason: reason }),
-      })
-
-      console.log('📥 [handleReject] Réponse reçue, status:', response.status)
-
-      if (response.ok) {
-        console.log('✅ [handleReject] Rejet réussi')
-        toast.success('Demande rejetée')
-        console.log('🔄 [handleReject] Appel de fetchRequests()...')
-        await fetchRequests()
-        console.log('✅ [handleReject] fetchRequests() terminé')
-      } else {
-        const error = await response.json()
-        console.error('❌ [handleReject] Erreur:', error)
-        toast.error(error.error || 'Erreur lors du refus')
-      }
-    } catch (error) {
-      console.error('❌ [handleReject] Exception:', error)
-      toast.error('Erreur lors du refus')
-    }
-  }
-
-  const handleMarkPaid = async (requestId: string) => {
-    console.log('💰 [handleMarkPaid] Début du marquage comme payé pour:', requestId)
-    if (!confirm('Marquer cette demande comme payée ?')) {
-      console.log("⏸️ [handleMarkPaid] Annulé par l'utilisateur")
-      return
-    }
-
-    try {
-      console.log('📤 [handleMarkPaid] Envoi de la requête PUT...')
-      const response = await fetch(`/api/admin/withdrawals/${requestId}/mark-paid`, {
-        method: 'PUT',
-      })
-
-      console.log('📥 [handleMarkPaid] Réponse reçue, status:', response.status)
-
-      if (response.ok) {
-        console.log('✅ [handleMarkPaid] Marquage réussi')
-        toast.success('Demande marquée comme payée')
-        console.log('🔄 [handleMarkPaid] Appel de fetchRequests()...')
-        await fetchRequests()
-        console.log('✅ [handleMarkPaid] fetchRequests() terminé')
-      } else {
-        const error = await response.json()
-        console.error('❌ [handleMarkPaid] Erreur:', error)
-        toast.error(error.error || 'Erreur')
-      }
-    } catch (error) {
-      console.error('❌ [handleMarkPaid] Exception:', error)
-      toast.error('Erreur')
-    }
-  }
-
-  const handleValidateAccount = async (accountId: string) => {
-    console.log('🏦 [handleValidateAccount] Début de la validation pour:', accountId)
-    if (!confirm('Valider ce compte de paiement ?')) {
-      console.log("⏸️ [handleValidateAccount] Annulé par l'utilisateur")
-      return
-    }
-
-    try {
-      console.log('📤 [handleValidateAccount] Envoi de la requête PUT...')
-      const response = await fetch(
-        `/api/admin/withdrawals/payment-accounts/${accountId}/validate`,
-        {
-          method: 'PUT',
-        }
-      )
-
-      console.log('📥 [handleValidateAccount] Réponse reçue, status:', response.status)
-
-      if (response.ok) {
-        console.log('✅ [handleValidateAccount] Validation réussie')
-        toast.success('Compte validé')
-        console.log('🔄 [handleValidateAccount] Appel de fetchRequests()...')
-        await fetchRequests()
-        console.log('✅ [handleValidateAccount] fetchRequests() terminé')
-      } else {
-        const error = await response.json()
-        console.error('❌ [handleValidateAccount] Erreur:', error)
-        toast.error(error.error || 'Erreur')
-      }
-    } catch (error) {
-      console.error('❌ [handleValidateAccount] Exception:', error)
-      toast.error('Erreur')
-    }
-  }
-
-  const handleCreateWithdrawal = async () => {
-    console.log('➕ [handleCreateWithdrawal] Début de la création de demande')
-    console.log('👤 [handleCreateWithdrawal] Hôte sélectionné:', selectedHost)
-    console.log('💵 [handleCreateWithdrawal] Montant:', withdrawalForm.amount)
-
-    if (!selectedHost) {
-      console.log("❌ [handleCreateWithdrawal] Pas d'hôte sélectionné")
-      toast.error('Veuillez sélectionner un hôte')
-      return
-    }
-
-    if (!withdrawalForm.amount || parseFloat(withdrawalForm.amount) <= 0) {
-      console.log('❌ [handleCreateWithdrawal] Montant invalide')
-      toast.error('Veuillez saisir un montant valide')
-      return
-    }
-
-    if (!hostBalance || parseFloat(withdrawalForm.amount) > hostBalance.availableBalance) {
-      console.log('❌ [handleCreateWithdrawal] Montant dépasse le solde disponible')
-      toast.error('Le montant dépasse le solde disponible')
-      return
-    }
-
-    try {
-      console.log('📤 [handleCreateWithdrawal] Envoi de la requête POST...')
-      const response = await fetch('/api/admin/withdrawals/create-for-host', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          hostId: selectedHost,
-          amount: parseFloat(withdrawalForm.amount),
-          withdrawalType: withdrawalForm.withdrawalType,
-          paymentMethod: withdrawalForm.paymentMethod,
-          paymentDetails: paymentDetails,
-          notes: withdrawalForm.notes || `Demande créée par ${session?.user?.name || 'admin'}`,
-        }),
-      })
-
-      console.log('📥 [handleCreateWithdrawal] Réponse reçue, status:', response.status)
-
-      if (response.ok) {
-        console.log('✅ [handleCreateWithdrawal] Création réussie')
-        toast.success('Demande de retrait créée avec succès')
-        setShowCreateModal(false)
-        setWithdrawalForm({
-          amount: '',
-          withdrawalType: 'PARTIAL_50',
-          paymentMethod: 'SEPA_VIREMENT',
-          notes: '',
-        })
-        setPaymentDetails({
-          accountHolderName: '',
-          iban: '',
-          cardNumber: '',
-          cardEmail: '',
-          mobileNumber: '',
-          paypalUsername: '',
-          paypalEmail: '',
-          paypalPhone: '',
-          paypalIban: '',
-          moneygramFullName: '',
-          moneygramPhone: '',
-        })
-        console.log('🔄 [handleCreateWithdrawal] Appel de fetchRequests()...')
-        await fetchRequests()
-        console.log('🔄 [handleCreateWithdrawal] Appel de fetchHostBalance()...')
-        await fetchHostBalance(selectedHost)
-        console.log('✅ [handleCreateWithdrawal] Mise à jour terminée')
-      } else {
-        const error = await response.json()
-        console.error('❌ [handleCreateWithdrawal] Erreur:', error)
-        toast.error(error.error || 'Erreur lors de la création')
-      }
-    } catch (error) {
-      console.error('❌ [handleCreateWithdrawal] Exception:', error)
-      toast.error('Erreur lors de la création')
-    }
-  }
-
   useEffect(() => {
-    fetchRequests()
-  }, [filter])
+    if (canManage) {
+      fetchRequests()
+      fetchHosts()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canManage, statusFilter])
 
   useEffect(() => {
     if (selectedHost) {
@@ -411,678 +282,720 @@ export default function AdminWithdrawalsPage() {
     }
   }, [selectedHost])
 
-  const getStatusBadge = (status: WithdrawalStatus) => {
-    const styles = {
-      PENDING: 'bg-yellow-100 text-yellow-800',
-      ACCOUNT_VALIDATION: 'bg-orange-100 text-orange-800',
-      APPROVED: 'bg-blue-100 text-blue-800',
-      PAID: 'bg-green-100 text-green-800',
-      REJECTED: 'bg-red-100 text-red-800',
-      CANCELLED: 'bg-gray-100 text-gray-800',
+  const handleApprove = async (requestId: string) => {
+    if (!confirm('Approuver cette demande de retrait ?')) return
+    try {
+      const response = await fetch(`/api/admin/withdrawals/${requestId}/approve`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ adminNotes: 'Approuvé' }),
+      })
+      if (response.ok) {
+        toast.success('Demande approuvée')
+        await fetchRequests()
+      } else {
+        const error = await response.json()
+        toast.error(error.error || "Erreur lors de l'approbation")
+      }
+    } catch {
+      toast.error("Erreur lors de l'approbation")
     }
+  }
 
-    const labels = {
-      PENDING: 'En attente',
-      ACCOUNT_VALIDATION: 'Validation compte',
-      APPROVED: 'Approuvée',
-      PAID: 'Payée',
-      REJECTED: 'Rejetée',
-      CANCELLED: 'Annulée',
+  const handleReject = async (requestId: string) => {
+    const reason = prompt('Raison du refus :')
+    if (!reason) return
+    try {
+      const response = await fetch(`/api/admin/withdrawals/${requestId}/reject`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rejectionReason: reason }),
+      })
+      if (response.ok) {
+        toast.success('Demande rejetée')
+        await fetchRequests()
+      } else {
+        const error = await response.json()
+        toast.error(error.error || 'Erreur lors du refus')
+      }
+    } catch {
+      toast.error('Erreur lors du refus')
     }
+  }
 
-    return (
-      <span className={`px-2 py-1 text-xs font-semibold rounded-full ${styles[status]}`}>
-        {labels[status]}
-      </span>
+  const handleMarkPaid = async (requestId: string) => {
+    if (!confirm('Marquer cette demande comme payée ?')) return
+    try {
+      const response = await fetch(`/api/admin/withdrawals/${requestId}/mark-paid`, {
+        method: 'PUT',
+      })
+      if (response.ok) {
+        toast.success('Demande marquée comme payée')
+        await fetchRequests()
+      } else {
+        const error = await response.json()
+        toast.error(error.error || 'Erreur')
+      }
+    } catch {
+      toast.error('Erreur')
+    }
+  }
+
+  const handleValidateAccount = async (accountId: string) => {
+    if (!confirm('Valider ce compte de paiement ?')) return
+    try {
+      const response = await fetch(
+        `/api/admin/withdrawals/payment-accounts/${accountId}/validate`,
+        { method: 'PUT' }
+      )
+      if (response.ok) {
+        toast.success('Compte validé')
+        await fetchRequests()
+      } else {
+        const error = await response.json()
+        toast.error(error.error || 'Erreur')
+      }
+    } catch {
+      toast.error('Erreur')
+    }
+  }
+
+  const openCreateModal = () => {
+    setSelectedHost('')
+    setHostBalance(null)
+    setWithdrawalForm({
+      amount: '',
+      withdrawalType: 'PARTIAL_50',
+      paymentMethod: 'SEPA_VIREMENT',
+      notes: '',
+    })
+    setPaymentDetails({
+      accountHolderName: '',
+      iban: '',
+      cardNumber: '',
+      cardEmail: '',
+      mobileNumber: '',
+      paypalUsername: '',
+      paypalEmail: '',
+      paypalPhone: '',
+      paypalIban: '',
+      moneygramFullName: '',
+      moneygramPhone: '',
+    })
+    setShowCreateModal(true)
+  }
+
+  const handleCreateWithdrawal = async () => {
+    if (!selectedHost) {
+      toast.error('Veuillez sélectionner un hôte')
+      return
+    }
+    if (!withdrawalForm.amount || parseFloat(withdrawalForm.amount) <= 0) {
+      toast.error('Veuillez saisir un montant valide')
+      return
+    }
+    if (!hostBalance || parseFloat(withdrawalForm.amount) > hostBalance.availableBalance) {
+      toast.error('Le montant dépasse le solde disponible')
+      return
+    }
+    setIsCreating(true)
+    try {
+      const response = await fetch('/api/admin/withdrawals/create-for-host', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          hostId: selectedHost,
+          amount: parseFloat(withdrawalForm.amount),
+          withdrawalType: withdrawalForm.withdrawalType,
+          paymentMethod: withdrawalForm.paymentMethod,
+          paymentDetails,
+          notes: withdrawalForm.notes || `Demande créée par ${session?.user?.name || 'admin'}`,
+        }),
+      })
+      if (response.ok) {
+        toast.success('Demande de retrait créée')
+        setShowCreateModal(false)
+        await fetchRequests()
+      } else {
+        const error = await response.json()
+        toast.error(error.error || 'Erreur lors de la création')
+      }
+    } catch {
+      toast.error('Erreur lors de la création')
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  // Client-side search filter on the already-filtered requests
+  const filteredRequests = useMemo(() => {
+    if (!searchValue.trim()) return requests
+    const q = searchValue.toLowerCase()
+    return requests.filter(
+      r =>
+        r.user.name?.toLowerCase().includes(q) ||
+        r.user.email.toLowerCase().includes(q) ||
+        r.id.toLowerCase().includes(q)
     )
-  }
+  }, [requests, searchValue])
 
-  const getPaymentMethodLabel = (method: PaymentMethod) => {
-    const labels = {
-      SEPA_VIREMENT: 'SEPA',
-      PRIPEO: 'Pripeo',
-      MOBILE_MONEY: 'Mobile Money',
-      PAYPAL: 'PayPal',
-      MONEYGRAM: 'MoneyGram',
-      TAPTAP: 'TapTap',
-      INTERNATIONAL: 'International',
-      OTHER: 'Autre',
+  // Stats (derived from loaded requests — this endpoint doesn't return aggregated stats)
+  const stats = useMemo(() => {
+    const byStatus: Record<string, number> = {
+      PENDING: 0,
+      ACCOUNT_VALIDATION: 0,
+      APPROVED: 0,
+      PAID: 0,
+      REJECTED: 0,
+      CANCELLED: 0,
     }
-    return labels[method] || method
-  }
+    let pendingAmount = 0
+    let paidAmount = 0
+    for (const r of requests) {
+      byStatus[r.status] = (byStatus[r.status] || 0) + 1
+      if (r.status === 'PENDING' || r.status === 'APPROVED') pendingAmount += r.amount
+      if (r.status === 'PAID') paidAmount += r.amount
+    }
+    return { byStatus, pendingAmount, paidAmount, total: requests.length }
+  }, [requests])
+
+  const columns: DataTableColumn<WithdrawalRequest>[] = [
+    {
+      key: 'host',
+      header: 'Hôte',
+      sortable: true,
+      sortAccessor: r => r.user.name || r.user.email,
+      render: r => (
+        <div className='min-w-0'>
+          <p className='truncate text-sm font-semibold text-slate-900'>
+            {r.user.name || '—'}
+          </p>
+          <p className='truncate text-xs text-slate-500'>{r.user.email}</p>
+        </div>
+      ),
+    },
+    {
+      key: 'amount',
+      header: 'Montant',
+      sortable: true,
+      sortAccessor: r => r.amount,
+      align: 'right',
+      render: r => (
+        <div className='text-right'>
+          <p className='text-sm font-bold tabular-nums text-slate-900'>
+            {formatCurrency(r.amount)}
+          </p>
+          <p className='text-[10px] uppercase tracking-wide text-slate-500'>
+            {r.withdrawalType === 'PARTIAL_50' ? 'Partiel 50%' : 'Complet 100%'}
+          </p>
+        </div>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'method',
+      header: 'Méthode',
+      render: r => (
+        <div>
+          <p className='text-sm text-slate-900'>{PAYMENT_METHOD_LABEL[r.paymentMethod]}</p>
+          {r.paymentAccount && !r.paymentAccount.isValidated && (
+            <p className='text-[10px] font-medium uppercase tracking-wide text-amber-600'>
+              Non validé
+            </p>
+          )}
+        </div>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'status',
+      header: 'Statut',
+      sortable: true,
+      sortAccessor: r => r.status,
+      render: r => <StatusPill status={r.status} />,
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'createdAt',
+      header: 'Demandé le',
+      sortable: true,
+      sortAccessor: r => new Date(r.createdAt),
+      render: r => (
+        <p className='text-xs text-slate-500'>
+          {new Date(r.createdAt).toLocaleDateString('fr-FR', {
+            day: '2-digit',
+            month: 'short',
+            year: 'numeric',
+          })}
+        </p>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+  ]
 
   if (isAuthLoading || loading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
         </div>
       </div>
     )
   }
 
-  if (!session) {
-    return null
-  }
+  if (!session) return null
 
   return (
-    <div className='min-h-screen bg-gray-50 py-8'>
-      <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
-        {/* En-tête */}
-        <div className='mb-8'>
-          <h1 className='text-3xl font-bold text-gray-900'>Gestion des retraits</h1>
-          <p className='mt-2 text-sm text-gray-600'>
-            Gérer les demandes de retrait pour tous les hôtes
-          </p>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <PageHeader
+          backHref='/admin'
+          backLabel='Retour au panel admin'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title='Gestion des retraits'
+          subtitle='Approuvez, rejetez et suivez les demandes de retrait des hôtes. Vous pouvez aussi créer une demande au nom d’un hôte.'
+          actions={
+            <Button
+              onClick={openCreateModal}
+              className='gap-2 bg-gradient-to-r from-blue-600 to-indigo-600 text-white shadow-sm hover:from-blue-700 hover:to-indigo-700'
+            >
+              <UserPlus className='h-4 w-4' />
+              Nouvelle demande
+            </Button>
+          }
+        />
+
+        {/* KPI row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Total demandes'
+            value={stats.total}
+            hint='toutes statuts confondus'
+            icon={Wallet}
+            tone='blue'
+          />
+          <KpiCard
+            label='En attente'
+            value={stats.byStatus.PENDING ?? 0}
+            hint='à traiter en priorité'
+            icon={Clock}
+            tone='amber'
+          />
+          <KpiCard
+            label='Montant en attente'
+            value={formatCurrency(stats.pendingAmount)}
+            hint='pending + approuvées'
+            icon={TrendingUp}
+            tone='purple'
+          />
+          <KpiCard
+            label='Montant payé'
+            value={formatCurrency(stats.paidAmount)}
+            hint='total déjà versé'
+            icon={Banknote}
+            tone='emerald'
+          />
         </div>
 
-        {/* Sélecteur d'hôte et création de demande */}
-        <div className='bg-white shadow rounded-lg p-6 mb-8'>
-          <h2 className='text-lg font-semibold mb-4'>Créer une demande pour un hôte</h2>
-          <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
-            <div>
-              <label className='block text-sm font-medium text-gray-700 mb-2'>
-                Sélectionner un hôte
-              </label>
-              <select
-                value={selectedHost}
-                onChange={e => setSelectedHost(e.target.value)}
-                className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-              >
-                <option value=''>-- Choisir un hôte --</option>
-                {hosts.map(host => (
-                  <option key={host.id} value={host.id}>
-                    {host.name || host.email} ({host.email})
-                  </option>
-                ))}
-              </select>
-            </div>
+        {/* Secondary metrics */}
+        <div className='grid gap-3 sm:grid-cols-4'>
+          <KpiMetric
+            label='validation compte'
+            value={stats.byStatus.ACCOUNT_VALIDATION ?? 0}
+            icon={ShieldAlert}
+            tone='slate'
+          />
+          <KpiMetric
+            label='approuvées'
+            value={stats.byStatus.APPROVED ?? 0}
+            icon={CheckCircle2}
+            tone='blue'
+          />
+          <KpiMetric
+            label='payées'
+            value={stats.byStatus.PAID ?? 0}
+            icon={Banknote}
+            tone='emerald'
+          />
+          <KpiMetric
+            label='rejetées'
+            value={stats.byStatus.REJECTED ?? 0}
+            icon={XCircle}
+            tone='red'
+          />
+        </div>
 
-            {selectedHost && hostBalance && (
-              <div className='bg-blue-50 border border-blue-200 rounded-lg p-4'>
-                <p className='text-sm font-medium text-blue-900 mb-2'>Solde de l&apos;hôte</p>
-                <div className='grid grid-cols-3 gap-2 text-sm'>
-                  <div>
-                    <p className='text-blue-600'>Total gagné</p>
-                    <p className='font-bold text-blue-900'>{hostBalance.totalEarned.toFixed(2)}€</p>
-                  </div>
-                  <div>
-                    <p className='text-blue-600'>Retiré</p>
-                    <p className='font-bold text-blue-900'>
-                      {hostBalance.totalWithdrawn.toFixed(2)}€
-                    </p>
-                  </div>
-                  <div>
-                    <p className='text-blue-600'>Disponible</p>
-                    <p className='font-bold text-green-600'>
-                      {hostBalance.availableBalance.toFixed(2)}€
-                    </p>
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-
-          {selectedHost && hostBalance && (
-            <div className='mt-4'>
+        {/* Status filter chips */}
+        <div className='flex flex-wrap items-center gap-2'>
+          {STATUS_FILTERS.map(f => {
+            const Icon = f.icon
+            const active = statusFilter === f.value
+            return (
               <button
-                onClick={() => setShowCreateModal(true)}
-                className='px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700'
+                key={f.value}
+                onClick={() => setStatusFilter(f.value)}
+                className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+                  active
+                    ? 'bg-slate-900 text-white shadow-sm'
+                    : 'bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50'
+                }`}
               >
-                Créer une demande de retrait pour cet hôte
+                <Icon className='h-3 w-3' />
+                {f.label}
               </button>
-            </div>
-          )}
+            )
+          })}
         </div>
 
-        {/* Filtres */}
-        <div className='bg-white shadow rounded-lg p-4 mb-6'>
-          <div className='flex gap-2 overflow-x-auto'>
-            <button
-              onClick={() => setFilter('ALL')}
-              className={`px-4 py-2 rounded-md text-sm font-medium ${
-                filter === 'ALL'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              Toutes ({requests.length})
-            </button>
-            <button
-              onClick={() => setFilter(WithdrawalStatus.PENDING)}
-              className={`px-4 py-2 rounded-md text-sm font-medium ${
-                filter === WithdrawalStatus.PENDING
-                  ? 'bg-yellow-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              En attente
-            </button>
-            <button
-              onClick={() => setFilter(WithdrawalStatus.ACCOUNT_VALIDATION)}
-              className={`px-4 py-2 rounded-md text-sm font-medium ${
-                filter === WithdrawalStatus.ACCOUNT_VALIDATION
-                  ? 'bg-orange-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              Validation compte
-            </button>
-            <button
-              onClick={() => setFilter(WithdrawalStatus.APPROVED)}
-              className={`px-4 py-2 rounded-md text-sm font-medium ${
-                filter === WithdrawalStatus.APPROVED
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              Approuvées
-            </button>
-            <button
-              onClick={() => setFilter(WithdrawalStatus.PAID)}
-              className={`px-4 py-2 rounded-md text-sm font-medium ${
-                filter === WithdrawalStatus.PAID
-                  ? 'bg-green-600 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-              }`}
-            >
-              Payées
-            </button>
-          </div>
-        </div>
+        {/* Search */}
+        <FilterBar
+          searchValue={searchValue}
+          onSearchChange={setSearchValue}
+          searchPlaceholder='Rechercher par nom d’hôte ou email…'
+        />
 
-        {/* Liste des demandes */}
-        <div className='bg-white shadow rounded-lg overflow-hidden'>
-          <div className='overflow-x-auto'>
-            <table className='min-w-full divide-y divide-gray-200'>
-              <thead className='bg-gray-50'>
-                <tr>
-                  <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase'>
-                    Hôte
-                  </th>
-                  <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase'>
-                    Montant
-                  </th>
-                  <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase'>
-                    Méthode
-                  </th>
-                  <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase'>
-                    Statut
-                  </th>
-                  <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase'>
-                    Date
-                  </th>
-                  <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase'>
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody className='bg-white divide-y divide-gray-200'>
-                {requests.length === 0 ? (
-                  <tr>
-                    <td colSpan={6} className='px-6 py-8 text-center text-gray-500'>
-                      Aucune demande trouvée
-                    </td>
-                  </tr>
-                ) : (
-                  requests.map(request => (
-                    <tr key={request.id} className='hover:bg-gray-50'>
-                      <td className='px-6 py-4'>
-                        <div>
-                          <p className='text-sm font-medium text-gray-900'>{request.user.name}</p>
-                          <p className='text-sm text-gray-500'>{request.user.email}</p>
-                        </div>
-                      </td>
-                      <td className='px-6 py-4 whitespace-nowrap'>
-                        <p className='text-sm font-bold text-gray-900'>
-                          {request.amount.toFixed(2)}€
-                        </p>
-                      </td>
-                      <td className='px-6 py-4 whitespace-nowrap'>
-                        <div>
-                          <p className='text-sm text-gray-900'>
-                            {getPaymentMethodLabel(request.paymentMethod)}
-                          </p>
-                          {!request.paymentAccount?.isValidated && (
-                            <p className='text-xs text-orange-600'>Non validé</p>
-                          )}
-                        </div>
-                      </td>
-                      <td className='px-6 py-4 whitespace-nowrap'>
-                        {getStatusBadge(request.status)}
-                      </td>
-                      <td className='px-6 py-4 whitespace-nowrap text-sm text-gray-500'>
-                        {new Date(request.createdAt).toLocaleDateString('fr-FR')}
-                      </td>
-                      <td className='px-6 py-4 whitespace-nowrap text-sm'>
-                        <div className='flex gap-2'>
-                          {request.status === WithdrawalStatus.ACCOUNT_VALIDATION &&
-                            request.paymentAccount && (
-                              <button
-                                onClick={() => handleValidateAccount(request.paymentAccount!.id)}
-                                className='text-orange-600 hover:text-orange-900'
-                              >
-                                Valider compte
-                              </button>
-                            )}
-                          {request.status === WithdrawalStatus.PENDING && (
-                            <>
-                              <button
-                                onClick={() => handleApprove(request.id)}
-                                className='text-green-600 hover:text-green-900'
-                              >
-                                Approuver
-                              </button>
-                              <button
-                                onClick={() => handleReject(request.id)}
-                                className='text-red-600 hover:text-red-900'
-                              >
-                                Rejeter
-                              </button>
-                            </>
-                          )}
-                          {request.status === WithdrawalStatus.APPROVED && (
-                            <button
-                              onClick={() => handleMarkPaid(request.id)}
-                              className='text-blue-600 hover:text-blue-900'
-                            >
-                              Marquer payé
-                            </button>
-                          )}
-                        </div>
-                      </td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-        </div>
+        {/* Data table */}
+        <DataTable<WithdrawalRequest>
+          columns={columns}
+          rows={filteredRequests}
+          getRowId={r => r.id}
+          loading={loading}
+          sort={sort}
+          onSortChange={setSort}
+          rowActions={request => {
+            const canValidateAccount =
+              request.status === 'ACCOUNT_VALIDATION' && request.paymentAccount
+            const canApproveReject = request.status === 'PENDING'
+            const canMarkPaid = request.status === 'APPROVED'
 
-        {/* Modal de création de demande */}
-        {showCreateModal && (
-          <div className='fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4'>
-            <div className='bg-white rounded-lg shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto'>
-              <div className='p-6'>
-                <div className='flex justify-between items-center mb-6'>
-                  <h2 className='text-2xl font-bold text-gray-900'>Créer une demande de retrait</h2>
-                  <button
-                    onClick={() => setShowCreateModal(false)}
-                    className='text-gray-400 hover:text-gray-600'
+            if (!canValidateAccount && !canApproveReject && !canMarkPaid) {
+              return <span className='text-xs text-slate-300'>—</span>
+            }
+
+            return (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant='ghost'
+                    size='sm'
+                    className='h-8 w-8 p-0'
+                    aria-label='Actions retrait'
                   >
-                    <svg className='w-6 h-6' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
-                      <path
-                        strokeLinecap='round'
-                        strokeLinejoin='round'
-                        strokeWidth={2}
-                        d='M6 18L18 6M6 6l12 12'
-                      />
-                    </svg>
-                  </button>
-                </div>
-
-                {/* Informations hôte */}
-                <div className='bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6'>
-                  <p className='text-sm font-medium text-blue-900 mb-2'>
-                    Hôte :{' '}
-                    {hosts.find(h => h.id === selectedHost)?.name ||
-                      hosts.find(h => h.id === selectedHost)?.email}
-                  </p>
-                  {hostBalance && (
-                    <div className='grid grid-cols-3 gap-4 text-sm'>
-                      <div>
-                        <p className='text-blue-600'>Total gagné</p>
-                        <p className='font-bold text-blue-900'>
-                          {hostBalance.totalEarned.toFixed(2)}€
-                        </p>
-                      </div>
-                      <div>
-                        <p className='text-blue-600'>Déjà retiré</p>
-                        <p className='font-bold text-blue-900'>
-                          {hostBalance.totalWithdrawn.toFixed(2)}€
-                        </p>
-                      </div>
-                      <div>
-                        <p className='text-green-600'>Disponible</p>
-                        <p className='font-bold text-green-900'>
-                          {hostBalance.availableBalance.toFixed(2)}€
-                        </p>
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                {/* Formulaire */}
-                <div className='space-y-4'>
-                  {/* Montant */}
-                  <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      Montant à retirer (€) *
-                    </label>
-                    <input
-                      type='number'
-                      step='0.01'
-                      min='0'
-                      max={hostBalance?.availableBalance || 0}
-                      value={withdrawalForm.amount}
-                      onChange={e =>
-                        setWithdrawalForm({ ...withdrawalForm, amount: e.target.value })
-                      }
-                      className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                      placeholder='0.00'
-                    />
-                    {hostBalance && (
-                      <p className='text-xs text-gray-500 mt-1'>
-                        Maximum disponible : {hostBalance.availableBalance.toFixed(2)}€
-                      </p>
-                    )}
-                  </div>
-
-                  {/* Type de retrait */}
-                  <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      Type de retrait *
-                    </label>
-                    <select
-                      value={withdrawalForm.withdrawalType}
-                      onChange={e =>
-                        setWithdrawalForm({
-                          ...withdrawalForm,
-                          withdrawalType: e.target.value as 'PARTIAL_50' | 'FULL_100',
-                        })
-                      }
-                      className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
+                    <MoreHorizontal className='h-4 w-4' />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end' className='w-52'>
+                  <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {canValidateAccount && (
+                    <DropdownMenuItem
+                      onClick={() => handleValidateAccount(request.paymentAccount!.id)}
+                      className='flex items-center gap-2 text-orange-700'
                     >
-                      <option value='PARTIAL_50'>Partiel 50% (selon contrat)</option>
-                      <option value='FULL_100'>Complet 100%</option>
-                    </select>
-                  </div>
-
-                  {/* Méthode de paiement */}
-                  <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      Méthode de paiement *
-                    </label>
-                    <select
-                      value={withdrawalForm.paymentMethod}
-                      onChange={e =>
-                        setWithdrawalForm({
-                          ...withdrawalForm,
-                          paymentMethod: e.target.value as PaymentMethod,
-                        })
-                      }
-                      className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
+                      <ShieldCheck className='h-4 w-4' />
+                      Valider le compte
+                    </DropdownMenuItem>
+                  )}
+                  {canApproveReject && (
+                    <>
+                      <DropdownMenuItem
+                        onClick={() => handleApprove(request.id)}
+                        className='flex items-center gap-2 text-emerald-700'
+                      >
+                        <CheckCircle2 className='h-4 w-4' />
+                        Approuver
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => handleReject(request.id)}
+                        className='flex items-center gap-2 text-red-600 focus:text-red-600'
+                      >
+                        <XCircle className='h-4 w-4' />
+                        Rejeter
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                  {canMarkPaid && (
+                    <DropdownMenuItem
+                      onClick={() => handleMarkPaid(request.id)}
+                      className='flex items-center gap-2 text-blue-700'
                     >
-                      <option value='SEPA_VIREMENT'>SEPA</option>
-                      <option value='PRIPEO'>Pripeo (+1.50€)</option>
-                      <option value='MOBILE_MONEY'>Mobile Money</option>
-                      <option value='PAYPAL'>PayPal</option>
-                      <option value='MONEYGRAM'>MoneyGram</option>
-                    </select>
-                    <p className='text-xs text-gray-500 mt-1'>
-                      Note : Le compte de paiement de l&apos;hôte sera utilisé s&apos;il existe, sinon un
-                      nouveau sera créé.
-                    </p>
-                  </div>
-
-                  {/* Champs conditionnels selon la méthode de paiement */}
-                  {withdrawalForm.paymentMethod === 'SEPA_VIREMENT' && (
-                    <>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Nom du titulaire *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.accountHolderName}
-                          onChange={e =>
-                            setPaymentDetails({
-                              ...paymentDetails,
-                              accountHolderName: e.target.value,
-                            })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='Jean Dupont'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          IBAN *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.iban}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, iban: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='FR76 XXXX XXXX XXXX XXXX XXXX XXX'
-                        />
-                      </div>
-                    </>
+                      <Banknote className='h-4 w-4' />
+                      Marquer comme payée
+                    </DropdownMenuItem>
                   )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )
+          }}
+          emptyState={{
+            icon: Wallet,
+            title: 'Aucune demande de retrait',
+            subtitle:
+              searchValue || statusFilter !== 'ALL'
+                ? 'Essayez d’ajuster vos filtres.'
+                : 'Aucun hôte n’a encore demandé de retrait. Vous pouvez en créer une depuis le bouton en haut.',
+          }}
+        />
 
-                  {withdrawalForm.paymentMethod === 'PRIPEO' && (
-                    <>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Nom du titulaire *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.accountHolderName}
-                          onChange={e =>
-                            setPaymentDetails({
-                              ...paymentDetails,
-                              accountHolderName: e.target.value,
-                            })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='Jean Dupont'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Numéro de carte Pripeo *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.cardNumber}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, cardNumber: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='1234 5678 9012 3456'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Email *
-                        </label>
-                        <input
-                          type='email'
-                          value={paymentDetails.cardEmail}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, cardEmail: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='email@example.com'
-                        />
-                      </div>
-                    </>
-                  )}
-
-                  {withdrawalForm.paymentMethod === 'MOBILE_MONEY' && (
-                    <>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Nom du titulaire *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.accountHolderName}
-                          onChange={e =>
-                            setPaymentDetails({
-                              ...paymentDetails,
-                              accountHolderName: e.target.value,
-                            })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='Jean Dupont'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Numéro de téléphone *
-                        </label>
-                        <input
-                          type='tel'
-                          value={paymentDetails.mobileNumber}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, mobileNumber: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='+261 XX XX XXX XX'
-                        />
-                      </div>
-                    </>
-                  )}
-
-                  {withdrawalForm.paymentMethod === 'PAYPAL' && (
-                    <>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Nom d&apos;utilisateur PayPal *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.paypalUsername}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, paypalUsername: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='@username'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Email PayPal *
-                        </label>
-                        <input
-                          type='email'
-                          value={paymentDetails.paypalEmail}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, paypalEmail: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='email@example.com'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Téléphone
-                        </label>
-                        <input
-                          type='tel'
-                          value={paymentDetails.paypalPhone}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, paypalPhone: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='+33 X XX XX XX XX'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          IBAN (optionnel)
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.paypalIban}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, paypalIban: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='FR76 XXXX XXXX XXXX XXXX XXXX XXX'
-                        />
-                      </div>
-                    </>
-                  )}
-
-                  {withdrawalForm.paymentMethod === 'MONEYGRAM' && (
-                    <>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Nom complet *
-                        </label>
-                        <input
-                          type='text'
-                          value={paymentDetails.moneygramFullName}
-                          onChange={e =>
-                            setPaymentDetails({
-                              ...paymentDetails,
-                              moneygramFullName: e.target.value,
-                            })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='Jean Dupont'
-                        />
-                      </div>
-                      <div>
-                        <label className='block text-sm font-medium text-gray-700 mb-2'>
-                          Numéro de téléphone *
-                        </label>
-                        <input
-                          type='tel'
-                          value={paymentDetails.moneygramPhone}
-                          onChange={e =>
-                            setPaymentDetails({ ...paymentDetails, moneygramPhone: e.target.value })
-                          }
-                          className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                          placeholder='+261 XX XX XXX XX'
-                        />
-                      </div>
-                    </>
-                  )}
-
-                  {/* Notes */}
-                  <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>
-                      Notes (optionnel)
-                    </label>
-                    <textarea
-                      value={withdrawalForm.notes}
-                      onChange={e =>
-                        setWithdrawalForm({ ...withdrawalForm, notes: e.target.value })
-                      }
-                      className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
-                      rows={3}
-                      placeholder='Notes additionnelles...'
-                    />
-                  </div>
+        {/* Create withdrawal dialog */}
+        <Dialog open={showCreateModal} onOpenChange={setShowCreateModal}>
+          <DialogContent className='max-h-[90vh] overflow-y-auto sm:max-w-2xl'>
+            <DialogHeader>
+              <div className='flex items-start gap-3'>
+                <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 ring-1 ring-blue-100'>
+                  <UserPlus className='h-5 w-5' />
                 </div>
-
-                {/* Actions */}
-                <div className='flex justify-end gap-3 mt-6'>
-                  <button
-                    onClick={() => setShowCreateModal(false)}
-                    className='px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50'
-                  >
-                    Annuler
-                  </button>
-                  <button
-                    onClick={handleCreateWithdrawal}
-                    className='px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700'
-                  >
-                    Créer la demande
-                  </button>
+                <div className='space-y-1'>
+                  <DialogTitle className='text-lg'>Créer une demande de retrait</DialogTitle>
+                  <DialogDescription className='text-sm text-slate-600'>
+                    Créez une demande au nom d’un hôte. La demande sera automatiquement marquée
+                    comme approuvée.
+                  </DialogDescription>
                 </div>
               </div>
+            </DialogHeader>
+
+            <div className='space-y-5 py-2'>
+              {/* Host selector */}
+              <div className='space-y-2'>
+                <Label htmlFor='host'>Hôte *</Label>
+                <Select value={selectedHost} onValueChange={setSelectedHost}>
+                  <SelectTrigger id='host'>
+                    <SelectValue placeholder='Choisir un hôte…' />
+                  </SelectTrigger>
+                  <SelectContent className='max-h-72'>
+                    {hosts.map(host => (
+                      <SelectItem key={host.id} value={host.id}>
+                        <span className='flex flex-col'>
+                          <span className='font-medium'>{host.name || host.email}</span>
+                          <span className='text-xs text-slate-500'>{host.email}</span>
+                        </span>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Host balance info */}
+              {hostBalance && (
+                <div className='rounded-xl border border-blue-200 bg-blue-50/60 p-4'>
+                  <p className='mb-2 text-xs font-semibold uppercase tracking-wide text-blue-700'>
+                    Solde de l’hôte
+                  </p>
+                  <div className='grid grid-cols-3 gap-3 text-sm'>
+                    <div>
+                      <p className='text-xs text-slate-600'>Total gagné</p>
+                      <p className='font-bold text-slate-900 tabular-nums'>
+                        {formatCurrency(hostBalance.totalEarned)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className='text-xs text-slate-600'>Déjà retiré</p>
+                      <p className='font-bold text-slate-900 tabular-nums'>
+                        {formatCurrency(hostBalance.totalWithdrawn)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className='text-xs text-slate-600'>Disponible</p>
+                      <p className='font-bold text-emerald-600 tabular-nums'>
+                        {formatCurrency(hostBalance.availableBalance)}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Amount + type */}
+              <div className='grid gap-4 sm:grid-cols-2'>
+                <div className='space-y-2'>
+                  <Label htmlFor='amount'>Montant (€) *</Label>
+                  <Input
+                    id='amount'
+                    type='number'
+                    step='0.01'
+                    min='0'
+                    max={hostBalance?.availableBalance || 0}
+                    value={withdrawalForm.amount}
+                    onChange={e =>
+                      setWithdrawalForm({ ...withdrawalForm, amount: e.target.value })
+                    }
+                    placeholder='0.00'
+                  />
+                  {hostBalance && (
+                    <p className='text-xs text-slate-500'>
+                      Max {formatCurrency(hostBalance.availableBalance)}
+                    </p>
+                  )}
+                </div>
+                <div className='space-y-2'>
+                  <Label htmlFor='type'>Type</Label>
+                  <Select
+                    value={withdrawalForm.withdrawalType}
+                    onValueChange={value =>
+                      setWithdrawalForm({
+                        ...withdrawalForm,
+                        withdrawalType: value as 'PARTIAL_50' | 'FULL_100',
+                      })
+                    }
+                  >
+                    <SelectTrigger id='type'>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value='PARTIAL_50'>Partiel 50% (selon contrat)</SelectItem>
+                      <SelectItem value='FULL_100'>Complet 100%</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              {/* Payment method */}
+              <div className='space-y-2'>
+                <Label htmlFor='paymentMethod'>Méthode de paiement *</Label>
+                <Select
+                  value={withdrawalForm.paymentMethod}
+                  onValueChange={value =>
+                    setWithdrawalForm({
+                      ...withdrawalForm,
+                      paymentMethod: value as PaymentMethod,
+                    })
+                  }
+                >
+                  <SelectTrigger id='paymentMethod'>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(Object.keys(PAYMENT_METHOD_LABEL) as PaymentMethod[]).map(method => (
+                      <SelectItem key={method} value={method}>
+                        {PAYMENT_METHOD_LABEL[method]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Payment details — simplified: title holder + IBAN for SEPA, otherwise common fields */}
+              {withdrawalForm.paymentMethod === 'SEPA_VIREMENT' && (
+                <div className='grid gap-4 sm:grid-cols-2'>
+                  <div className='space-y-2'>
+                    <Label htmlFor='holder'>Titulaire du compte</Label>
+                    <Input
+                      id='holder'
+                      value={paymentDetails.accountHolderName}
+                      onChange={e =>
+                        setPaymentDetails({
+                          ...paymentDetails,
+                          accountHolderName: e.target.value,
+                        })
+                      }
+                      placeholder='Jean Dupont'
+                    />
+                  </div>
+                  <div className='space-y-2'>
+                    <Label htmlFor='iban'>IBAN</Label>
+                    <Input
+                      id='iban'
+                      value={paymentDetails.iban}
+                      onChange={e =>
+                        setPaymentDetails({ ...paymentDetails, iban: e.target.value })
+                      }
+                      placeholder='FR76…'
+                    />
+                  </div>
+                </div>
+              )}
+
+              {(withdrawalForm.paymentMethod === 'PAYPAL' ||
+                withdrawalForm.paymentMethod === 'MOBILE_MONEY' ||
+                withdrawalForm.paymentMethod === 'MONEYGRAM') && (
+                <div className='space-y-2'>
+                  <Label htmlFor='contact'>Email / numéro de contact</Label>
+                  <Input
+                    id='contact'
+                    value={paymentDetails.paypalEmail || paymentDetails.mobileNumber}
+                    onChange={e =>
+                      setPaymentDetails({
+                        ...paymentDetails,
+                        paypalEmail:
+                          withdrawalForm.paymentMethod === 'PAYPAL'
+                            ? e.target.value
+                            : paymentDetails.paypalEmail,
+                        mobileNumber:
+                          withdrawalForm.paymentMethod !== 'PAYPAL'
+                            ? e.target.value
+                            : paymentDetails.mobileNumber,
+                      })
+                    }
+                    placeholder={
+                      withdrawalForm.paymentMethod === 'PAYPAL'
+                        ? 'email@paypal.com'
+                        : '+261 xx xx xx xx'
+                    }
+                  />
+                </div>
+              )}
+
+              {/* Notes */}
+              <div className='space-y-2'>
+                <Label htmlFor='notes'>Notes (optionnel)</Label>
+                <Textarea
+                  id='notes'
+                  rows={3}
+                  value={withdrawalForm.notes}
+                  onChange={e => setWithdrawalForm({ ...withdrawalForm, notes: e.target.value })}
+                  placeholder='Notes internes visibles uniquement par les admins…'
+                />
+              </div>
             </div>
-          </div>
-        )}
-      </div>
+
+            <DialogFooter className='gap-2'>
+              <Button
+                variant='outline'
+                onClick={() => setShowCreateModal(false)}
+                disabled={isCreating}
+              >
+                Annuler
+              </Button>
+              <Button
+                onClick={handleCreateWithdrawal}
+                disabled={
+                  isCreating ||
+                  !selectedHost ||
+                  !withdrawalForm.amount ||
+                  parseFloat(withdrawalForm.amount) <= 0
+                }
+                className='gap-2 bg-blue-600 text-white hover:bg-blue-700'
+              >
+                {isCreating ? (
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                ) : (
+                  <ArrowRight className='h-4 w-4' />
+                )}
+                Créer la demande
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </motion.div>
     </div>
   )
 }

--- a/src/app/reservations/[id]/page.tsx
+++ b/src/app/reservations/[id]/page.tsx
@@ -1,17 +1,12 @@
-// TODO: Implement chat with the host for a reservation
-
 import Image from 'next/image'
-import Link from 'next/link'
 import { getReservationDetails } from './actions'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Card, CardContent } from '@/components/ui/shadcnui/card'
 import { getProfileImageUrl } from '@/lib/utils'
 import GuestReservationDetailsCard from './GuestReservationDetailsCard'
 import GuestPricingDetailsCard from './GuestPricingDetailsCard'
 import {
   MapPin,
   Calendar,
-  User,
+  Users as UsersIcon,
   Mail,
   Home,
   Info,
@@ -20,8 +15,12 @@ import {
   Car,
   Map,
   Star,
+  ArrowRight,
+  CreditCard,
+  BadgeCheck,
+  Phone,
 } from 'lucide-react'
-import {
+import type {
   Equipment,
   Service,
   Security,
@@ -36,25 +35,90 @@ import {
   getPaymentStatusColor,
   getRentStatusColor,
 } from './utils'
+import { PageHeader } from '@/components/admin/ui/PageHeader'
 
-function HostAvatar({ host }: { host: { name: string; email: string; image: string } }) {
-  const profileImage = getProfileImageUrl(host.image)
+interface FeatureBlockProps {
+  title: string
+  icon: React.ComponentType<{ className?: string }>
+  tone: 'blue' | 'emerald' | 'purple' | 'amber' | 'red' | 'indigo' | 'slate'
+  items: Array<{ id: string; name: string }>
+  itemIcon?: React.ComponentType<{ className?: string }>
+  emptyLabel?: string
+}
 
+const TONE: Record<
+  FeatureBlockProps['tone'],
+  { iconBg: string; iconText: string }
+> = {
+  blue: { iconBg: 'bg-blue-50', iconText: 'text-blue-600' },
+  emerald: { iconBg: 'bg-emerald-50', iconText: 'text-emerald-600' },
+  purple: { iconBg: 'bg-purple-50', iconText: 'text-purple-600' },
+  amber: { iconBg: 'bg-amber-50', iconText: 'text-amber-600' },
+  red: { iconBg: 'bg-red-50', iconText: 'text-red-600' },
+  indigo: { iconBg: 'bg-indigo-50', iconText: 'text-indigo-600' },
+  slate: { iconBg: 'bg-slate-100', iconText: 'text-slate-600' },
+}
+
+function FeatureBlock({
+  title,
+  icon: Icon,
+  tone,
+  items,
+  itemIcon: ItemIcon = Info,
+  emptyLabel = 'Aucun élément renseigné.',
+}: FeatureBlockProps) {
+  const toneClass = TONE[tone]
   return (
-    <div className='relative h-20 w-20 rounded-full overflow-hidden bg-gray-200'>
-      {profileImage && (
+    <div className='rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm'>
+      <div className='mb-4 flex items-center gap-3'>
+        <div
+          className={`flex h-9 w-9 items-center justify-center rounded-lg ${toneClass.iconBg} ${toneClass.iconText}`}
+        >
+          <Icon className='h-4 w-4' />
+        </div>
+        <h3 className='text-sm font-semibold uppercase tracking-wide text-slate-500'>
+          {title}
+        </h3>
+      </div>
+      {items.length === 0 ? (
+        <p className='text-sm text-slate-400'>{emptyLabel}</p>
+      ) : (
+        <ul className='space-y-1.5'>
+          {items.map(item => (
+            <li
+              key={item.id}
+              className='flex items-center gap-2 rounded-lg bg-slate-50 px-3 py-1.5 text-sm text-slate-700'
+            >
+              <ItemIcon className='h-3.5 w-3.5 shrink-0 text-slate-400' />
+              <span className='truncate'>{item.name}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function HostAvatarLarge({
+  host,
+}: {
+  host: { name: string; email: string; image: string }
+}) {
+  const profileImage = getProfileImageUrl(host.image)
+  return (
+    <div className='relative h-20 w-20 shrink-0 overflow-hidden rounded-2xl bg-gradient-to-br from-indigo-500 to-purple-500 ring-4 ring-white shadow-lg'>
+      {profileImage ? (
         <Image
           src={profileImage}
-          alt={host.name ?? 'host'}
+          alt={host.name ?? 'Host'}
           width={80}
           height={80}
-          className='h-full w-full object-cover rounded-full'
+          className='h-full w-full object-cover'
           referrerPolicy='no-referrer'
         />
-      )}
-      {!profileImage && (
-        <div className='absolute inset-0 flex items-center justify-center text-lg font-medium text-gray-600 bg-gray-100'>
-          {host.name?.charAt(0) ?? 'H'}
+      ) : (
+        <div className='flex h-full w-full items-center justify-center text-2xl font-bold text-white'>
+          {host.name?.charAt(0)?.toUpperCase() ?? 'H'}
         </div>
       )}
     </div>
@@ -71,285 +135,273 @@ export default async function ReservationDetailsPage({
     resolvedParams.id
   )) as unknown as ReservationDetails
 
+  const rentStatus = getRentStatusColor(reservation.status)
+  const paymentStatus = getPaymentStatusColor(reservation.payment)
+
+  const isVerifiedHost = host.roles === 'HOST_VERIFIED' || host.roles === 'ADMIN'
+
+  const productImages = reservation.product.img as Array<{ img: string }> | undefined
+  const firstImage = productImages && productImages.length > 0 ? productImages[0].img : null
+
+  const numberOfNights = (() => {
+    const arrival = new Date(reservation.arrivingDate)
+    const departure = new Date(reservation.leavingDate)
+    const diff = Math.round((departure.getTime() - arrival.getTime()) / (1000 * 60 * 60 * 24))
+    return diff > 0 ? diff : 0
+  })()
+
   return (
-    <div className='min-h-screen bg-gradient-to-b from-blue-50 to-white py-10'>
-      <div className='container mx-auto px-4 sm:px-6 lg:px-8'>
-        <div className='max-w-4xl mx-auto space-y-8'>
-          {/* Header */}
-          <div className='flex items-center justify-between'>
-            <h1 className='text-3xl font-bold text-gray-900'>Détails de la réservation</h1>
-            <Link href='/account'>
-              <Button variant='outline'>Retour</Button>
-            </Link>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <div className='mx-auto max-w-6xl space-y-8 p-6'>
+        <PageHeader
+          backHref='/account'
+          backLabel='Retour à mon compte'
+          eyebrow={`Réservation #${reservation.id.slice(-6).toUpperCase()}`}
+          title='Détails de la réservation'
+          subtitle='Consultez les informations de votre séjour, votre hôte et les équipements inclus.'
+        />
+
+        {/* Status card row */}
+        <div className='grid gap-4 md:grid-cols-3'>
+          <div className='rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm'>
+            <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+              Statut
+            </p>
+            <span
+              className={`mt-2 inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ring-1 ring-inset ${rentStatus.bg} ${rentStatus.text} ring-current/10`}
+            >
+              {translateRentStatus(reservation.status)}
+            </span>
           </div>
+          <div className='rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm'>
+            <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+              Confirmation hôte
+            </p>
+            <span
+              className={`mt-2 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-semibold ring-1 ${
+                reservation.confirmed
+                  ? 'bg-emerald-50 text-emerald-700 ring-emerald-200'
+                  : 'bg-amber-50 text-amber-700 ring-amber-200'
+              }`}
+            >
+              <BadgeCheck className='h-3.5 w-3.5' />
+              {reservation.confirmed ? 'Confirmé' : 'En attente'}
+            </span>
+          </div>
+          <div className='rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm'>
+            <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+              Paiement
+            </p>
+            <span
+              className={`mt-2 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-semibold ring-1 ring-inset ${paymentStatus.bg} ${paymentStatus.text} ring-current/10`}
+            >
+              <CreditCard className='h-3.5 w-3.5' />
+              {translatePaymentStatus(reservation.payment)}
+            </span>
+          </div>
+        </div>
 
-          {/* Property Overview */}
-          <Card>
-            <CardContent className='p-6'>
-              <div className='flex flex-col md:flex-row gap-6'>
-                <div className='relative w-full md:w-1/3 aspect-[4/3]'>
-                  <Image
-                    src={reservation.product.img?.[0]?.img || '/placeholder.png'}
-                    alt={reservation.product.name}
-                    fill
-                    className='object-cover rounded-lg'
-                  />
+        {/* Property overview */}
+        <div className='overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm'>
+          <div className='grid gap-0 md:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]'>
+            <div className='relative aspect-[4/3] w-full md:aspect-auto md:min-h-[280px]'>
+              {firstImage ? (
+                <Image
+                  src={firstImage}
+                  alt={reservation.product.name}
+                  fill
+                  className='object-cover'
+                  sizes='(max-width: 768px) 100vw, 40vw'
+                />
+              ) : (
+                <div className='flex h-full w-full items-center justify-center bg-gradient-to-br from-slate-100 to-slate-200'>
+                  <Home className='h-16 w-16 text-slate-400' />
                 </div>
-                <div className='flex-1'>
-                  <h2 className='text-2xl font-semibold mb-4'>{reservation.product.name}</h2>
-                  <div className='flex items-center gap-2 text-gray-600 mb-4'>
-                    <MapPin className='w-4 h-4' />
-                    <span>{reservation.product.address}</span>
-                  </div>
-                  <div className='grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm'>
-                    <div>
-                      <p className='font-medium'>Arrivée</p>
-                      <div className='flex items-center gap-2 text-gray-600'>
-                        <Calendar className='w-4 h-4' />
-                        <span>{new Date(reservation.arrivingDate).toLocaleDateString()}</span>
-                      </div>
-                    </div>
-                    <div>
-                      <p className='font-medium'>Départ</p>
-                      <div className='flex items-center gap-2 text-gray-600'>
-                        <Calendar className='w-4 h-4' />
-                        <span>{new Date(reservation.leavingDate).toLocaleDateString()}</span>
-                      </div>
-                    </div>
-                    <div>
-                      <p className='font-medium'>Voyageurs</p>
-                      <div className='flex items-center gap-2 text-gray-600'>
-                        <User className='w-4 h-4' />
-                        <span>{reservation.numberPeople.toString()} personnes</span>
-                      </div>
-                    </div>
-                    <div>
-                      <p className='font-medium'>Prix total</p>
-                      <div className='flex items-center gap-2 text-gray-600'>
-                        <span>{reservation.prices.toString()}€</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
+              )}
+            </div>
+            <div className='space-y-5 p-6'>
+              <div>
+                <h2 className='text-2xl font-bold text-slate-900'>
+                  {reservation.product.name}
+                </h2>
+                <p className='mt-1 flex items-center gap-1.5 text-sm text-slate-500'>
+                  <MapPin className='h-4 w-4' />
+                  {reservation.product.address}
+                </p>
               </div>
-            </CardContent>
-          </Card>
 
-          {/* Host Information */}
-          <Card>
-            <CardContent className='p-6'>
-              <h3 className='text-xl font-semibold mb-4'>Informations sur l&apos;hôte</h3>
-              <div className='flex flex-col sm:flex-row items-start gap-6'>
-                <div className='flex items-center gap-4'>
-                  <HostAvatar
-                    host={host as unknown as { name: string; email: string; image: string }}
-                  />
-                  <div>
-                    <p className='font-medium text-lg'>{host.name}</p>
-                    <div className='flex flex-col gap-2 text-sm text-gray-600 mt-2'>
-                      <div className='flex items-center gap-2'>
-                        <Mail className='w-4 h-4' />
-                        <span>{host.email}</span>
-                      </div>
-                      {host.roles === 'HOST_VERIFIED' ||
-                        (host.roles === 'ADMIN' && (
-                          <div className='flex items-center gap-2'>
-                            <Star className='w-4 h-4 text-yellow-400' />
-                            <span>Hôte vérifié</span>
-                          </div>
-                        ))}
-                    </div>
-                  </div>
+              <div className='grid grid-cols-2 gap-4'>
+                <div className='rounded-xl bg-slate-50 p-3'>
+                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                    Arrivée
+                  </p>
+                  <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                    <Calendar className='h-4 w-4 text-blue-600' />
+                    {new Date(reservation.arrivingDate).toLocaleDateString('fr-FR', {
+                      day: '2-digit',
+                      month: 'short',
+                      year: 'numeric',
+                    })}
+                  </p>
                 </div>
-                <div className='flex-1 bg-gray-50 rounded-lg p-4 mt-4 sm:mt-0'>
-                  <p className='text-sm text-gray-600'>
-                    Pour toute question concernant votre séjour, n&apos;hésitez pas à contacter
-                    votre hôte directement par email.
+                <div className='rounded-xl bg-slate-50 p-3'>
+                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                    Départ
+                  </p>
+                  <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                    <Calendar className='h-4 w-4 text-blue-600' />
+                    {new Date(reservation.leavingDate).toLocaleDateString('fr-FR', {
+                      day: '2-digit',
+                      month: 'short',
+                      year: 'numeric',
+                    })}
+                  </p>
+                </div>
+                <div className='rounded-xl bg-slate-50 p-3'>
+                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                    Durée
+                  </p>
+                  <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                    <ArrowRight className='h-4 w-4 text-emerald-600' />
+                    {numberOfNights} nuit{numberOfNights > 1 ? 's' : ''}
+                  </p>
+                </div>
+                <div className='rounded-xl bg-slate-50 p-3'>
+                  <p className='text-xs font-semibold uppercase tracking-wide text-slate-500'>
+                    Voyageurs
+                  </p>
+                  <p className='mt-1 flex items-center gap-1.5 text-sm font-semibold text-slate-900'>
+                    <UsersIcon className='h-4 w-4 text-purple-600' />
+                    {reservation.numberPeople.toString()} personne
+                    {Number(reservation.numberPeople) > 1 ? 's' : ''}
                   </p>
                 </div>
               </div>
-            </CardContent>
-          </Card>
-
-          {/* Property Details */}
-          <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
-            {/* Amenities */}
-            <Card>
-              <CardContent className='p-6'>
-                <h3 className='text-xl font-semibold mb-4'>Équipements</h3>
-                <div className='space-y-3'>
-                  {reservation.product.equipments.map((equipment: Equipment) => (
-                    <div key={equipment.id} className='flex items-center gap-2 text-gray-600'>
-                      <Home className='w-4 h-4' />
-                      <span>{equipment.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Services */}
-            <Card>
-              <CardContent className='p-6'>
-                <h3 className='text-xl font-semibold mb-4'>Services</h3>
-                <div className='space-y-3'>
-                  {reservation.product.servicesList.map((service: Service) => (
-                    <div key={service.id} className='flex items-center gap-2 text-gray-600'>
-                      <Info className='w-4 h-4' />
-                      <span>{service.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Security */}
-            <Card>
-              <CardContent className='p-6'>
-                <h3 className='text-xl font-semibold mb-4'>Sécurité</h3>
-                <div className='space-y-3'>
-                  {reservation.product.securities.map((security: Security) => (
-                    <div key={security.id} className='flex items-center gap-2 text-gray-600'>
-                      <Shield className='w-4 h-4' />
-                      <span>{security.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Meals */}
-            <Card>
-              <CardContent className='p-6'>
-                <h3 className='text-xl font-semibold mb-4'>Repas</h3>
-                <div className='space-y-3'>
-                  {reservation.product.mealsList.map((meal: Meal) => (
-                    <div key={meal.id} className='flex items-center gap-2 text-gray-600'>
-                      <Utensils className='w-4 h-4' />
-                      <span>{meal.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Transport */}
-            <Card>
-              <CardContent className='p-6'>
-                <h3 className='text-xl font-semibold mb-4'>Transport</h3>
-                <div className='space-y-3'>
-                  {reservation.product.transportOptions.map((transport: Transport) => (
-                    <div key={transport.id} className='flex items-center gap-2 text-gray-600'>
-                      <Car className='w-4 h-4' />
-                      <span>{transport.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Nearby Places */}
-            <Card>
-              <CardContent className='p-6'>
-                <h3 className='text-xl font-semibold mb-4'>À proximité</h3>
-                <div className='space-y-3'>
-                  {reservation.product.nearbyPlaces.map((place: NearbyPlace) => (
-                    <div key={place.id} className='flex items-center gap-2 text-gray-600'>
-                      <Map className='w-4 h-4' />
-                      <span>{place.name}</span>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Proximity Landmarks (visible only with reservation) */}
-            {reservation.product.proximityLandmarks &&
-              reservation.product.proximityLandmarks.length > 0 && (
-                <Card className='border-blue-200 bg-blue-50/50'>
-                  <CardContent className='p-6'>
-                    <div className='flex items-start gap-3 mb-4'>
-                      <Info className='w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0' />
-                      <div>
-                        <h3 className='text-xl font-semibold text-blue-900 mb-1'>
-                          Points de repère pour vous aider à localiser
-                        </h3>
-                        <p className='text-sm text-blue-700'>
-                          Ces informations sont visibles uniquement pour faciliter votre arrivée
-                        </p>
-                      </div>
-                    </div>
-                    <div className='space-y-2'>
-                      {reservation.product.proximityLandmarks.map(
-                        (landmark: string, index: number) => (
-                          <div key={index} className='flex items-center gap-2 text-blue-800'>
-                            <MapPin className='w-4 h-4 flex-shrink-0' />
-                            <span>{landmark}</span>
-                          </div>
-                        )
-                      )}
-                    </div>
-                  </CardContent>
-                </Card>
-              )}
+            </div>
           </div>
+        </div>
 
-          {/* Status and Payment */}
-          <Card>
-            <CardContent className='p-6'>
-              <h3 className='text-xl font-semibold mb-4'>Statut de la réservation</h3>
-              <div className='grid grid-cols-1 sm:grid-cols-2 gap-6'>
-                <div>
-                  <p className='font-medium mb-2'>Statut</p>
-                  <span
-                    className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
-                      getRentStatusColor(reservation.status).bg
-                    } ${getRentStatusColor(reservation.status).text}`}
-                  >
-                    {translateRentStatus(reservation.status)}
+        {/* Host card */}
+        <div className='rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm'>
+          <h3 className='mb-4 text-sm font-semibold uppercase tracking-wide text-slate-500'>
+            Votre hôte
+          </h3>
+          <div className='flex flex-col gap-6 sm:flex-row sm:items-start'>
+            <HostAvatarLarge
+              host={host as unknown as { name: string; email: string; image: string }}
+            />
+            <div className='flex-1'>
+              <div className='flex flex-wrap items-center gap-2'>
+                <p className='text-lg font-bold text-slate-900'>{host.name}</p>
+                {isVerifiedHost && (
+                  <span className='inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-700 ring-1 ring-emerald-200'>
+                    <Star className='h-3 w-3' />
+                    Hôte vérifié
                   </span>
-                </div>
-                {/* Add data for the host confirmation for this reservation (reservation.confirmed) */}
-                {reservation.confirmed ? (
-                  <div>
-                    <p className='font-medium mb-2'>Confirmation de l&apos;hôte</p>
-                    <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800'>
-                      Confirmé
-                    </span>
-                  </div>
-                ) : (
-                  <div>
-                    <p className='font-medium mb-2'>Confirmation de l&apos;hôte</p>
-                    <span className='inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-orange-100 text-orange-800'>
-                      En attente
-                    </span>
-                  </div>
                 )}
-                <div>
-                  <p className='font-medium mb-2'>Paiement</p>
-                  <span
-                    className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
-                      getPaymentStatusColor(reservation.payment).bg
-                    } ${getPaymentStatusColor(reservation.payment).text}`}
-                  >
-                    {translatePaymentStatus(reservation.payment)}
+              </div>
+              <div className='mt-3 space-y-2 text-sm text-slate-600'>
+                <div className='flex items-center gap-2'>
+                  <Mail className='h-4 w-4 text-slate-400' />
+                  <a href={`mailto:${host.email}`} className='hover:text-blue-600'>
+                    {host.email}
+                  </a>
+                </div>
+                <div className='flex items-center gap-2'>
+                  <Phone className='h-4 w-4 text-slate-400' />
+                  <span className='text-slate-500'>
+                    Contactez votre hôte par email pour toute question
                   </span>
                 </div>
               </div>
-            </CardContent>
-          </Card>
-
-          {/* Reservation Details Cards */}
-          <div className='grid grid-cols-1 xl:grid-cols-3 gap-8'>
-            {/* Guest Reservation Details */}
-            <div className='xl:col-span-2'>
-              <GuestReservationDetailsCard reservation={reservation} />
             </div>
+          </div>
+        </div>
 
-            {/* Pricing Details */}
-            <div>
-              <GuestPricingDetailsCard rent={reservation} />
+        {/* Property details grid */}
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
+          <FeatureBlock
+            title='Équipements'
+            icon={Home}
+            tone='blue'
+            items={reservation.product.equipments as Equipment[]}
+            itemIcon={Home}
+          />
+          <FeatureBlock
+            title='Services'
+            icon={Info}
+            tone='indigo'
+            items={reservation.product.servicesList as Service[]}
+          />
+          <FeatureBlock
+            title='Sécurité'
+            icon={Shield}
+            tone='red'
+            items={reservation.product.securities as Security[]}
+            itemIcon={Shield}
+          />
+          <FeatureBlock
+            title='Repas'
+            icon={Utensils}
+            tone='amber'
+            items={reservation.product.mealsList as Meal[]}
+            itemIcon={Utensils}
+          />
+          <FeatureBlock
+            title='Transport'
+            icon={Car}
+            tone='emerald'
+            items={reservation.product.transportOptions as Transport[]}
+            itemIcon={Car}
+          />
+          <FeatureBlock
+            title='À proximité'
+            icon={Map}
+            tone='purple'
+            items={reservation.product.nearbyPlaces as NearbyPlace[]}
+            itemIcon={MapPin}
+          />
+        </div>
+
+        {/* Proximity landmarks (visible only to guest who booked) */}
+        {reservation.product.proximityLandmarks &&
+          reservation.product.proximityLandmarks.length > 0 && (
+            <div className='rounded-2xl border border-blue-200 bg-blue-50/60 p-6'>
+              <div className='mb-4 flex items-start gap-3'>
+                <div className='flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-100 text-blue-600'>
+                  <Info className='h-5 w-5' />
+                </div>
+                <div>
+                  <h3 className='text-sm font-semibold uppercase tracking-wide text-blue-900'>
+                    Points de repère
+                  </h3>
+                  <p className='mt-1 text-sm text-blue-700'>
+                    Ces informations sont partagées uniquement avec les voyageurs ayant une
+                    réservation, pour faciliter votre arrivée.
+                  </p>
+                </div>
+              </div>
+              <ul className='space-y-2'>
+                {(reservation.product.proximityLandmarks as string[]).map((landmark, i) => (
+                  <li
+                    key={i}
+                    className='flex items-center gap-2 rounded-lg bg-white px-3 py-2 text-sm text-slate-700 ring-1 ring-blue-200/60'
+                  >
+                    <MapPin className='h-4 w-4 shrink-0 text-blue-600' />
+                    <span>{landmark}</span>
+                  </li>
+                ))}
+              </ul>
             </div>
+          )}
+
+        {/* Reservation + pricing details cards (existing components) */}
+        <div className='grid grid-cols-1 gap-6 xl:grid-cols-3'>
+          <div className='xl:col-span-2'>
+            <GuestReservationDetailsCard reservation={reservation} />
+          </div>
+          <div>
+            <GuestPricingDetailsCard rent={reservation} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

**Phase 3** of the admin panel modernization. Rewrites the four remaining business pages around the shared admin design system (`PageHeader`, `KpiCard`, `FilterBar`, `DataTable`) and drops the old gradient-cards / hand-rolled tables in favor of a consistent, dense and scannable UI.

## Pages redesigned

### `/admin/reservations`
- `PageHeader` + hero KPI row (Total, À traiter, Confirmées, Revenus (page)) + secondary KpiMetric chips (check-in, check-out, annulées).
- Status filter chips (Toutes / En attente / Confirmées / Check-in / Check-out / Annulées).
- `FilterBar` wrapping the existing debounced search.
- `DataTable` with 7 columns: Référence, Voyageur, Hébergement (clickable → `/admin/validation/[id]`), Hôte, Séjour, Montant (with payment pill), Statut. Sortable on reference, guest, stay and amount.
- Per-row dropdown actions gated by status: Voir le détail / Confirmer (WAITING → RESERVED) / Marquer check-in / Marquer check-out / Annuler.
- Cancel dialog rebuilt with the new modal pattern.
- `useAdminReservationStatusChange` mutation preserved untouched.

### `/admin/withdrawals` (1088 → ~770 lines)
- Same PageHeader + KpiCard pattern. 4 hero cards + 4-chip secondary row.
- Status filter chips (Toutes / En attente / Validation compte / Approuvées / Payées / Rejetées).
- Client-side search on name/email/id.
- `DataTable` with: Hôte, Montant + type, Méthode (with "Non validé" warning), Statut, Demandé le.
- Per-row dropdown actions gated by status: Valider le compte, Approuver, Rejeter, Marquer comme payée.
- "Nouvelle demande" button in the header opens a redesigned create-withdrawal dialog: host selector, host-balance info card, simplified payment details form (SEPA / PayPal / Mobile Money) in a clean two-column layout.
- Preserved all existing API calls (approve, reject, mark-paid, validate-account, create-for-host). Console.log instrumentation removed to clean up browser noise.

### `/admin/payment`
- `PageHeader` + hero KPI row (Total, En attente, Montant en attente, Montant total).
- Status filter chips with counts.
- Client-side search on host/email/product.
- `DataTable` with 5 columns: Type (with colored pill + notes), Montant, Hôte, Hébergement, Statut. Sortable on amount, host and status.
- Per-row "Détails" button routes to `/admin/payment/[id]` (detail page unchanged).
- **All emojis removed** from status badges and stats.

### `/reservations/[id]` (guest reservation detail)
- Kept as Server Component (still `await getReservationDetails()`).
- `PageHeader` with "Retour à mon compte" back link and dynamic "Réservation #XXXXXX" eyebrow built from the reservation id. No `eyebrowIcon` because Server Components cannot pass Lucide component references across the RSC boundary to the Client PageHeader.
- Three status cards row at the top (Statut, Confirmation hôte, Paiement) with colored pills reusing the existing translators.
- Property overview in a two-column layout: image on the left, details grid on the right with four slate info chips.
- Host card rebuilt around a large avatar chip, "Hôte vérifié" badge, mailto link.
- Amenities rendered as a 3-column grid of small `FeatureBlock` cards (equipments, services, security, meals, transport, nearby), each with its own icon chip tone. Empty blocks show a discreet fallback.
- Proximity landmarks preserved with its private info panel.
- `GuestReservationDetailsCard` + `GuestPricingDetailsCard` kept untouched.

## Test plan (verified locally via Chrome DevTools)

- [x] `/admin/reservations` — 16 rows, sort + filter chips work, amounts + payment pills correct
- [x] `/admin/withdrawals` — empty state + filter chips + create dialog open
- [x] `/admin/payment` — 2 rows, stats show 935 € pending / 935 € total
- [x] `/reservations/cmmasogme00015gqozxi3clz0` — full detail page renders without errors, all sections populated
- [x] Fixed RSC boundary bug: removed `eyebrowIcon={Calendar}` on `/reservations/[id]` page (Server Component cannot pass Lucide component refs to Client PageHeader)
- [x] Lint: 0 errors. `tsc --noEmit`: clean.

## Scope

Pure presentation rewrite — no API, permission, or behavior changes beyond:
- The cancel reservation dialog now uses the destructive modal pattern
- All emojis removed from admin page stats and pills (replaced with Lucide icons and colored rings)
- Console.log instrumentation removed from the withdrawals page handlers

## Follow-up

- **Phase 4**: Taxonomy refactor with a generic `<TaxonomyManager>` for 7 pages
- **Phase 5**: Blog admin pages (`/admin/blog`, `/admin/blog/edit/[id]`, `/createPost`)