### PR TITLE
feat(admin): unify taxonomy pages with shared TaxonomyManager

### DIFF
--- a/src/app/admin/equipments/page.tsx
+++ b/src/app/admin/equipments/page.tsx
@@ -1,530 +1,96 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
-import { useAuth } from '@/hooks/useAuth'
-import { isAdmin } from '@/hooks/useAdminAuth'
-import Link from 'next/link'
-import { motion, Variants } from 'framer-motion'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/shadcnui/input'
-import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
+import { Sofa, Shield } from 'lucide-react'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/shadcnui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import {
-  Loader2,
-  Search,
-  Eye,
-  BrushCleaning,
-  Plus,
-  ArrowLeft,
-  CheckCircle,
-  Edit3,
-  Trash2,
-} from 'lucide-react'
-
-import {
-  findAllEquipments,
   createEquipment,
-  updateEquipment,
   deleteEquipement,
+  findAllEquipments,
+  updateEquipment,
 } from '@/lib/services/equipments.service'
 import { EquipmentInterface } from '@/lib/interface/equipmentInterface'
-import { IconPicker } from '@/components/ui/IconPicker'
-import { DynamicIcon } from '@/lib/utils/iconMapping'
+import { TaxonomyManager, type TaxonomyAdapter } from '@/components/admin/ui/TaxonomyManager'
+import type { DataTableColumn } from '@/components/admin/ui/DataTable'
 
-const containerVariants: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
+interface EquipmentFormData {
+  name: string
+  icon: string
+}
+
+const adapter: TaxonomyAdapter<EquipmentInterface, EquipmentFormData> = {
+  fetchAll: async () => {
+    const result = await findAllEquipments()
+    return result ?? []
+  },
+  create: async data => {
+    const created = await createEquipment(data.name, data.icon)
+    return created ?? null
+  },
+  update: async (id, data) => {
+    const updated = await updateEquipment(id, data.name, data.icon)
+    return updated ?? null
+  },
+  delete: async id => {
+    const success = await deleteEquipement(id)
+    return Boolean(success)
   },
 }
 
-const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: 'tween' as const,
-      duration: 0.5,
-      ease: 'easeOut',
-    },
+const extraColumns: Array<DataTableColumn<EquipmentInterface>> = [
+  {
+    key: 'icon',
+    header: 'Icône',
+    render: item =>
+      item.icon ? (
+        <span className='inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 font-mono text-xs text-slate-600'>
+          {item.icon}
+        </span>
+      ) : (
+        <span className='text-xs text-slate-400'>—</span>
+      ),
+    cellClassName: 'whitespace-nowrap',
   },
-}
+]
 
 export default function EquipmentsPage() {
-  const {
-    session,
-    isLoading: isAuthLoading,
-    isAuthenticated,
-  } = useAuth({ required: true, redirectTo: '/auth' })
-  const router = useRouter()
-  const [equipments, setEquipments] = useState<EquipmentInterface[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState('')
-  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
-  const [newOptionName, setNewOptionName] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [selectedIcon, setSelectedIcon] = useState('CheckCircle')
-
-  // États pour l'édition
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
-  const [editingOption, setEditingOption] = useState<EquipmentInterface | null>(null)
-  const [editOptionName, setEditOptionName] = useState('')
-  const [editIcon, setEditIcon] = useState('CheckCircle')
-
-  // États pour la suppression
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
-  const [deletingOption, setDeletingOption] = useState<EquipmentInterface | null>(null)
-
-  useEffect(() => {
-    if (isAuthenticated && (!session?.user?.roles || !isAdmin(session.user.roles))) {
-      router.push('/')
-    }
-  }, [isAuthenticated, session, router])
-
-  useEffect(() => {
-    const fetchEquipments = async () => {
-      try {
-        const equipmentsData = await findAllEquipments()
-        if (equipmentsData) {
-          setEquipments(equipmentsData)
-        }
-      } catch (err) {
-        setError("Erreur lors du chargement des options d'équipements")
-        console.error(err)
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchEquipments()
-  }, [])
-
-  const filteredEquipments = equipments.filter((option: EquipmentInterface) =>
-    option.name?.toLowerCase().includes(searchTerm.toLowerCase())
-  )
-
-  const handleAddOption = async () => {
-    if (!newOptionName.trim()) return
-
-    setIsSubmitting(true)
-    try {
-      const newOption = await createEquipment(newOptionName, selectedIcon)
-
-      if (newOption) {
-        setEquipments([...equipments, newOption])
-        setNewOptionName('')
-        setSelectedIcon('CheckCircle')
-        setIsAddDialogOpen(false)
-      } else {
-        setError("Erreur lors de la création de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la création:', err)
-      setError("Erreur lors de la création de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleEditOption = (option: EquipmentInterface) => {
-    setEditingOption(option)
-    setEditOptionName(option.name || '')
-    setEditIcon(option.icon || 'CheckCircle')
-    setIsEditDialogOpen(true)
-  }
-
-  const handleUpdateOption = async () => {
-    if (!editingOption || !editOptionName.trim()) return
-
-    setIsSubmitting(true)
-    try {
-      const updatedOption = await updateEquipment(
-        editingOption.id,
-        editOptionName,
-        editIcon
-      )
-
-      if (updatedOption) {
-        setEquipments(equipments.map(opt => (opt.id === editingOption.id ? updatedOption : opt)))
-        setEditOptionName('')
-        setEditingOption(null)
-        setIsEditDialogOpen(false)
-      } else {
-        setError("Erreur lors de la modification de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la modification:', err)
-      setError("Erreur lors de la modification de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleDeleteOption = (option: EquipmentInterface) => {
-    setDeletingOption(option)
-    setIsDeleteDialogOpen(true)
-  }
-
-  const handleConfirmDelete = async () => {
-    if (!deletingOption) return
-
-    setIsSubmitting(true)
-    try {
-      const success = await deleteEquipement(deletingOption.id)
-
-      if (success) {
-        setEquipments(equipments.filter(opt => opt.id !== deletingOption.id))
-        setDeletingOption(null)
-        setIsDeleteDialogOpen(false)
-      } else {
-        setError("Erreur lors de la suppression de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la suppression:', err)
-      setError("Erreur lors de la suppression de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  if (isAuthLoading || loading) {
-    return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
-        </div>
-      </div>
-    )
-  }
-
-  if (!session) {
-    return null
-  }
-
-  if (error) {
-    return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive'>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        </div>
-      </div>
-    )
-  }
-
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
-      <motion.div
-        className='max-w-7xl mx-auto p-6 space-y-8'
-        variants={containerVariants}
-        initial='hidden'
-        animate='visible'
-      >
-        {/* Header with breadcrumb */}
-        <motion.div variants={itemVariants} className='space-y-4'>
-          <Button variant='ghost' size='sm' asChild className='text-slate-600 hover:text-slate-800'>
-            <Link href='/admin' className='flex items-center gap-2'>
-              <ArrowLeft className='h-4 w-4' />
-              Retour au dashboard
-            </Link>
-          </Button>
-
-          <div className='flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4'>
-            <div>
-              <div className='flex items-center gap-2 mb-2'>
-                <BrushCleaning className='h-8 w-8 text-green-600' />
-                <h1 className='text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-800 via-green-700 to-emerald-700'>
-                  Gestion des options d&apos;équipements
-                </h1>
-              </div>
-              <p className='text-slate-600 text-lg'>
-                {equipments.length} option{equipments.length > 1 ? 's' : ''} enregistrée
-                {equipments.length > 1 ? 's' : ''}
-              </p>
-            </div>
-
-            <div className='flex items-center gap-3'>
-              <div className='relative'>
-                <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4' />
-                <Input
-                  type='text'
-                  placeholder='Rechercher un équipement...'
-                  value={searchTerm}
-                  onChange={e => setSearchTerm(e.target.value)}
-                  className='pl-10 w-full sm:w-64'
-                />
-              </div>
-
-              <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-                <DialogTrigger asChild>
-                  <Button className='bg-green-600 hover:bg-green-700 text-white shadow-lg'>
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter un équipement
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className='sm:max-w-lg'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <BrushCleaning className='h-5 w-5 text-green-600' />
-                      Nouvel équipement
-                    </DialogTitle>
-                    <DialogDescription>
-                      Ajoutez un nouvel équipement à la liste disponible.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='optionName'>Nom de l&apos;équipement</Label>
-                      <Input
-                        id='optionName'
-                        placeholder='Ex: Lave-linge, Lave-vaisselle, Micro-ondes...'
-                        value={newOptionName}
-                        onChange={e => setNewOptionName(e.target.value)}
-                        onKeyDown={e => e.key === 'Enter' && !isSubmitting && handleAddOption()}
-                      />
-                    </div>
-                    <IconPicker value={selectedIcon} onChange={setSelectedIcon} />
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => {
-                        setIsAddDialogOpen(false)
-                        setSelectedIcon('CheckCircle')
-                      }}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleAddOption}
-                      disabled={!newOptionName.trim() || isSubmitting}
-                      className='bg-green-600 hover:bg-green-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Création...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Créer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Dialog d'édition */}
-              <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-                <DialogContent className='sm:max-w-lg'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Edit3 className='h-5 w-5 text-green-600' />
-                      Modifier l&apos;équipement
-                    </DialogTitle>
-                    <DialogDescription>Modifiez le nom de cet équipement.</DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='editOptionName'>Nom de l&apos;équipement</Label>
-                      <Input
-                        id='editOptionName'
-                        placeholder='Ex: Aspirateur, Fer à repasser...'
-                        value={editOptionName}
-                        onChange={e => setEditOptionName(e.target.value)}
-                        onKeyDown={e => e.key === 'Enter' && !isSubmitting && handleUpdateOption()}
-                      />
-                    </div>
-                    <IconPicker value={editIcon} onChange={setEditIcon} />
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsEditDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleUpdateOption}
-                      disabled={!editOptionName.trim() || isSubmitting}
-                      className='bg-green-600 hover:bg-green-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Modification...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Modifier
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Dialog de suppression */}
-              <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Trash2 className='h-5 w-5 text-red-600' />
-                      Supprimer l&apos;équipement
-                    </DialogTitle>
-                    <DialogDescription>
-                      Êtes-vous sûr de vouloir supprimer l&apos;équipement &quot;
-                      {deletingOption?.name}&quot; ? Cette action est irréversible.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsDeleteDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleConfirmDelete}
-                      disabled={isSubmitting}
-                      variant='destructive'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Suppression...
-                        </>
-                      ) : (
-                        <>
-                          <Trash2 className='h-4 w-4 mr-2' />
-                          Supprimer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-            </div>
-          </div>
-        </motion.div>
-
-        {/* Content */}
-        <motion.div variants={itemVariants}>
-          {filteredEquipments.length === 0 ? (
-            <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm'>
-              <CardContent className='text-center py-12'>
-                <BrushCleaning className='h-16 w-16 text-slate-300 mx-auto mb-4' />
-                <h3 className='text-xl font-semibold text-slate-600 mb-2'>
-                  {searchTerm ? 'Aucun résultat' : 'Aucun équipement'}
-                </h3>
-                <p className='text-slate-500 mb-6'>
-                  {searchTerm
-                    ? 'Aucun équipement ne correspond à votre recherche.'
-                    : 'Commencez par ajouter votre premier équipement.'}
-                </p>
-                {!searchTerm && (
-                  <Button
-                    onClick={() => setIsAddDialogOpen(true)}
-                    className='bg-green-600 hover:bg-green-700'
-                  >
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter un équipement
-                  </Button>
-                )}
-              </CardContent>
-            </Card>
-          ) : (
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 items-stretch'>
-              {filteredEquipments.map((option, index) => (
-                <motion.div
-                  key={option.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.05 }}
-                >
-                  <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm hover:shadow-xl transition-all duration-300 group h-full'>
-                    <CardHeader className='pb-3'>
-                      <div className='flex items-start justify-between'>
-                        <div className='flex items-center gap-3'>
-                          <div className='p-2 bg-green-50 rounded-lg group-hover:bg-green-100 transition-colors'>
-                            <DynamicIcon name={option.icon} className='h-5 w-5 text-green-600' />
-                          </div>
-                          <div>
-                            <CardTitle className='text-lg font-semibold text-slate-800'>
-                              {option.name || 'Équipement sans nom'}
-                            </CardTitle>
-                          </div>
-                        </div>
-                        <Badge
-                          variant='secondary'
-                          className='bg-green-50 text-green-700 border-green-200'
-                        >
-                          Actif
-                        </Badge>
-                      </div>
-                    </CardHeader>
-                    <CardContent className='pt-0'>
-                      <div className='flex items-center gap-2'>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          asChild
-                          className='flex-1 hover:bg-green-50 hover:text-green-600'
-                        >
-                          <Link href={`/admin/equipments/${option.id}`}>
-                            <Eye className='h-4 w-4 mr-2' />
-                            Voir détails
-                          </Link>
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-green-50 hover:text-green-600'
-                          onClick={() => handleEditOption(option)}
-                        >
-                          <Edit3 className='h-4 w-4' />
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-red-50 hover:text-red-600'
-                          onClick={() => handleDeleteOption(option)}
-                        >
-                          <Trash2 className='h-4 w-4' />
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </motion.div>
-              ))}
-            </div>
-          )}
-        </motion.div>
-      </motion.div>
-    </div>
+    <TaxonomyManager<EquipmentInterface, EquipmentFormData>
+      eyebrow='Espace administrateur'
+      eyebrowIcon={Shield}
+      title='Équipements'
+      subtitle='Gérez les équipements disponibles dans les hébergements (lave-linge, wifi, etc.).'
+      backHref='/admin'
+      backLabel='Retour au panel admin'
+      icon={Sofa}
+      kpiTone='blue'
+      itemLabelSingular='équipement'
+      itemLabelPlural='équipements'
+      searchPlaceholder='Rechercher un équipement…'
+      getItemId={item => item.id}
+      getItemName={item => item.name ?? ''}
+      searchMatches={(item, q) =>
+        (item.name ?? '').toLowerCase().includes(q) ||
+        (item.icon ?? '').toLowerCase().includes(q)
+      }
+      extraColumns={extraColumns}
+      fields={[
+        {
+          name: 'name',
+          label: 'Nom',
+          type: 'text',
+          required: true,
+          placeholder: 'Ex: Lave-linge, Wifi, Climatisation',
+        },
+        {
+          name: 'icon',
+          label: 'Icône',
+          type: 'text',
+          placeholder: "Nom de l'icône Lucide (optionnel)",
+          help: 'Laisser vide pour utiliser l’icône par défaut.',
+        },
+      ]}
+      emptyFormData={{ name: '', icon: '' }}
+      toFormData={item => ({ name: item.name ?? '', icon: item.icon ?? '' })}
+      adapter={adapter}
+    />
   )
 }

--- a/src/app/admin/extras/page.tsx
+++ b/src/app/admin/extras/page.tsx
@@ -1,36 +1,10 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/input'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/shadcnui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/shadcnui/dialog'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import { Label } from '@/components/ui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import { Plus, Edit, Trash2 } from 'lucide-react'
-import { toast } from 'sonner'
+import { PlusCircle, Shield } from 'lucide-react'
 import { ExtraPriceType } from '@prisma/client'
+import { TaxonomyManager, type TaxonomyAdapter } from '@/components/admin/ui/TaxonomyManager'
+import type { DataTableColumn } from '@/components/admin/ui/DataTable'
+import { formatCurrency } from '@/lib/utils/formatNumber'
 
 interface ProductExtra {
   id: string
@@ -46,6 +20,14 @@ interface ProductExtra {
   }
 }
 
+interface ExtraFormData {
+  name: string
+  description: string
+  priceEUR: string
+  priceMGA: string
+  type: ExtraPriceType | ''
+}
+
 const PRICE_TYPE_LABELS: Record<ExtraPriceType, string> = {
   PER_DAY: 'Par jour',
   PER_PERSON: 'Par personne',
@@ -53,328 +35,184 @@ const PRICE_TYPE_LABELS: Record<ExtraPriceType, string> = {
   PER_BOOKING: 'Par réservation',
 }
 
-export default function ExtrasPage() {
-  const [extras, setExtras] = useState<ProductExtra[]>([])
-  const [loading, setLoading] = useState(true)
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [editingExtra, setEditingExtra] = useState<ProductExtra | null>(null)
-  const [formData, setFormData] = useState({
-    name: '',
-    description: '',
-    priceEUR: '',
-    priceMGA: '',
-    type: '' as ExtraPriceType | '',
-  })
-
-  useEffect(() => {
-    fetchExtras()
-  }, [])
-
-  const fetchExtras = async () => {
-    try {
-      const response = await fetch('/api/admin/extras', {
-        cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      })
-      if (response.ok) {
-        const data = await response.json()
-        setExtras(data)
-      } else {
-        toast.error('Erreur lors du chargement des extras')
-      }
-    } catch {
-      toast.error('Erreur lors du chargement des extras')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    if (!formData.name.trim() || !formData.priceEUR || !formData.priceMGA || !formData.type) {
-      toast.error('Tous les champs obligatoires doivent être renseignés')
-      return
-    }
-
-    // Validation des prix
-    const priceEUR = parseFloat(formData.priceEUR)
-    const priceMGA = parseFloat(formData.priceMGA)
-
-    if (isNaN(priceEUR) || priceEUR < 0) {
-      toast.error('Le prix en EUR doit être un nombre positif')
-      return
-    }
-
-    if (isNaN(priceMGA) || priceMGA < 0) {
-      toast.error('Le prix en MGA doit être un nombre positif')
-      return
-    }
-
-    try {
-      const url = editingExtra ? `/api/admin/extras/${editingExtra.id}` : '/api/admin/extras'
-
-      const method = editingExtra ? 'PUT' : 'POST'
-
-      const response = await fetch(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          ...formData,
-          priceEUR,
-          priceMGA,
-        }),
-      })
-
-      if (response.ok) {
-        toast.success(editingExtra ? 'Extra mis à jour avec succès' : 'Extra créé avec succès')
-        setDialogOpen(false)
-        resetForm()
-        fetchExtras()
-      } else {
-        const error = await response.json()
-        toast.error(error.error || 'Une erreur est survenue')
-      }
-    } catch {
-      toast.error('Erreur lors de la sauvegarde')
-    }
-  }
-
-  const handleEdit = (extra: ProductExtra) => {
-    setEditingExtra(extra)
-    setFormData({
-      name: extra.name,
-      description: extra.description || '',
-      priceEUR: extra.priceEUR.toString(),
-      priceMGA: extra.priceMGA.toString(),
-      type: extra.type,
+const adapter: TaxonomyAdapter<ProductExtra, ExtraFormData> = {
+  fetchAll: async () => {
+    const response = await fetch('/api/admin/extras', {
+      cache: 'no-store',
+      headers: { 'Cache-Control': 'no-cache' },
     })
-    setDialogOpen(true)
-  }
-
-  const handleDelete = async (extra: ProductExtra) => {
-    if (!confirm('Êtes-vous sûr de vouloir supprimer cet extra ?')) {
-      return
+    if (!response.ok) throw new Error('Erreur lors du chargement des extras')
+    return response.json()
+  },
+  create: async data => {
+    const response = await fetch('/api/admin/extras', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...data,
+        priceEUR: parseFloat(data.priceEUR),
+        priceMGA: parseFloat(data.priceMGA),
+      }),
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la création')
     }
-
-    try {
-      const response = await fetch(`/api/admin/extras/${extra.id}`, {
-        method: 'DELETE',
-      })
-
-      if (response.ok) {
-        toast.success('Extra supprimé avec succès')
-        fetchExtras()
-      } else {
-        const error = await response.json()
-        toast.error(error.error || 'Erreur lors de la suppression')
-      }
-    } catch {
-      toast.error('Erreur lors de la suppression')
+    return response.json()
+  },
+  update: async (id, data) => {
+    const response = await fetch(`/api/admin/extras/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...data,
+        priceEUR: parseFloat(data.priceEUR),
+        priceMGA: parseFloat(data.priceMGA),
+      }),
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la mise à jour')
     }
-  }
-
-  const resetForm = () => {
-    setFormData({ name: '', description: '', priceEUR: '', priceMGA: '', type: '' })
-    setEditingExtra(null)
-  }
-
-  const handleDialogOpenChange = (open: boolean) => {
-    setDialogOpen(open)
-    if (!open) {
-      resetForm()
+    return response.json()
+  },
+  delete: async id => {
+    const response = await fetch(`/api/admin/extras/${id}`, { method: 'DELETE' })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la suppression')
     }
-  }
+    return true
+  },
+}
 
-  if (loading) {
-    return (
-      <div className='container mx-auto px-4 py-8'>
-        <div className='flex items-center justify-center min-h-[400px]'>
-          <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600'></div>
-        </div>
+const extraColumns: Array<DataTableColumn<ProductExtra>> = [
+  {
+    key: 'price',
+    header: 'Prix',
+    sortable: true,
+    sortAccessor: item => item.priceEUR,
+    align: 'right',
+    render: item => (
+      <div className='space-y-0.5 text-right'>
+        <p className='text-sm font-semibold tabular-nums text-slate-900'>
+          {formatCurrency(item.priceEUR)}
+        </p>
+        <p className='text-xs tabular-nums text-slate-500'>
+          {item.priceMGA.toLocaleString('fr-FR')} Ar
+        </p>
       </div>
-    )
-  }
+    ),
+    cellClassName: 'whitespace-nowrap',
+  },
+  {
+    key: 'type',
+    header: 'Tarification',
+    sortable: true,
+    sortAccessor: item => item.type,
+    render: item => (
+      <span className='inline-flex items-center rounded-full bg-indigo-50 px-2.5 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-indigo-200'>
+        {PRICE_TYPE_LABELS[item.type]}
+      </span>
+    ),
+    cellClassName: 'whitespace-nowrap',
+  },
+]
 
+export default function ExtrasPage() {
   return (
-    <div className='container mx-auto px-4 py-8'>
-      <div className='flex items-center justify-between mb-8'>
-        <div>
-          <h1 className='text-3xl font-bold text-gray-900'>Extras</h1>
-          <p className='text-gray-600 mt-2'>
-            Gérez les options payantes disponibles pour les hébergements
-          </p>
-        </div>
-
-        <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
-          <DialogTrigger asChild>
-            <Button>
-              <Plus className='w-4 h-4 mr-2' />
-              Ajouter un extra
-            </Button>
-          </DialogTrigger>
-          <DialogContent className='max-w-md'>
-            <DialogHeader>
-              <DialogTitle>{editingExtra ? "Modifier l'extra" : 'Ajouter un extra'}</DialogTitle>
-              <DialogDescription>
-                {editingExtra
-                  ? "Modifiez les informations de l'extra"
-                  : 'Créez un nouvel extra payant pour les hébergements'}
-              </DialogDescription>
-            </DialogHeader>
-            <form onSubmit={handleSubmit}>
-              <div className='grid gap-4 py-4'>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='name' className='text-right'>
-                    Nom *
-                  </Label>
-                  <Input
-                    id='name'
-                    value={formData.name}
-                    onChange={e => setFormData({ ...formData, name: e.target.value })}
-                    className='col-span-3'
-                    placeholder='Ex: Petit déjeuner'
-                    required
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='description' className='text-right'>
-                    Description
-                  </Label>
-                  <Input
-                    id='description'
-                    value={formData.description}
-                    onChange={e => setFormData({ ...formData, description: e.target.value })}
-                    className='col-span-3'
-                    placeholder="Description de l'extra (optionnel)"
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='priceEUR' className='text-right'>
-                    Prix EUR *
-                  </Label>
-                  <Input
-                    id='priceEUR'
-                    type='number'
-                    step='0.01'
-                    min='0'
-                    value={formData.priceEUR}
-                    onChange={e => setFormData({ ...formData, priceEUR: e.target.value })}
-                    className='col-span-3'
-                    placeholder='0.00'
-                    required
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='priceMGA' className='text-right'>
-                    Prix MGA *
-                  </Label>
-                  <Input
-                    id='priceMGA'
-                    type='number'
-                    step='1'
-                    min='0'
-                    value={formData.priceMGA}
-                    onChange={e => setFormData({ ...formData, priceMGA: e.target.value })}
-                    className='col-span-3'
-                    placeholder='0'
-                    required
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='type' className='text-right'>
-                    Type *
-                  </Label>
-                  <Select
-                    value={formData.type}
-                    onValueChange={(value: ExtraPriceType) =>
-                      setFormData({ ...formData, type: value })
-                    }
-                    required
-                  >
-                    <SelectTrigger className='col-span-3'>
-                      <SelectValue placeholder='Sélectionner un type' />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Object.entries(PRICE_TYPE_LABELS).map(([value, label]) => (
-                        <SelectItem key={value} value={value}>
-                          {label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-              <DialogFooter>
-                <Button type='submit'>{editingExtra ? 'Mettre à jour' : 'Créer'}</Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
-      </div>
-
-      <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
-        {extras.map(extra => (
-          <Card key={extra.id}>
-            <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-              <div className='flex items-center space-x-2'>
-                <Plus className='w-5 h-5 text-green-600' />
-                <CardTitle className='text-lg'>{extra.name}</CardTitle>
-              </div>
-              <div className='flex space-x-1'>
-                <Button variant='ghost' size='sm' onClick={() => handleEdit(extra)}>
-                  <Edit className='w-4 h-4' />
-                </Button>
-                <Button
-                  variant='ghost'
-                  size='sm'
-                  onClick={() => handleDelete(extra)}
-                  className='text-red-600 hover:text-red-800'
-                >
-                  <Trash2 className='w-4 h-4' />
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent>
-              {extra.description && (
-                <CardDescription className='mb-3'>{extra.description}</CardDescription>
-              )}
-              <div className='space-y-2 mb-3'>
-                <div className='flex justify-between text-sm'>
-                  <span className='font-medium'>Prix EUR:</span>
-                  <span>{extra.priceEUR.toFixed(2)} €</span>
-                </div>
-                <div className='flex justify-between text-sm'>
-                  <span className='font-medium'>Prix MGA:</span>
-                  <span>{extra.priceMGA.toLocaleString()} Ar</span>
-                </div>
-              </div>
-              <div className='flex items-center justify-between'>
-                <Badge variant='secondary'>
-                  {extra._count.products} produit{extra._count.products !== 1 ? 's' : ''}
-                </Badge>
-                <Badge variant='outline'>{PRICE_TYPE_LABELS[extra.type]}</Badge>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      {extras.length === 0 && (
-        <div className='text-center py-12'>
-          <Plus className='w-12 h-12 text-gray-400 mx-auto mb-4' />
-          <h3 className='text-lg font-medium text-gray-900 mb-2'>Aucun extra</h3>
-          <p className='text-gray-500 mb-4'>Commencez par créer votre premier extra payant</p>
-          <Button onClick={() => setDialogOpen(true)}>
-            <Plus className='w-4 h-4 mr-2' />
-            Ajouter un extra
-          </Button>
-        </div>
-      )}
-    </div>
+    <TaxonomyManager<ProductExtra, ExtraFormData>
+      eyebrow='Espace administrateur'
+      eyebrowIcon={Shield}
+      title='Extras payants'
+      subtitle='Gérez les options payantes proposées en supplément sur les hébergements (petit déjeuner, ménage, etc.).'
+      backHref='/admin'
+      backLabel='Retour au panel admin'
+      icon={PlusCircle}
+      kpiTone='orange'
+      itemLabelSingular='extra'
+      itemLabelPlural='extras'
+      searchPlaceholder='Rechercher un extra…'
+      getItemId={item => item.id}
+      getItemName={item => item.name}
+      getItemCount={item => item._count?.products ?? 0}
+      searchMatches={(item, q) =>
+        item.name.toLowerCase().includes(q) ||
+        (item.description?.toLowerCase().includes(q) ?? false)
+      }
+      extraColumns={extraColumns}
+      fields={[
+        {
+          name: 'name',
+          label: 'Nom',
+          type: 'text',
+          required: true,
+          placeholder: 'Ex: Petit déjeuner, Ménage',
+        },
+        {
+          name: 'description',
+          label: 'Description',
+          type: 'textarea',
+          placeholder: "Description de l'extra (optionnel)",
+        },
+        {
+          name: 'priceEUR',
+          label: 'Prix EUR',
+          type: 'number',
+          required: true,
+          step: '0.01',
+          min: '0',
+          placeholder: '0.00',
+        },
+        {
+          name: 'priceMGA',
+          label: 'Prix MGA',
+          type: 'number',
+          required: true,
+          step: '1',
+          min: '0',
+          placeholder: '0',
+        },
+        {
+          name: 'type',
+          label: 'Tarification',
+          type: 'select',
+          required: true,
+          placeholder: 'Sélectionner un type',
+          options: Object.entries(PRICE_TYPE_LABELS).map(([value, label]) => ({
+            value,
+            label,
+          })),
+        },
+      ]}
+      emptyFormData={{
+        name: '',
+        description: '',
+        priceEUR: '',
+        priceMGA: '',
+        type: '',
+      }}
+      toFormData={item => ({
+        name: item.name,
+        description: item.description ?? '',
+        priceEUR: item.priceEUR.toString(),
+        priceMGA: item.priceMGA.toString(),
+        type: item.type,
+      })}
+      validate={data => {
+        if (!data.name.trim()) return 'Le nom est requis'
+        if (!data.type) return 'La tarification est requise'
+        const priceEUR = parseFloat(data.priceEUR)
+        const priceMGA = parseFloat(data.priceMGA)
+        if (isNaN(priceEUR) || priceEUR < 0) {
+          return 'Le prix EUR doit être un nombre positif'
+        }
+        if (isNaN(priceMGA) || priceMGA < 0) {
+          return 'Le prix MGA doit être un nombre positif'
+        }
+        return null
+      }}
+      adapter={adapter}
+    />
   )
 }

--- a/src/app/admin/highlights/page.tsx
+++ b/src/app/admin/highlights/page.tsx
@@ -1,28 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/input'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/shadcnui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import { Plus, Edit, Trash2, Highlighter } from 'lucide-react'
-import { toast } from 'sonner'
+import { Highlighter, Shield } from 'lucide-react'
+import { TaxonomyManager, type TaxonomyAdapter } from '@/components/admin/ui/TaxonomyManager'
+import type { DataTableColumn } from '@/components/admin/ui/DataTable'
 
 interface PropertyHighlight {
   id: string
@@ -36,259 +16,135 @@ interface PropertyHighlight {
   }
 }
 
-export default function HighlightsPage() {
-  const [highlights, setHighlights] = useState<PropertyHighlight[]>([])
-  const [loading, setLoading] = useState(true)
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [editingHighlight, setEditingHighlight] = useState<PropertyHighlight | null>(null)
-  const [formData, setFormData] = useState({
-    name: '',
-    description: '',
-    icon: '',
-  })
+interface HighlightFormData {
+  name: string
+  description: string
+  icon: string
+}
 
-  useEffect(() => {
-    fetchHighlights()
-  }, [])
-
-  const fetchHighlights = async () => {
-    try {
-      const response = await fetch('/api/admin/highlights', {
-        cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      })
-      if (response.ok) {
-        const data = await response.json()
-        setHighlights(data)
-      } else {
-        toast.error('Erreur lors du chargement des points forts')
-      }
-    } catch {
-      toast.error('Erreur lors du chargement des points forts')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    if (!formData.name.trim()) {
-      toast.error('Le nom du point fort est requis')
-      return
-    }
-
-    try {
-      const url = editingHighlight
-        ? `/api/admin/highlights/${editingHighlight.id}`
-        : '/api/admin/highlights'
-
-      const method = editingHighlight ? 'PUT' : 'POST'
-
-      const response = await fetch(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData),
-      })
-
-      if (response.ok) {
-        toast.success(
-          editingHighlight ? 'Point fort mis à jour avec succès' : 'Point fort créé avec succès'
-        )
-        setDialogOpen(false)
-        resetForm()
-        fetchHighlights()
-      } else {
-        const error = await response.json()
-        toast.error(error.error || 'Une erreur est survenue')
-      }
-    } catch {
-      toast.error('Erreur lors de la sauvegarde')
-    }
-  }
-
-  const handleEdit = (highlight: PropertyHighlight) => {
-    setEditingHighlight(highlight)
-    setFormData({
-      name: highlight.name,
-      description: highlight.description || '',
-      icon: highlight.icon || '',
+const adapter: TaxonomyAdapter<PropertyHighlight, HighlightFormData> = {
+  fetchAll: async () => {
+    const response = await fetch('/api/admin/highlights', {
+      cache: 'no-store',
+      headers: { 'Cache-Control': 'no-cache' },
     })
-    setDialogOpen(true)
-  }
-
-  const handleDelete = async (highlight: PropertyHighlight) => {
-    if (!confirm('Êtes-vous sûr de vouloir supprimer ce point fort ?')) {
-      return
+    if (!response.ok) {
+      throw new Error('Erreur lors du chargement des points forts')
     }
-
-    try {
-      const response = await fetch(`/api/admin/highlights/${highlight.id}`, {
-        method: 'DELETE',
-      })
-
-      if (response.ok) {
-        toast.success('Point fort supprimé avec succès')
-        fetchHighlights()
-      } else {
-        const error = await response.json()
-        toast.error(error.error || 'Erreur lors de la suppression')
-      }
-    } catch {
-      toast.error('Erreur lors de la suppression')
+    return response.json()
+  },
+  create: async data => {
+    const response = await fetch('/api/admin/highlights', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la création')
     }
-  }
-
-  const resetForm = () => {
-    setFormData({ name: '', description: '', icon: '' })
-    setEditingHighlight(null)
-  }
-
-  const handleDialogOpenChange = (open: boolean) => {
-    setDialogOpen(open)
-    if (!open) {
-      resetForm()
+    return response.json()
+  },
+  update: async (id, data) => {
+    const response = await fetch(`/api/admin/highlights/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la mise à jour')
     }
-  }
+    return response.json()
+  },
+  delete: async id => {
+    const response = await fetch(`/api/admin/highlights/${id}`, {
+      method: 'DELETE',
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la suppression')
+    }
+    return true
+  },
+}
 
-  if (loading) {
-    return (
-      <div className='container mx-auto px-4 py-8'>
-        <div className='flex items-center justify-center min-h-[400px]'>
-          <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600'></div>
-        </div>
-      </div>
-    )
-  }
+const extraColumns: Array<DataTableColumn<PropertyHighlight>> = [
+  {
+    key: 'description',
+    header: 'Description',
+    render: item => (
+      <p className='line-clamp-2 max-w-md text-sm text-slate-600'>
+        {item.description ?? '—'}
+      </p>
+    ),
+  },
+  {
+    key: 'icon',
+    header: 'Icône',
+    render: item =>
+      item.icon ? (
+        <span className='inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 font-mono text-xs text-slate-600'>
+          {item.icon}
+        </span>
+      ) : (
+        <span className='text-xs text-slate-400'>—</span>
+      ),
+    cellClassName: 'whitespace-nowrap',
+  },
+]
 
+export default function HighlightsPage() {
   return (
-    <div className='container mx-auto px-4 py-8'>
-      <div className='flex items-center justify-between mb-8'>
-        <div>
-          <h1 className='text-3xl font-bold text-gray-900'>Points forts</h1>
-          <p className='text-gray-600 mt-2'>
-            Gérez les points forts disponibles pour valoriser les hébergements
-          </p>
-        </div>
-
-        <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
-          <DialogTrigger asChild>
-            <Button>
-              <Plus className='w-4 h-4 mr-2' />
-              Ajouter un point fort
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                {editingHighlight ? 'Modifier le point fort' : 'Ajouter un point fort'}
-              </DialogTitle>
-              <DialogDescription>
-                {editingHighlight
-                  ? 'Modifiez les informations du point fort'
-                  : 'Créez un nouveau point fort pour valoriser les hébergements'}
-              </DialogDescription>
-            </DialogHeader>
-            <form onSubmit={handleSubmit}>
-              <div className='grid gap-4 py-4'>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='name' className='text-right'>
-                    Nom *
-                  </Label>
-                  <Input
-                    id='name'
-                    value={formData.name}
-                    onChange={e => setFormData({ ...formData, name: e.target.value })}
-                    className='col-span-3'
-                    placeholder='Ex: Spa, Massage, Piscine'
-                    required
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='description' className='text-right'>
-                    Description
-                  </Label>
-                  <Input
-                    id='description'
-                    value={formData.description}
-                    onChange={e => setFormData({ ...formData, description: e.target.value })}
-                    className='col-span-3'
-                    placeholder='Description du point fort (optionnel)'
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='icon' className='text-right'>
-                    Icône
-                  </Label>
-                  <Input
-                    id='icon'
-                    value={formData.icon}
-                    onChange={e => setFormData({ ...formData, icon: e.target.value })}
-                    className='col-span-3'
-                    placeholder="Nom de l'icône Lucide (optionnel)"
-                  />
-                </div>
-              </div>
-              <DialogFooter>
-                <Button type='submit'>{editingHighlight ? 'Mettre à jour' : 'Créer'}</Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
-      </div>
-
-      <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
-        {highlights.map(highlight => (
-          <Card key={highlight.id}>
-            <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-              <div className='flex items-center space-x-2'>
-                <Highlighter className='w-5 h-5 text-yellow-600' />
-                <CardTitle className='text-lg'>{highlight.name}</CardTitle>
-              </div>
-              <div className='flex space-x-1'>
-                <Button variant='ghost' size='sm' onClick={() => handleEdit(highlight)}>
-                  <Edit className='w-4 h-4' />
-                </Button>
-                <Button
-                  variant='ghost'
-                  size='sm'
-                  onClick={() => handleDelete(highlight)}
-                  className='text-red-600 hover:text-red-800'
-                >
-                  <Trash2 className='w-4 h-4' />
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent>
-              {highlight.description && (
-                <CardDescription className='mb-3'>{highlight.description}</CardDescription>
-              )}
-              <div className='flex items-center justify-between'>
-                <Badge variant='secondary'>
-                  {highlight._count.products} produit{highlight._count.products !== 1 ? 's' : ''}
-                </Badge>
-                {highlight.icon && <Badge variant='outline'>Icône: {highlight.icon}</Badge>}
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      {highlights.length === 0 && (
-        <div className='text-center py-12'>
-          <Highlighter className='w-12 h-12 text-gray-400 mx-auto mb-4' />
-          <h3 className='text-lg font-medium text-gray-900 mb-2'>Aucun point fort</h3>
-          <p className='text-gray-500 mb-4'>Commencez par créer votre premier point fort</p>
-          <Button onClick={() => setDialogOpen(true)}>
-            <Plus className='w-4 h-4 mr-2' />
-            Ajouter un point fort
-          </Button>
-        </div>
-      )}
-    </div>
+    <TaxonomyManager<PropertyHighlight, HighlightFormData>
+      eyebrow='Espace administrateur'
+      eyebrowIcon={Shield}
+      title='Points forts'
+      subtitle='Gérez les points forts qui valorisent les hébergements et apparaissent sur les fiches produit.'
+      backHref='/admin'
+      backLabel='Retour au panel admin'
+      icon={Highlighter}
+      kpiTone='amber'
+      itemLabelSingular='point fort'
+      itemLabelPlural='points forts'
+      searchPlaceholder='Rechercher un point fort…'
+      getItemId={item => item.id}
+      getItemName={item => item.name}
+      getItemCount={item => item._count?.products ?? 0}
+      searchMatches={(item, q) =>
+        item.name.toLowerCase().includes(q) ||
+        (item.description?.toLowerCase().includes(q) ?? false)
+      }
+      extraColumns={extraColumns}
+      fields={[
+        {
+          name: 'name',
+          label: 'Nom',
+          type: 'text',
+          required: true,
+          placeholder: 'Ex: Spa, Piscine, Vue panoramique',
+        },
+        {
+          name: 'description',
+          label: 'Description',
+          type: 'textarea',
+          placeholder: 'Description du point fort (optionnel)',
+        },
+        {
+          name: 'icon',
+          label: 'Icône',
+          type: 'text',
+          placeholder: "Nom de l'icône Lucide (optionnel)",
+          help: 'Laisser vide pour utiliser l’icône par défaut.',
+        },
+      ]}
+      emptyFormData={{ name: '', description: '', icon: '' }}
+      toFormData={item => ({
+        name: item.name,
+        description: item.description ?? '',
+        icon: item.icon ?? '',
+      })}
+      adapter={adapter}
+    />
   )
 }

--- a/src/app/admin/included-services/page.tsx
+++ b/src/app/admin/included-services/page.tsx
@@ -1,28 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/input'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/shadcnui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import { Plus, Edit, Trash2, Package } from 'lucide-react'
-import { toast } from 'sonner'
+import { Package, Shield } from 'lucide-react'
+import { TaxonomyManager, type TaxonomyAdapter } from '@/components/admin/ui/TaxonomyManager'
+import type { DataTableColumn } from '@/components/admin/ui/DataTable'
 
 interface IncludedService {
   id: string
@@ -36,259 +16,135 @@ interface IncludedService {
   }
 }
 
-export default function IncludedServicesPage() {
-  const [services, setServices] = useState<IncludedService[]>([])
-  const [loading, setLoading] = useState(true)
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [editingService, setEditingService] = useState<IncludedService | null>(null)
-  const [formData, setFormData] = useState({
-    name: '',
-    description: '',
-    icon: '',
-  })
+interface ServiceFormData {
+  name: string
+  description: string
+  icon: string
+}
 
-  useEffect(() => {
-    fetchServices()
-  }, [])
-
-  const fetchServices = async () => {
-    try {
-      const response = await fetch('/api/admin/included-services', {
-        cache: 'no-store',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      })
-      if (response.ok) {
-        const data = await response.json()
-        setServices(data)
-      } else {
-        toast.error('Erreur lors du chargement des services')
-      }
-    } catch {
-      toast.error('Erreur lors du chargement des services')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    if (!formData.name.trim()) {
-      toast.error('Le nom du service est requis')
-      return
-    }
-
-    try {
-      const url = editingService
-        ? `/api/admin/included-services/${editingService.id}`
-        : '/api/admin/included-services'
-
-      const method = editingService ? 'PUT' : 'POST'
-
-      const response = await fetch(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData),
-      })
-
-      if (response.ok) {
-        toast.success(
-          editingService ? 'Service mis à jour avec succès' : 'Service créé avec succès'
-        )
-        setDialogOpen(false)
-        resetForm()
-        fetchServices()
-      } else {
-        const error = await response.json()
-        toast.error(error.error || 'Une erreur est survenue')
-      }
-    } catch {
-      toast.error('Erreur lors de la sauvegarde')
-    }
-  }
-
-  const handleEdit = (service: IncludedService) => {
-    setEditingService(service)
-    setFormData({
-      name: service.name,
-      description: service.description || '',
-      icon: service.icon || '',
+const adapter: TaxonomyAdapter<IncludedService, ServiceFormData> = {
+  fetchAll: async () => {
+    const response = await fetch('/api/admin/included-services', {
+      cache: 'no-store',
+      headers: { 'Cache-Control': 'no-cache' },
     })
-    setDialogOpen(true)
-  }
-
-  const handleDelete = async (service: IncludedService) => {
-    if (!confirm('Êtes-vous sûr de vouloir supprimer ce service ?')) {
-      return
+    if (!response.ok) {
+      throw new Error('Erreur lors du chargement des services inclus')
     }
-
-    try {
-      const response = await fetch(`/api/admin/included-services/${service.id}`, {
-        method: 'DELETE',
-      })
-
-      if (response.ok) {
-        toast.success('Service supprimé avec succès')
-        fetchServices()
-      } else {
-        const error = await response.json()
-        toast.error(error.error || 'Erreur lors de la suppression')
-      }
-    } catch {
-      toast.error('Erreur lors de la suppression')
+    return response.json()
+  },
+  create: async data => {
+    const response = await fetch('/api/admin/included-services', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la création')
     }
-  }
-
-  const resetForm = () => {
-    setFormData({ name: '', description: '', icon: '' })
-    setEditingService(null)
-  }
-
-  const handleDialogOpenChange = (open: boolean) => {
-    setDialogOpen(open)
-    if (!open) {
-      resetForm()
+    return response.json()
+  },
+  update: async (id, data) => {
+    const response = await fetch(`/api/admin/included-services/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la mise à jour')
     }
-  }
+    return response.json()
+  },
+  delete: async id => {
+    const response = await fetch(`/api/admin/included-services/${id}`, {
+      method: 'DELETE',
+    })
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.error || 'Erreur lors de la suppression')
+    }
+    return true
+  },
+}
 
-  if (loading) {
-    return (
-      <div className='container mx-auto px-4 py-8'>
-        <div className='flex items-center justify-center min-h-[400px]'>
-          <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600'></div>
-        </div>
-      </div>
-    )
-  }
+const extraColumns: Array<DataTableColumn<IncludedService>> = [
+  {
+    key: 'description',
+    header: 'Description',
+    render: item => (
+      <p className='line-clamp-2 max-w-md text-sm text-slate-600'>
+        {item.description ?? '—'}
+      </p>
+    ),
+  },
+  {
+    key: 'icon',
+    header: 'Icône',
+    render: item =>
+      item.icon ? (
+        <span className='inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 font-mono text-xs text-slate-600'>
+          {item.icon}
+        </span>
+      ) : (
+        <span className='text-xs text-slate-400'>—</span>
+      ),
+    cellClassName: 'whitespace-nowrap',
+  },
+]
 
+export default function IncludedServicesPage() {
   return (
-    <div className='container mx-auto px-4 py-8'>
-      <div className='flex items-center justify-between mb-8'>
-        <div>
-          <h1 className='text-3xl font-bold text-gray-900'>Services inclus</h1>
-          <p className='text-gray-600 mt-2'>
-            Gérez les services inclus disponibles pour les hébergements
-          </p>
-        </div>
-
-        <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
-          <DialogTrigger asChild>
-            <Button>
-              <Plus className='w-4 h-4 mr-2' />
-              Ajouter un service
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>
-                {editingService ? 'Modifier le service' : 'Ajouter un service inclus'}
-              </DialogTitle>
-              <DialogDescription>
-                {editingService
-                  ? 'Modifiez les informations du service inclus'
-                  : 'Créez un nouveau service inclus pour les hébergements'}
-              </DialogDescription>
-            </DialogHeader>
-            <form onSubmit={handleSubmit}>
-              <div className='grid gap-4 py-4'>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='name' className='text-right'>
-                    Nom *
-                  </Label>
-                  <Input
-                    id='name'
-                    value={formData.name}
-                    onChange={e => setFormData({ ...formData, name: e.target.value })}
-                    className='col-span-3'
-                    placeholder='Ex: Service de ménage'
-                    required
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='description' className='text-right'>
-                    Description
-                  </Label>
-                  <Input
-                    id='description'
-                    value={formData.description}
-                    onChange={e => setFormData({ ...formData, description: e.target.value })}
-                    className='col-span-3'
-                    placeholder='Description du service (optionnel)'
-                  />
-                </div>
-                <div className='grid grid-cols-4 items-center gap-4'>
-                  <Label htmlFor='icon' className='text-right'>
-                    Icône
-                  </Label>
-                  <Input
-                    id='icon'
-                    value={formData.icon}
-                    onChange={e => setFormData({ ...formData, icon: e.target.value })}
-                    className='col-span-3'
-                    placeholder="Nom de l'icône Lucide (optionnel)"
-                  />
-                </div>
-              </div>
-              <DialogFooter>
-                <Button type='submit'>{editingService ? 'Mettre à jour' : 'Créer'}</Button>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
-      </div>
-
-      <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
-        {services.map(service => (
-          <Card key={service.id}>
-            <CardHeader className='flex flex-row items-center justify-between space-y-0 pb-2'>
-              <div className='flex items-center space-x-2'>
-                <Package className='w-5 h-5 text-blue-600' />
-                <CardTitle className='text-lg'>{service.name}</CardTitle>
-              </div>
-              <div className='flex space-x-1'>
-                <Button variant='ghost' size='sm' onClick={() => handleEdit(service)}>
-                  <Edit className='w-4 h-4' />
-                </Button>
-                <Button
-                  variant='ghost'
-                  size='sm'
-                  onClick={() => handleDelete(service)}
-                  className='text-red-600 hover:text-red-800'
-                >
-                  <Trash2 className='w-4 h-4' />
-                </Button>
-              </div>
-            </CardHeader>
-            <CardContent>
-              {service.description && (
-                <CardDescription className='mb-3'>{service.description}</CardDescription>
-              )}
-              <div className='flex items-center justify-between'>
-                <Badge variant='secondary'>
-                  {service._count.products} produit{service._count.products !== 1 ? 's' : ''}
-                </Badge>
-                {service.icon && <Badge variant='outline'>Icône: {service.icon}</Badge>}
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      {services.length === 0 && (
-        <div className='text-center py-12'>
-          <Package className='w-12 h-12 text-gray-400 mx-auto mb-4' />
-          <h3 className='text-lg font-medium text-gray-900 mb-2'>Aucun service inclus</h3>
-          <p className='text-gray-500 mb-4'>Commencez par créer votre premier service inclus</p>
-          <Button onClick={() => setDialogOpen(true)}>
-            <Plus className='w-4 h-4 mr-2' />
-            Ajouter un service
-          </Button>
-        </div>
-      )}
-    </div>
+    <TaxonomyManager<IncludedService, ServiceFormData>
+      eyebrow='Espace administrateur'
+      eyebrowIcon={Shield}
+      title='Services inclus'
+      subtitle='Gérez les services gratuits inclus dans les hébergements (wifi, parking, etc.).'
+      backHref='/admin'
+      backLabel='Retour au panel admin'
+      icon={Package}
+      kpiTone='emerald'
+      itemLabelSingular='service inclus'
+      itemLabelPlural='services inclus'
+      searchPlaceholder='Rechercher un service…'
+      getItemId={item => item.id}
+      getItemName={item => item.name}
+      getItemCount={item => item._count?.products ?? 0}
+      searchMatches={(item, q) =>
+        item.name.toLowerCase().includes(q) ||
+        (item.description?.toLowerCase().includes(q) ?? false)
+      }
+      extraColumns={extraColumns}
+      fields={[
+        {
+          name: 'name',
+          label: 'Nom',
+          type: 'text',
+          required: true,
+          placeholder: 'Ex: Wifi gratuit, Parking, Climatisation',
+        },
+        {
+          name: 'description',
+          label: 'Description',
+          type: 'textarea',
+          placeholder: 'Description du service (optionnel)',
+        },
+        {
+          name: 'icon',
+          label: 'Icône',
+          type: 'text',
+          placeholder: "Nom de l'icône Lucide (optionnel)",
+          help: 'Laisser vide pour utiliser l’icône par défaut.',
+        },
+      ]}
+      emptyFormData={{ name: '', description: '', icon: '' }}
+      toFormData={item => ({
+        name: item.name,
+        description: item.description ?? '',
+        icon: item.icon ?? '',
+      })}
+      adapter={adapter}
+    />
   )
 }

--- a/src/app/admin/meals/page.tsx
+++ b/src/app/admin/meals/page.tsx
@@ -1,510 +1,67 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
-import { useAuth } from '@/hooks/useAuth'
-import { isAdmin } from '@/hooks/useAdminAuth'
-import Link from 'next/link'
-import { motion, Variants } from 'framer-motion'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/shadcnui/input'
-import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
+import { Soup, Shield } from 'lucide-react'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/shadcnui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import {
-  Loader2,
-  Search,
-  Eye,
-  Soup,
-  Plus,
-  ArrowLeft,
-  CheckCircle,
-  Edit3,
-  Trash2,
-} from 'lucide-react'
-import { SecurityInterface } from '@/lib/interface/securityInterface'
+  createMeal,
+  deleteMeal,
+  findAllMeals,
+  updateMeal,
+} from '@/lib/services/meals.service'
 import { MealsInterface } from '@/lib/interface/mealsInterface'
-import { findAllMeals, createMeal, updateMeal, deleteMeal } from '@/lib/services/meals.service'
+import { TaxonomyManager, type TaxonomyAdapter } from '@/components/admin/ui/TaxonomyManager'
 
-const containerVariants: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
-  },
+interface MealFormData {
+  name: string
 }
 
-const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: 'tween' as const,
-      duration: 0.5,
-      ease: 'easeOut',
-    },
+const adapter: TaxonomyAdapter<MealsInterface, MealFormData> = {
+  fetchAll: async () => {
+    const result = await findAllMeals()
+    return result ?? []
+  },
+  create: async data => {
+    const created = await createMeal(data.name)
+    return created ?? null
+  },
+  update: async (id, data) => {
+    const updated = await updateMeal(id, data.name)
+    return updated ?? null
+  },
+  delete: async id => {
+    const success = await deleteMeal(id)
+    return Boolean(success)
   },
 }
 
 export default function MealsPage() {
-  const {
-    session,
-    isLoading: isAuthLoading,
-    isAuthenticated,
-  } = useAuth({ required: true, redirectTo: '/auth' })
-  const router = useRouter()
-  const [meals, setMeals] = useState<MealsInterface[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState('')
-  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
-  const [newOptionName, setNewOptionName] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
-
-  // États pour l'édition
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
-  const [editingOption, setEditingOption] = useState<MealsInterface | null>(null)
-  const [editOptionName, setEditOptionName] = useState('')
-
-  // États pour la suppression
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
-  const [deletingOption, setDeletingOption] = useState<MealsInterface | null>(null)
-
-  useEffect(() => {
-    if (isAuthenticated && (!session?.user?.roles || !isAdmin(session.user.roles))) {
-      router.push('/')
-    }
-  }, [isAuthenticated, session, router])
-
-  useEffect(() => {
-    const fetchMeals = async () => {
-      try {
-        const mealsData = await findAllMeals()
-        if (mealsData) {
-          setMeals(mealsData)
-        }
-      } catch (err) {
-        setError('Erreur lors du chargement des options de repas')
-        console.error(err)
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchMeals()
-  }, [])
-
-  const filteredMeals = meals.filter((option: SecurityInterface) =>
-    option.name?.toLowerCase().includes(searchTerm.toLowerCase())
-  )
-
-  const handleAddOption = async () => {
-    if (!newOptionName.trim()) return
-
-    setIsSubmitting(true)
-    try {
-      const newOption = await createMeal(newOptionName)
-
-      if (newOption) {
-        setMeals([...meals, newOption])
-        setNewOptionName('')
-        setIsAddDialogOpen(false)
-      } else {
-        setError("Erreur lors de la création de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la création:', err)
-      setError("Erreur lors de la création de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleEditOption = (option: MealsInterface) => {
-    setEditingOption(option)
-    setEditOptionName(option.name || '')
-    setIsEditDialogOpen(true)
-  }
-
-  const handleUpdateOption = async () => {
-    if (!editingOption || !editOptionName.trim()) return
-
-    setIsSubmitting(true)
-    try {
-      const updatedOption = await updateMeal(editingOption.id, editOptionName)
-
-      if (updatedOption) {
-        setMeals(meals.map(opt => (opt.id === editingOption.id ? updatedOption : opt)))
-        setEditOptionName('')
-        setEditingOption(null)
-        setIsEditDialogOpen(false)
-      } else {
-        setError("Erreur lors de la modification de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la modification:', err)
-      setError("Erreur lors de la modification de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleDeleteOption = (option: MealsInterface) => {
-    setDeletingOption(option)
-    setIsDeleteDialogOpen(true)
-  }
-
-  const handleConfirmDelete = async () => {
-    if (!deletingOption) return
-
-    setIsSubmitting(true)
-    try {
-      const success = await deleteMeal(deletingOption.id)
-
-      if (success) {
-        setMeals(meals.filter(opt => opt.id !== deletingOption.id))
-        setDeletingOption(null)
-        setIsDeleteDialogOpen(false)
-      } else {
-        setError("Erreur lors de la suppression de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la suppression:', err)
-      setError("Erreur lors de la suppression de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  if (isAuthLoading || loading) {
-    return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
-        </div>
-      </div>
-    )
-  }
-
-  if (!session) {
-    return null
-  }
-
-  if (error) {
-    return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive'>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        </div>
-      </div>
-    )
-  }
-
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
-      <motion.div
-        className='max-w-7xl mx-auto p-6 space-y-8'
-        variants={containerVariants}
-        initial='hidden'
-        animate='visible'
-      >
-        {/* Header with breadcrumb */}
-        <motion.div variants={itemVariants} className='space-y-4'>
-          <Button variant='ghost' size='sm' asChild className='text-slate-600 hover:text-slate-800'>
-            <Link href='/admin' className='flex items-center gap-2'>
-              <ArrowLeft className='h-4 w-4' />
-              Retour au dashboard
-            </Link>
-          </Button>
-
-          <div className='flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4'>
-            <div>
-              <div className='flex items-center gap-2 mb-2'>
-                <Soup className='h-8 w-8 text-orange-600' />
-                <h1 className='text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-800 via-orange-700 to-red-700'>
-                  Gestion des options de repas
-                </h1>
-              </div>
-              <p className='text-slate-600 text-lg'>
-                {meals.length} option{meals.length > 1 ? 's' : ''} enregistrée
-                {meals.length > 1 ? 's' : ''}
-              </p>
-            </div>
-
-            <div className='flex items-center gap-3'>
-              <div className='relative'>
-                <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4' />
-                <Input
-                  type='text'
-                  placeholder='Rechercher une option...'
-                  value={searchTerm}
-                  onChange={e => setSearchTerm(e.target.value)}
-                  className='pl-10 w-full sm:w-64'
-                />
-              </div>
-
-              <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-                <DialogTrigger asChild>
-                  <Button className='bg-orange-600 hover:bg-orange-700 text-white shadow-lg'>
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter une option
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className='sm:max-w-md'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Soup className='h-5 w-5 text-orange-600' />
-                      Nouvelle option de repas
-                    </DialogTitle>
-                    <DialogDescription>
-                      Ajoutez une nouvelle option de repas à la liste disponible.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='optionName'>Nom de l&apos;option</Label>
-                      <Input
-                        id='optionName'
-                        placeholder='Ex: Petit déjeuner, Déjeuner, Dîner...'
-                        value={newOptionName}
-                        onChange={e => setNewOptionName(e.target.value)}
-                        onKeyDown={e => e.key === 'Enter' && !isSubmitting && handleAddOption()}
-                      />
-                    </div>
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsAddDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleAddOption}
-                      disabled={!newOptionName.trim() || isSubmitting}
-                      className='bg-orange-600 hover:bg-orange-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Création...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Créer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Dialog d'édition */}
-              <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Edit3 className='h-5 w-5 text-orange-600' />
-                      Modifier l&apos;option de repas
-                    </DialogTitle>
-                    <DialogDescription>Modifiez le nom de cette option de repas.</DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='editOptionName'>Nom de l&apos;option</Label>
-                      <Input
-                        id='editOptionName'
-                        placeholder='Ex: Petit déjeuner, Dîner...'
-                        value={editOptionName}
-                        onChange={e => setEditOptionName(e.target.value)}
-                        onKeyDown={e => e.key === 'Enter' && !isSubmitting && handleUpdateOption()}
-                      />
-                    </div>
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsEditDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleUpdateOption}
-                      disabled={!editOptionName.trim() || isSubmitting}
-                      className='bg-orange-600 hover:bg-orange-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Modification...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Modifier
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Dialog de suppression */}
-              <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Trash2 className='h-5 w-5 text-red-600' />
-                      Supprimer l&apos;option de repas
-                    </DialogTitle>
-                    <DialogDescription>
-                      Êtes-vous sûr de vouloir supprimer l&apos;option &quot;{deletingOption?.name}
-                      &quot; ? Cette action est irréversible.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsDeleteDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleConfirmDelete}
-                      disabled={isSubmitting}
-                      variant='destructive'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Suppression...
-                        </>
-                      ) : (
-                        <>
-                          <Trash2 className='h-4 w-4 mr-2' />
-                          Supprimer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-            </div>
-          </div>
-        </motion.div>
-
-        {/* Content */}
-        <motion.div variants={itemVariants}>
-          {filteredMeals.length === 0 ? (
-            <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm'>
-              <CardContent className='text-center py-12'>
-                <Soup className='h-16 w-16 text-slate-300 mx-auto mb-4' />
-                <h3 className='text-xl font-semibold text-slate-600 mb-2'>
-                  {searchTerm ? 'Aucun résultat' : 'Aucune option de repas'}
-                </h3>
-                <p className='text-slate-500 mb-6'>
-                  {searchTerm
-                    ? 'Aucune option ne correspond à votre recherche.'
-                    : 'Commencez par ajouter votre première option de repas.'}
-                </p>
-                {!searchTerm && (
-                  <Button
-                    onClick={() => setIsAddDialogOpen(true)}
-                    className='bg-orange-600 hover:bg-orange-700'
-                  >
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter une option
-                  </Button>
-                )}
-              </CardContent>
-            </Card>
-          ) : (
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 items-stretch'>
-              {filteredMeals.map((option, index) => (
-                <motion.div
-                  key={option.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.05 }}
-                >
-                  <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm hover:shadow-xl transition-all duration-300 group h-full'>
-                    <CardHeader className='pb-3'>
-                      <div className='flex items-start justify-between'>
-                        <div className='flex items-center gap-3'>
-                          <div className='p-2 bg-orange-50 rounded-lg group-hover:bg-orange-100 transition-colors'>
-                            <Soup className='h-5 w-5 text-orange-600' />
-                          </div>
-                          <div>
-                            <CardTitle className='text-lg font-semibold text-slate-800'>
-                              {option.name || 'Option sans nom'}
-                            </CardTitle>
-                          </div>
-                        </div>
-                        <Badge
-                          variant='secondary'
-                          className='bg-green-50 text-green-700 border-green-200'
-                        >
-                          Actif
-                        </Badge>
-                      </div>
-                    </CardHeader>
-                    <CardContent className='pt-0'>
-                      <div className='flex items-center gap-2'>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          asChild
-                          className='flex-1 hover:bg-orange-50 hover:text-orange-600'
-                        >
-                          <Link href={`/admin/meals/${option.id}`}>
-                            <Eye className='h-4 w-4 mr-2' />
-                            Voir détails
-                          </Link>
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-orange-50 hover:text-orange-600'
-                          onClick={() => handleEditOption(option)}
-                        >
-                          <Edit3 className='h-4 w-4' />
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-red-50 hover:text-red-600'
-                          onClick={() => handleDeleteOption(option)}
-                        >
-                          <Trash2 className='h-4 w-4' />
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </motion.div>
-              ))}
-            </div>
-          )}
-        </motion.div>
-      </motion.div>
-    </div>
+    <TaxonomyManager<MealsInterface, MealFormData>
+      eyebrow='Espace administrateur'
+      eyebrowIcon={Shield}
+      title='Options de repas'
+      subtitle='Gérez les formules de repas disponibles dans le catalogue (petit-déjeuner, demi-pension, etc.).'
+      backHref='/admin'
+      backLabel='Retour au panel admin'
+      icon={Soup}
+      kpiTone='amber'
+      itemLabelSingular='option de repas'
+      itemLabelPlural='options de repas'
+      searchPlaceholder='Rechercher une option de repas…'
+      getItemId={item => item.id}
+      getItemName={item => item.name ?? ''}
+      searchMatches={(item, q) => (item.name ?? '').toLowerCase().includes(q)}
+      fields={[
+        {
+          name: 'name',
+          label: 'Nom',
+          type: 'text',
+          required: true,
+          placeholder: 'Ex: Petit-déjeuner, Demi-pension, Pension complète',
+        },
+      ]}
+      emptyFormData={{ name: '' }}
+      toFormData={item => ({ name: item.name ?? '' })}
+      adapter={adapter}
+    />
   )
 }

--- a/src/app/admin/security/page.tsx
+++ b/src/app/admin/security/page.tsx
@@ -1,515 +1,67 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
-import { useAuth } from '@/hooks/useAuth'
-import { isAdmin } from '@/hooks/useAdminAuth'
-import Link from 'next/link'
-import { motion, Variants } from 'framer-motion'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
-import { Button } from '@/components/ui/shadcnui/button'
-import { Input } from '@/components/ui/shadcnui/input'
-import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
+import { ShieldCheck, Shield } from 'lucide-react'
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/shadcnui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import {
-  Loader2,
-  Search,
-  Eye,
-  Cctv,
-  Plus,
-  ArrowLeft,
-  CheckCircle,
-  Edit3,
-  Trash2,
-} from 'lucide-react'
-import {
-  findAllSecurity,
   createSecurity,
-  updateSecurity,
   deleteSecurity,
+  findAllSecurity,
+  updateSecurity,
 } from '@/lib/services/security.services'
 import { SecurityInterface } from '@/lib/interface/securityInterface'
+import { TaxonomyManager, type TaxonomyAdapter } from '@/components/admin/ui/TaxonomyManager'
 
-const containerVariants: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
-  },
+interface SecurityFormData {
+  name: string
 }
 
-const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: 'tween' as const,
-      duration: 0.5,
-      ease: 'easeOut',
-    },
+const adapter: TaxonomyAdapter<SecurityInterface, SecurityFormData> = {
+  fetchAll: async () => {
+    const result = await findAllSecurity()
+    return result ?? []
+  },
+  create: async data => {
+    const created = await createSecurity(data.name)
+    return created ?? null
+  },
+  update: async (id, data) => {
+    const updated = await updateSecurity(id, data.name)
+    return updated ?? null
+  },
+  delete: async id => {
+    const success = await deleteSecurity(id)
+    return Boolean(success)
   },
 }
 
 export default function SecurityPage() {
-  const {
-    session,
-    isLoading: isAuthLoading,
-    isAuthenticated,
-  } = useAuth({ required: true, redirectTo: '/auth' })
-  const router = useRouter()
-  const [security, setSecurity] = useState<SecurityInterface[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [searchTerm, setSearchTerm] = useState('')
-  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
-  const [newOptionName, setNewOptionName] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
-
-  // États pour l'édition
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
-  const [editingOption, setEditingOption] = useState<SecurityInterface | null>(null)
-  const [editOptionName, setEditOptionName] = useState('')
-
-  // États pour la suppression
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
-  const [deletingOption, setDeletingOption] = useState<SecurityInterface | null>(null)
-
-  useEffect(() => {
-    if (isAuthenticated && (!session?.user?.roles || !isAdmin(session.user.roles))) {
-      router.push('/')
-    }
-  }, [isAuthenticated, session, router])
-
-  useEffect(() => {
-    const fetchSecurity = async () => {
-      try {
-        const securityData = await findAllSecurity()
-        if (securityData) {
-          setSecurity(securityData)
-        }
-      } catch (err) {
-        setError('Erreur lors du chargement des options de sécurité')
-        console.error(err)
-      } finally {
-        setLoading(false)
-      }
-    }
-    fetchSecurity()
-  }, [])
-
-  const filteredUsers = security.filter(option =>
-    option.name?.toLowerCase().includes(searchTerm.toLowerCase())
-  )
-
-  const handleAddOption = async () => {
-    if (!newOptionName.trim()) return
-
-    setIsSubmitting(true)
-    try {
-      const newOption = await createSecurity(newOptionName)
-
-      if (newOption) {
-        setSecurity([...security, newOption])
-        setNewOptionName('')
-        setIsAddDialogOpen(false)
-      } else {
-        setError("Erreur lors de la création de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la création:', err)
-      setError("Erreur lors de la création de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleEditOption = (option: SecurityInterface) => {
-    setEditingOption(option)
-    setEditOptionName(option.name || '')
-    setIsEditDialogOpen(true)
-  }
-
-  const handleUpdateOption = async () => {
-    if (!editingOption || !editOptionName.trim()) return
-
-    setIsSubmitting(true)
-    try {
-      const updatedOption = await updateSecurity(editingOption.id, editOptionName)
-
-      if (updatedOption) {
-        setSecurity(security.map(opt => (opt.id === editingOption.id ? updatedOption : opt)))
-        setEditOptionName('')
-        setEditingOption(null)
-        setIsEditDialogOpen(false)
-      } else {
-        setError("Erreur lors de la modification de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la modification:', err)
-      setError("Erreur lors de la modification de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleDeleteOption = (option: SecurityInterface) => {
-    setDeletingOption(option)
-    setIsDeleteDialogOpen(true)
-  }
-
-  const handleConfirmDelete = async () => {
-    if (!deletingOption) return
-
-    setIsSubmitting(true)
-    try {
-      const success = await deleteSecurity(deletingOption.id)
-
-      if (success) {
-        setSecurity(security.filter(opt => opt.id !== deletingOption.id))
-        setDeletingOption(null)
-        setIsDeleteDialogOpen(false)
-      } else {
-        setError("Erreur lors de la suppression de l'option")
-      }
-    } catch (err) {
-      console.error('Erreur lors de la suppression:', err)
-      setError("Erreur lors de la suppression de l'option")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-  if (isAuthLoading || loading) {
-    return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
-        </div>
-      </div>
-    )
-  }
-
-  if (!session) {
-    return null
-  }
-
-  if (error) {
-    return (
-      <div className='min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive'>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        </div>
-      </div>
-    )
-  }
-
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
-      <motion.div
-        className='max-w-7xl mx-auto p-6 space-y-8'
-        variants={containerVariants}
-        initial='hidden'
-        animate='visible'
-      >
-        {/* Header with breadcrumb */}
-        <motion.div variants={itemVariants} className='space-y-4'>
-          <Button variant='ghost' size='sm' asChild className='text-slate-600 hover:text-slate-800'>
-            <Link href='/admin' className='flex items-center gap-2'>
-              <ArrowLeft className='h-4 w-4' />
-              Retour au dashboard
-            </Link>
-          </Button>
-
-          <div className='flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4'>
-            <div>
-              <div className='flex items-center gap-2 mb-2'>
-                <Cctv className='h-8 w-8 text-blue-600' />
-                <h1 className='text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-800 via-blue-700 to-indigo-700'>
-                  Gestion des options de sécurité
-                </h1>
-              </div>
-              <p className='text-slate-600 text-lg'>
-                {security.length} option{security.length > 1 ? 's' : ''} enregistrée
-                {security.length > 1 ? 's' : ''}
-              </p>
-            </div>
-
-            <div className='flex items-center gap-3'>
-              <div className='relative'>
-                <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4' />
-                <Input
-                  type='text'
-                  placeholder='Rechercher une option...'
-                  value={searchTerm}
-                  onChange={e => setSearchTerm(e.target.value)}
-                  className='pl-10 w-full sm:w-64'
-                />
-              </div>
-
-              <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-                <DialogTrigger asChild>
-                  <Button className='bg-blue-600 hover:bg-blue-700 text-white shadow-lg'>
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter une option
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className='sm:max-w-md'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Cctv className='h-5 w-5 text-blue-600' />
-                      Nouvelle option de sécurité
-                    </DialogTitle>
-                    <DialogDescription>
-                      Ajoutez une nouvelle option de sécurité à la liste disponible.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='optionName'>Nom de l&apos;option</Label>
-                      <Input
-                        id='optionName'
-                        placeholder='Ex: Détecteur de fumée, Extincteur...'
-                        value={newOptionName}
-                        onChange={e => setNewOptionName(e.target.value)}
-                        onKeyDown={e => e.key === 'Enter' && !isSubmitting && handleAddOption()}
-                      />
-                    </div>
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsAddDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleAddOption}
-                      disabled={!newOptionName.trim() || isSubmitting}
-                      className='bg-blue-600 hover:bg-blue-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Création...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Créer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Dialog d'édition */}
-              <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Edit3 className='h-5 w-5 text-orange-600' />
-                      Modifier l&apos;option de sécurité
-                    </DialogTitle>
-                    <DialogDescription>
-                      Modifiez le nom de cette option de sécurité.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='editOptionName'>Nom de l&apos;option</Label>
-                      <Input
-                        id='editOptionName'
-                        placeholder='Ex: Détecteur de fumée, Extincteur...'
-                        value={editOptionName}
-                        onChange={e => setEditOptionName(e.target.value)}
-                        onKeyDown={e => e.key === 'Enter' && !isSubmitting && handleUpdateOption()}
-                      />
-                    </div>
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsEditDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleUpdateOption}
-                      disabled={!editOptionName.trim() || isSubmitting}
-                      className='bg-orange-600 hover:bg-orange-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Modification...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Modifier
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Dialog de suppression */}
-              <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Trash2 className='h-5 w-5 text-red-600' />
-                      Supprimer l&apos;option de sécurité
-                    </DialogTitle>
-                    <DialogDescription>
-                      Êtes-vous sûr de vouloir supprimer l&apos;option &quot;{deletingOption?.name}
-                      &quot; ? Cette action est irréversible.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsDeleteDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleConfirmDelete}
-                      disabled={isSubmitting}
-                      variant='destructive'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Suppression...
-                        </>
-                      ) : (
-                        <>
-                          <Trash2 className='h-4 w-4 mr-2' />
-                          Supprimer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-            </div>
-          </div>
-        </motion.div>
-
-        {/* Content */}
-        <motion.div variants={itemVariants}>
-          {filteredUsers.length === 0 ? (
-            <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm'>
-              <CardContent className='text-center py-12'>
-                <Cctv className='h-16 w-16 text-slate-300 mx-auto mb-4' />
-                <h3 className='text-xl font-semibold text-slate-600 mb-2'>
-                  {searchTerm ? 'Aucun résultat' : 'Aucune option de sécurité'}
-                </h3>
-                <p className='text-slate-500 mb-6'>
-                  {searchTerm
-                    ? 'Aucune option ne correspond à votre recherche.'
-                    : 'Commencez par ajouter votre première option de sécurité.'}
-                </p>
-                {!searchTerm && (
-                  <Button
-                    onClick={() => setIsAddDialogOpen(true)}
-                    className='bg-blue-600 hover:bg-blue-700'
-                  >
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter une option
-                  </Button>
-                )}
-              </CardContent>
-            </Card>
-          ) : (
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 items-stretch'>
-              {filteredUsers.map((option, index) => (
-                <motion.div
-                  key={option.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.05 }}
-                >
-                  <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm hover:shadow-xl transition-all duration-300 group h-full'>
-                    <CardHeader className='pb-3'>
-                      <div className='flex items-start justify-between'>
-                        <div className='flex items-center gap-3'>
-                          <div className='p-2 bg-blue-50 rounded-lg group-hover:bg-blue-100 transition-colors'>
-                            <Cctv className='h-5 w-5 text-blue-600' />
-                          </div>
-                          <div>
-                            <CardTitle className='text-lg font-semibold text-slate-800'>
-                              {option.name || 'Option sans nom'}
-                            </CardTitle>
-                          </div>
-                        </div>
-                        <Badge
-                          variant='secondary'
-                          className='bg-green-50 text-green-700 border-green-200'
-                        >
-                          Actif
-                        </Badge>
-                      </div>
-                    </CardHeader>
-                    <CardContent className='pt-0'>
-                      <div className='flex items-center gap-2'>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          asChild
-                          className='flex-1 hover:bg-blue-50 hover:text-blue-600'
-                        >
-                          <Link href={`/admin/security/${option.id}`}>
-                            <Eye className='h-4 w-4 mr-2' />
-                            Voir détails
-                          </Link>
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-orange-50 hover:text-orange-600'
-                          onClick={() => handleEditOption(option)}
-                        >
-                          <Edit3 className='h-4 w-4' />
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-red-50 hover:text-red-600'
-                          onClick={() => handleDeleteOption(option)}
-                        >
-                          <Trash2 className='h-4 w-4' />
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </motion.div>
-              ))}
-            </div>
-          )}
-        </motion.div>
-      </motion.div>
-    </div>
+    <TaxonomyManager<SecurityInterface, SecurityFormData>
+      eyebrow='Espace administrateur'
+      eyebrowIcon={Shield}
+      title='Équipements de sécurité'
+      subtitle='Gérez les équipements de sécurité proposés par les hébergements (détecteur, extincteur, etc.).'
+      backHref='/admin'
+      backLabel='Retour au panel admin'
+      icon={ShieldCheck}
+      kpiTone='red'
+      itemLabelSingular='équipement de sécurité'
+      itemLabelPlural='équipements de sécurité'
+      searchPlaceholder='Rechercher un équipement de sécurité…'
+      getItemId={item => item.id}
+      getItemName={item => item.name ?? ''}
+      searchMatches={(item, q) => (item.name ?? '').toLowerCase().includes(q)}
+      fields={[
+        {
+          name: 'name',
+          label: 'Nom',
+          type: 'text',
+          required: true,
+          placeholder: 'Ex: Détecteur de fumée, Extincteur',
+        },
+      ]}
+      emptyFormData={{ name: '' }}
+      toFormData={item => ({ name: item.name ?? '' })}
+      adapter={adapter}
+    />
   )
 }

--- a/src/app/admin/typeRent/[id]/page.tsx
+++ b/src/app/admin/typeRent/[id]/page.tsx
@@ -2,14 +2,40 @@
 
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState, use } from 'react'
+import { useEffect, useMemo, useState, use } from 'react'
 import Link from 'next/link'
 import { motion } from 'framer-motion'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
+import {
+  Loader2,
+  Home,
+  Hotel,
+  Eye,
+  Edit,
+  Trash2,
+  MapPin,
+  Users,
+  ExternalLink,
+  Shield,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  AlertTriangle,
+  ImageIcon,
+} from 'lucide-react'
+import { ProductValidation } from '@prisma/client'
+
+import { findTypeById, updateTypeRent } from '@/lib/services/typeRent.service'
+import { TypeRentInterface } from '@/lib/interface/typeRentInterface'
+import DeleteTypeModal from '../components/DeleteTypeModal'
+import { toast } from 'sonner'
+
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard } from '@/components/admin/ui/KpiCard'
+import { FilterBar } from '@/components/admin/ui/FilterBar'
+import { DataTable, type DataTableColumn } from '@/components/admin/ui/DataTable'
 import { Button } from '@/components/ui/shadcnui/button'
 import { Input } from '@/components/ui/shadcnui/input'
-import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
-import { Badge } from '@/components/ui/shadcnui/badge'
+import { Label } from '@/components/ui/shadcnui/label'
 import { Checkbox } from '@/components/ui/shadcnui/checkbox'
 import {
   Dialog,
@@ -19,34 +45,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/shadcnui/label'
-import {
-  Loader2,
-  Search,
-  Eye,
-  Home,
-  ArrowLeft,
-  MapPin,
-  Users,
-  Euro,
-  Edit,
-  ExternalLink,
-  Trash2,
-  CheckCircle,
-  Hotel,
-} from 'lucide-react'
-import { findTypeById, updateTypeRent } from '@/lib/services/typeRent.service'
-import { TypeRentInterface } from '@/lib/interface/typeRentInterface'
-import DeleteTypeModal from '../components/DeleteTypeModal'
-import { ProductValidation } from '@prisma/client'
+import { formatCurrency } from '@/lib/utils/formatNumber'
 
-interface Product {
+interface ExtendedProduct {
   id: string
-  title: string | null
-  status: string | null
-}
-
-interface ExtendedProduct extends Product {
   name: string
   address: string
   basePrice: string
@@ -54,24 +56,66 @@ interface ExtendedProduct extends Product {
   validate: string
 }
 
+const VALIDATION_CONFIG: Record<
+  string,
+  { label: string; tone: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  Approve: {
+    label: 'Validé',
+    tone: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    icon: CheckCircle2,
+  },
+  NotVerified: {
+    label: 'En attente',
+    tone: 'bg-amber-50 text-amber-700 ring-amber-200',
+    icon: Clock,
+  },
+  Refused: {
+    label: 'Rejeté',
+    tone: 'bg-red-50 text-red-700 ring-red-200',
+    icon: XCircle,
+  },
+  Recheck: {
+    label: 'À revérifier',
+    tone: 'bg-blue-50 text-blue-700 ring-blue-200',
+    icon: AlertTriangle,
+  },
+}
+
+function ValidationPill({ status }: { status: string }) {
+  const config = VALIDATION_CONFIG[status] ?? {
+    label: status,
+    tone: 'bg-slate-50 text-slate-600 ring-slate-200',
+    icon: Clock,
+  }
+  const Icon = config.icon
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${config.tone}`}
+    >
+      <Icon className='h-3 w-3' />
+      {config.label}
+    </span>
+  )
+}
+
 export default function TypeRentDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)
   const { data: session } = useSession()
   const router = useRouter()
+
   const [typeRent, setTypeRent] = useState<TypeRentInterface | null>(null)
   const [products, setProducts] = useState<ExtendedProduct[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
 
-  // États pour l'édition
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
   const [editTypeName, setEditTypeName] = useState('')
   const [editTypeDescription, setEditTypeDescription] = useState('')
   const [editIsHotelType, setEditIsHotelType] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  // États pour la suppression
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
   const isAdmin = session?.user?.roles === 'ADMIN'
@@ -87,7 +131,6 @@ export default function TypeRentDetailPage({ params }: { params: Promise<{ id: s
 
     const fetchData = async () => {
       try {
-        // Récupérer le type de logement
         const type = await findTypeById(id)
         if (!type) {
           setError('Type de logement introuvable')
@@ -95,7 +138,6 @@ export default function TypeRentDetailPage({ params }: { params: Promise<{ id: s
         }
         setTypeRent(type)
 
-        // Récupérer les produits associés avec plus de détails
         const response = await fetch(`/api/admin/typeRent/${id}/products`)
         if (response.ok) {
           const productsData = await response.json()
@@ -111,13 +153,30 @@ export default function TypeRentDetailPage({ params }: { params: Promise<{ id: s
     fetchData()
   }, [id, isAdmin])
 
+  const filteredProducts = useMemo(() => {
+    const q = searchTerm.trim().toLowerCase()
+    if (!q) return products
+    return products.filter(
+      p =>
+        p.name?.toLowerCase().includes(q) ||
+        p.address?.toLowerCase().includes(q)
+    )
+  }, [products, searchTerm])
+
+  const stats = useMemo(() => {
+    const total = products.length
+    const approved = products.filter(p => p.validate === ProductValidation.Approve).length
+    const pending = products.filter(p => p.validate === ProductValidation.NotVerified).length
+    const refused = products.filter(p => p.validate === ProductValidation.Refused).length
+    return { total, approved, pending, refused }
+  }, [products])
+
   const handleEditType = () => {
-    if (typeRent) {
-      setEditTypeName(typeRent.name || '')
-      setEditTypeDescription(typeRent.description || '')
-      setEditIsHotelType(typeRent.isHotelType || false)
-      setIsEditDialogOpen(true)
-    }
+    if (!typeRent) return
+    setEditTypeName(typeRent.name || '')
+    setEditTypeDescription(typeRent.description || '')
+    setEditIsHotelType(typeRent.isHotelType || false)
+    setIsEditDialogOpen(true)
   }
 
   const handleUpdateType = async () => {
@@ -125,74 +184,105 @@ export default function TypeRentDetailPage({ params }: { params: Promise<{ id: s
 
     setIsSubmitting(true)
     try {
-      const updatedType = await updateTypeRent(
+      const updated = await updateTypeRent(
         typeRent.id,
         editTypeName,
         editTypeDescription,
         editIsHotelType
       )
-
-      if (updatedType) {
-        setTypeRent(updatedType)
+      if (updated) {
+        setTypeRent(updated)
         setIsEditDialogOpen(false)
+        toast.success('Type de logement mis à jour')
       } else {
-        setError('Erreur lors de la modification du type de logement')
+        toast.error('Erreur lors de la modification du type de logement')
       }
     } catch (err) {
       console.error('Erreur lors de la modification:', err)
-      setError('Erreur lors de la modification du type de logement')
+      toast.error('Erreur lors de la modification du type de logement')
     } finally {
       setIsSubmitting(false)
     }
   }
 
-  const handleDeleteSuccess = () => {
-    router.push('/admin/typeRent')
-  }
-
-  const handleDeleteError = (message: string) => {
-    setError(message)
-    setTimeout(() => setError(null), 5000)
-  }
-
-  const filteredProducts = products.filter(
-    product =>
-      product.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      product.address?.toLowerCase().includes(searchTerm.toLowerCase())
-  )
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'Verified':
-        return 'bg-green-50 text-green-700 border-green-200'
-      case 'Rejected':
-        return 'bg-red-50 text-red-700 border-red-200'
-      case 'NotVerified':
-        return 'bg-yellow-50 text-yellow-700 border-yellow-200'
-      default:
-        return 'bg-gray-50 text-gray-700 border-gray-200'
-    }
-  }
-
-  const getStatusLabel = (status: string) => {
-    switch (status) {
-      case 'Verified':
-        return 'Validé'
-      case 'Rejected':
-        return 'Rejeté'
-      case 'NotVerified':
-        return 'En attente'
-      default:
-        return status
-    }
-  }
+  const columns: Array<DataTableColumn<ExtendedProduct>> = [
+    {
+      key: 'name',
+      header: 'Hébergement',
+      sortable: true,
+      sortAccessor: item => (item.name ?? '').toLowerCase(),
+      render: item => (
+        <div className='flex items-center gap-3 min-w-0'>
+          <div className='flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-600'>
+            <Home className='h-4 w-4' />
+          </div>
+          <div className='min-w-0'>
+            <p className='truncate text-sm font-semibold text-slate-900'>
+              {item.name || 'Sans nom'}
+            </p>
+            <p className='flex items-center gap-1 truncate text-xs text-slate-500'>
+              <MapPin className='h-3 w-3 shrink-0' />
+              {item.address || 'Adresse non renseignée'}
+            </p>
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: 'basePrice',
+      header: 'Prix de base',
+      sortable: true,
+      sortAccessor: item => parseFloat(item.basePrice || '0'),
+      align: 'right',
+      render: item => (
+        <p className='text-sm font-semibold tabular-nums text-slate-900'>
+          {formatCurrency(parseFloat(item.basePrice || '0'))}
+        </p>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'capacity',
+      header: 'Capacité',
+      sortable: true,
+      sortAccessor: item => Number(item.maxPeople ?? 0),
+      align: 'right',
+      render: item => (
+        <div className='flex items-center justify-end gap-1 text-sm text-slate-600'>
+          <Users className='h-4 w-4 text-slate-400' />
+          {item.maxPeople ? `${item.maxPeople.toString()} pers.` : '—'}
+        </div>
+      ),
+      cellClassName: 'whitespace-nowrap',
+    },
+    {
+      key: 'validate',
+      header: 'Validation',
+      sortable: true,
+      sortAccessor: item => item.validate,
+      render: item => <ValidationPill status={item.validate} />,
+      cellClassName: 'whitespace-nowrap',
+    },
+  ]
 
   if (loading) {
     return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 p-8 flex items-center justify-center'>
-        <div className='flex items-center gap-3'>
-          <Loader2 className='h-6 w-6 animate-spin text-purple-600' />
-          <p className='text-slate-600 text-lg'>Chargement des données...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
         </div>
       </div>
     )
@@ -200,298 +290,244 @@ export default function TypeRentDetailPage({ params }: { params: Promise<{ id: s
 
   if (error || !typeRent) {
     return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive'>
-            <AlertDescription>{error || 'Type de logement introuvable'}</AlertDescription>
-          </Alert>
-          <Button variant='outline' className='mt-4' asChild>
-            <Link href='/admin/typeRent'>
-              <ArrowLeft className='h-4 w-4 mr-2' />
-              Retour aux types
-            </Link>
-          </Button>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-4xl space-y-8 p-6'>
+          <PageHeader
+            backHref='/admin/typeRent'
+            backLabel='Retour aux types'
+            eyebrow='Espace administrateur'
+            title='Type introuvable'
+            subtitle='Ce type de logement n’existe pas ou a été supprimé.'
+          />
+          <div className='rounded-2xl border border-slate-200/80 bg-white p-12 text-center shadow-sm'>
+            <div className='mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 text-red-600'>
+              <AlertTriangle className='h-8 w-8' />
+            </div>
+            <h2 className='mt-4 text-lg font-bold text-slate-900'>
+              {error || 'Type de logement introuvable'}
+            </h2>
+            <Button className='mt-6' asChild>
+              <Link href='/admin/typeRent'>Retour aux types</Link>
+            </Button>
+          </div>
         </div>
       </div>
     )
   }
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
       <motion.div
-        className='max-w-7xl mx-auto p-6 space-y-8'
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.5 }}
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
       >
-        {/* Header with breadcrumb */}
-        <motion.div
-          className='flex items-center gap-4'
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-        >
-          <Button variant='ghost' size='sm' asChild className='text-slate-600 hover:text-slate-800'>
-            <Link href='/admin/typeRent' className='flex items-center gap-2'>
-              <ArrowLeft className='h-4 w-4' />
-              Retour aux types
-            </Link>
-          </Button>
-        </motion.div>
-
-        {/* Type Info Header */}
-        <motion.div
-          className='bg-white/70 backdrop-blur-sm rounded-2xl p-8 border-0 shadow-lg'
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.1 }}
-        >
-          <div className='flex items-start justify-between'>
-            <div className='space-y-4'>
-              <div className='flex items-center gap-3'>
-                <div className='p-3 bg-purple-100 rounded-xl'>
-                  <Home className='h-8 w-8 text-purple-600' />
-                </div>
-                <div>
-                  <h1 className='text-3xl font-bold text-slate-800'>{typeRent.name}</h1>
-                  <p className='text-slate-600 mt-1'>{typeRent.description}</p>
-                </div>
-              </div>
-              <div className='flex items-center gap-4 flex-wrap'>
-                {typeRent.isHotelType && (
-                  <Badge
-                    variant='secondary'
-                    className='bg-purple-50 text-purple-700 border-purple-200 px-3 py-1'
-                  >
-                    <Hotel className='h-3 w-3 mr-1' />
-                    Type Hôtel
-                  </Badge>
-                )}
-                <Badge variant='secondary' className='bg-blue-50 text-blue-700 px-3 py-1'>
-                  <Home className='h-3 w-3 mr-1' />
-                  {products.length} logement{products.length > 1 ? 's' : ''}
-                </Badge>
-                <Badge variant='secondary' className='bg-green-50 text-green-700 px-3 py-1'>
-                  {products.filter(p => p.validate === ProductValidation.Approve).length} validé
-                  {products.filter(p => p.validate === ProductValidation.Approve).length > 1 ? 's' : ''}
-                </Badge>
-                <Badge variant='secondary' className='bg-yellow-50 text-yellow-700 px-3 py-1'>
-                  {products.filter(p => p.validate === ProductValidation.NotVerified).length} en attente
-                </Badge>
-              </div>
-            </div>
-            <div className='flex gap-2'>
-              <Button variant='outline' onClick={handleEditType}>
-                <Edit className='h-4 w-4 mr-2' />
+        <PageHeader
+          backHref='/admin/typeRent'
+          backLabel='Retour aux types'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title={typeRent.name || 'Type sans nom'}
+          subtitle={typeRent.description || 'Aucune description'}
+          actions={
+            <div className='flex flex-wrap items-center gap-2'>
+              {typeRent.isHotelType && (
+                <span className='inline-flex items-center gap-1 rounded-full bg-purple-50 px-3 py-1 text-xs font-semibold text-purple-700 ring-1 ring-purple-200'>
+                  <Hotel className='h-3 w-3' />
+                  Type hôtel
+                </span>
+              )}
+              {typeRent.coverImage && (
+                <span className='inline-flex items-center gap-1 rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700 ring-1 ring-emerald-200'>
+                  <ImageIcon className='h-3 w-3' />
+                  Image définie
+                </span>
+              )}
+              <Button variant='outline' onClick={handleEditType} className='gap-2'>
+                <Edit className='h-4 w-4' />
                 Modifier
               </Button>
               <Button
                 variant='outline'
-                className='hover:bg-red-50 hover:text-red-600 hover:border-red-200'
                 onClick={() => setIsDeleteModalOpen(true)}
+                className='gap-2 border-red-200 text-red-700 hover:bg-red-50 hover:text-red-700'
               >
-                <Trash2 className='h-4 w-4 mr-2' />
+                <Trash2 className='h-4 w-4' />
                 Supprimer
               </Button>
             </div>
-          </div>
-        </motion.div>
+          }
+        />
 
-        {/* Search bar */}
-        <motion.div
-          className='bg-white/70 backdrop-blur-sm rounded-2xl p-6 border-0 shadow-lg'
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.2 }}
-        >
-          <div className='relative'>
-            <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4' />
-            <Input
-              placeholder='Rechercher un logement par nom ou adresse...'
-              value={searchTerm}
-              onChange={e => setSearchTerm(e.target.value)}
-              className='pl-10 border-slate-200 focus:border-purple-300 focus:ring-purple-200'
-            />
-          </div>
-        </motion.div>
+        {/* KPI row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Hébergements'
+            value={stats.total}
+            hint='utilisant ce type'
+            icon={Home}
+            tone='purple'
+          />
+          <KpiCard
+            label='Validés'
+            value={stats.approved}
+            hint={`sur ${stats.total}`}
+            icon={CheckCircle2}
+            tone='emerald'
+          />
+          <KpiCard
+            label='En attente'
+            value={stats.pending}
+            hint='à valider'
+            icon={Clock}
+            tone='amber'
+          />
+          <KpiCard
+            label='Rejetés'
+            value={stats.refused}
+            hint='non publiés'
+            icon={XCircle}
+            tone='red'
+          />
+        </div>
 
-        {/* Products Grid */}
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.3 }}>
-          {filteredProducts.length === 0 ? (
-            <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm'>
-              <CardContent className='text-center py-12'>
-                <Home className='h-16 w-16 text-slate-300 mx-auto mb-4' />
-                <h3 className='text-xl font-semibold text-slate-600 mb-2'>
-                  {searchTerm ? 'Aucun résultat' : 'Aucun logement'}
-                </h3>
-                <p className='text-slate-500'>
-                  {searchTerm
-                    ? 'Aucun logement ne correspond à votre recherche.'
-                    : `Aucun logement n'utilise ce type "${typeRent.name}".`}
-                </p>
-              </CardContent>
-            </Card>
-          ) : (
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3'>
-              {filteredProducts.map((product, index) => (
-                <motion.div
-                  key={product.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.3 + index * 0.05 }}
+        {/* Search */}
+        <FilterBar
+          searchValue={searchTerm}
+          onSearchChange={setSearchTerm}
+          searchPlaceholder='Rechercher un hébergement par nom ou adresse…'
+        />
+
+        {/* Products table */}
+        <DataTable<ExtendedProduct>
+          columns={columns}
+          rows={filteredProducts}
+          getRowId={item => item.id}
+          loading={false}
+          rowActions={item => (
+            <div className='flex items-center justify-end gap-1'>
+              <Button variant='ghost' size='sm' asChild>
+                <Link
+                  href={`/admin/products/${item.id}`}
+                  className='gap-1 text-slate-600 hover:text-slate-900'
                 >
-                  <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm hover:shadow-xl transition-all duration-300 group h-full'>
-                    <CardHeader className='pb-3'>
-                      <div className='flex items-start justify-between mb-2'>
-                        <CardTitle className='text-lg font-semibold text-slate-800 line-clamp-1'>
-                          {product.name || 'Sans nom'}
-                        </CardTitle>
-                        <Badge className={getStatusColor(product.validate)}>
-                          {getStatusLabel(product.validate)}
-                        </Badge>
-                      </div>
-                      <div className='space-y-2 text-sm text-slate-600'>
-                        <div className='flex items-center gap-2'>
-                          <MapPin className='h-4 w-4 text-slate-400' />
-                          <span className='line-clamp-1'>
-                            {product.address || 'Adresse non renseignée'}
-                          </span>
-                        </div>
-                        <div className='flex items-center gap-4'>
-                          <div className='flex items-center gap-1'>
-                            <Euro className='h-4 w-4 text-slate-400' />
-                            <span className='font-medium'>{product.basePrice || '0'}</span>
-                          </div>
-                          {product.maxPeople && (
-                            <div className='flex items-center gap-1'>
-                              <Users className='h-4 w-4 text-slate-400' />
-                              <span>{product.maxPeople.toString()} pers.</span>
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </CardHeader>
-                    <CardContent className='pt-0'>
-                      <div className='flex items-center gap-2'>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          asChild
-                          className='flex-1 hover:bg-purple-50 hover:text-purple-600'
-                        >
-                          <Link href={`/admin/products/${product.id}`}>
-                            <Eye className='h-4 w-4 mr-2' />
-                            Voir détails
-                          </Link>
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          asChild
-                          className='hover:bg-blue-50 hover:text-blue-600'
-                        >
-                          <Link href={`/host/${product.id}`} target='_blank'>
-                            <ExternalLink className='h-4 w-4' />
-                          </Link>
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </motion.div>
-              ))}
+                  <Eye className='h-4 w-4' />
+                  Détails
+                </Link>
+              </Button>
+              <Button
+                variant='ghost'
+                size='sm'
+                asChild
+                className='text-slate-600 hover:text-blue-600'
+              >
+                <Link href={`/host/${item.id}`} target='_blank'>
+                  <ExternalLink className='h-4 w-4' />
+                </Link>
+              </Button>
             </div>
           )}
-        </motion.div>
-
-        {/* Dialog d'édition */}
-        <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-          <DialogContent className='sm:max-w-[425px]'>
-            <DialogHeader>
-              <DialogTitle className='flex items-center gap-2'>
-                <Edit className='h-5 w-5 text-orange-600' />
-                Modifier le type de logement
-              </DialogTitle>
-              <DialogDescription>
-                Modifiez les informations de ce type de logement.
-              </DialogDescription>
-            </DialogHeader>
-            <div className='space-y-4 py-4'>
-              <div className='space-y-2'>
-                <Label htmlFor='editTypeName'>Nom du type</Label>
-                <Input
-                  id='editTypeName'
-                  placeholder='Ex: Villa, Appartement, Maison...'
-                  value={editTypeName}
-                  onChange={e => setEditTypeName(e.target.value)}
-                />
-              </div>
-              <div className='space-y-2'>
-                <Label htmlFor='editTypeDescription'>Description</Label>
-                <Input
-                  id='editTypeDescription'
-                  placeholder='Description du type de logement...'
-                  value={editTypeDescription}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setEditTypeDescription(e.target.value)
-                  }
-                />
-              </div>
-              <div className='flex items-center space-x-2 pt-2'>
-                <Checkbox
-                  id='editIsHotelType'
-                  checked={editIsHotelType}
-                  onCheckedChange={checked => setEditIsHotelType(checked as boolean)}
-                />
-                <Label
-                  htmlFor='editIsHotelType'
-                  className='text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer'
-                >
-                  <div className='flex items-center gap-2'>
-                    <Hotel className='h-4 w-4 text-orange-600' />
-                    <span>Fonctionne comme un hôtel (gestion multi-chambres)</span>
-                  </div>
-                </Label>
-              </div>
-            </div>
-            <DialogFooter>
-              <Button
-                variant='outline'
-                onClick={() => setIsEditDialogOpen(false)}
-                disabled={isSubmitting}
-              >
-                Annuler
-              </Button>
-              <Button
-                onClick={handleUpdateType}
-                disabled={!editTypeName.trim() || !editTypeDescription.trim() || isSubmitting}
-                className='bg-orange-600 hover:bg-orange-700'
-              >
-                {isSubmitting ? (
-                  <>
-                    <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                    Modification...
-                  </>
-                ) : (
-                  <>
-                    <CheckCircle className='h-4 w-4 mr-2' />
-                    Modifier
-                  </>
-                )}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-
-        {/* Modal de suppression */}
-        <DeleteTypeModal
-          isOpen={isDeleteModalOpen}
-          onClose={() => {
-            setIsDeleteModalOpen(false)
+          emptyState={{
+            icon: Home,
+            title: searchTerm ? 'Aucun résultat' : 'Aucun hébergement',
+            subtitle: searchTerm
+              ? 'Essayez d’ajuster votre recherche.'
+              : `Aucun hébergement n'utilise ce type.`,
           }}
-          typeToDelete={typeRent}
-          onDeleteSuccess={handleDeleteSuccess}
-          onError={handleDeleteError}
         />
       </motion.div>
+
+      {/* Edit dialog */}
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent className='sm:max-w-[520px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 ring-1 ring-blue-100'>
+                <Edit className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>Modifier le type de logement</DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  Mettez à jour les informations de ce type.
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <div className='space-y-4 py-2'>
+            <div className='space-y-1.5'>
+              <Label htmlFor='editTypeName'>
+                Nom <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='editTypeName'
+                value={editTypeName}
+                onChange={e => setEditTypeName(e.target.value)}
+              />
+            </div>
+            <div className='space-y-1.5'>
+              <Label htmlFor='editTypeDescription'>
+                Description <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='editTypeDescription'
+                value={editTypeDescription}
+                onChange={e => setEditTypeDescription(e.target.value)}
+              />
+            </div>
+            <div className='flex items-start gap-3 rounded-xl border border-slate-200 bg-slate-50/60 p-3'>
+              <Checkbox
+                id='editIsHotelType'
+                checked={editIsHotelType}
+                onCheckedChange={checked => setEditIsHotelType(checked === true)}
+              />
+              <Label htmlFor='editIsHotelType' className='cursor-pointer space-y-0.5'>
+                <span className='flex items-center gap-1.5 text-sm font-medium text-slate-900'>
+                  <Hotel className='h-4 w-4 text-purple-600' />
+                  Fonctionne comme un hôtel
+                </span>
+                <span className='text-xs text-slate-500'>
+                  Active la gestion multi-chambres pour ce type.
+                </span>
+              </Label>
+            </div>
+          </div>
+
+          <DialogFooter className='gap-2'>
+            <Button
+              variant='outline'
+              onClick={() => setIsEditDialogOpen(false)}
+              disabled={isSubmitting}
+            >
+              Annuler
+            </Button>
+            <Button
+              onClick={handleUpdateType}
+              disabled={!editTypeName.trim() || !editTypeDescription.trim() || isSubmitting}
+              className='gap-2'
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Mise à jour…
+                </>
+              ) : (
+                'Mettre à jour'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete modal — redirects back to the list on success */}
+      <DeleteTypeModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        typeToDelete={typeRent}
+        onDeleteSuccess={() => router.push('/admin/typeRent')}
+        onError={message => toast.error(message)}
+      />
     </div>
   )
 }

--- a/src/app/admin/typeRent/page.tsx
+++ b/src/app/admin/typeRent/page.tsx
@@ -1,15 +1,38 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+import {
+  Home,
+  Hotel,
+  Plus,
+  Eye,
+  Edit,
+  Trash2,
+  Shield,
+  Loader2,
+  ImageIcon,
+  CheckCircle2,
+} from 'lucide-react'
+
 import { useAuth } from '@/hooks/useAuth'
 import { isAdmin } from '@/hooks/useAdminAuth'
-import Link from 'next/link'
-import { motion, Variants } from 'framer-motion'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/shadcnui/card'
+import { findAllTypeRent, createTypeRent, updateTypeRent } from '@/lib/services/typeRent.service'
+import { TypeRentInterface } from '@/lib/interface/typeRentInterface'
+import DeleteTypeModal from './components/DeleteTypeModal'
+import ImageUpload from './components/ImageUpload'
+
+import { PageHeader } from '@/components/admin/ui/PageHeader'
+import { KpiCard } from '@/components/admin/ui/KpiCard'
+import { FilterBar } from '@/components/admin/ui/FilterBar'
+import { DataTable, type DataTableColumn } from '@/components/admin/ui/DataTable'
 import { Button } from '@/components/ui/shadcnui/button'
 import { Input } from '@/components/ui/shadcnui/input'
-import { Alert, AlertDescription } from '@/components/ui/shadcnui/alert'
+import { Label } from '@/components/ui/shadcnui/label'
+import { Checkbox } from '@/components/ui/shadcnui/checkbox'
 import {
   Dialog,
   DialogContent,
@@ -17,49 +40,10 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/shadcnui/dialog'
-import { Label } from '@/components/ui/shadcnui/label'
-import { Badge } from '@/components/ui/shadcnui/badge'
-import { Checkbox } from '@/components/ui/shadcnui/checkbox'
-import {
-  Loader2,
-  Search,
-  Eye,
-  Home,
-  Plus,
-  ArrowLeft,
-  CheckCircle,
-  Edit3,
-  Trash2,
-  Hotel,
-} from 'lucide-react'
-import { findAllTypeRent, createTypeRent, updateTypeRent } from '@/lib/services/typeRent.service'
-import { TypeRentInterface } from '@/lib/interface/typeRentInterface'
-import DeleteTypeModal from './components/DeleteTypeModal'
-import ImageUpload from './components/ImageUpload'
 
-const containerVariants: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.1,
-    },
-  },
-}
-
-const itemVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      type: 'tween' as const,
-      duration: 0.5,
-      ease: 'easeOut',
-    },
-  },
+interface TypeRentWithCount extends TypeRentInterface {
+  _count?: { products: number }
 }
 
 export default function TypeRentPage() {
@@ -69,10 +53,12 @@ export default function TypeRentPage() {
     isAuthenticated,
   } = useAuth({ required: true, redirectTo: '/auth' })
   const router = useRouter()
-  const [typeRents, setTypeRents] = useState<TypeRentInterface[]>([])
+
+  const [typeRents, setTypeRents] = useState<TypeRentWithCount[]>([])
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
+
+  // Add dialog state
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
   const [newTypeName, setNewTypeName] = useState('')
   const [newTypeDescription, setNewTypeDescription] = useState('')
@@ -80,15 +66,15 @@ export default function TypeRentPage() {
   const [newCoverImage, setNewCoverImage] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  // États pour l'édition
+  // Edit dialog state
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
-  const [editingType, setEditingType] = useState<TypeRentInterface | null>(null)
+  const [editingType, setEditingType] = useState<TypeRentWithCount | null>(null)
   const [editTypeName, setEditTypeName] = useState('')
   const [editTypeDescription, setEditTypeDescription] = useState('')
   const [editIsHotelType, setEditIsHotelType] = useState(false)
   const [editCoverImage, setEditCoverImage] = useState<string | null>(null)
 
-  // États pour la suppression
+  // Delete modal state
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [deletingType, setDeletingType] = useState<TypeRentInterface | null>(null)
 
@@ -101,13 +87,10 @@ export default function TypeRentPage() {
   useEffect(() => {
     const fetchTypeRents = async () => {
       try {
-        const typeRentData = await findAllTypeRent()
-        if (typeRentData) {
-          setTypeRents(typeRentData)
-        }
-      } catch (err) {
-        setError('Erreur lors du chargement des types de logements')
-        console.error(err)
+        const data = await findAllTypeRent()
+        if (data) setTypeRents(data as TypeRentWithCount[])
+      } catch (error) {
+        console.error('Erreur lors du chargement des types:', error)
       } finally {
         setLoading(false)
       }
@@ -115,11 +98,33 @@ export default function TypeRentPage() {
     fetchTypeRents()
   }, [])
 
-  const filteredTypes = typeRents.filter(
-    type =>
-      type.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      type.description?.toLowerCase().includes(searchTerm.toLowerCase())
-  )
+  const filteredTypes = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase()
+    if (!query) return typeRents
+    return typeRents.filter(
+      type =>
+        type.name?.toLowerCase().includes(query) ||
+        type.description?.toLowerCase().includes(query)
+    )
+  }, [typeRents, searchTerm])
+
+  const stats = useMemo(() => {
+    const total = typeRents.length
+    const hotelCount = typeRents.filter(t => t.isHotelType).length
+    const withImage = typeRents.filter(t => Boolean(t.coverImage)).length
+    const totalUsages = typeRents.reduce(
+      (sum, t) => sum + (t._count?.products ?? 0),
+      0
+    )
+    return { total, hotelCount, withImage, totalUsages }
+  }, [typeRents])
+
+  const resetNewForm = () => {
+    setNewTypeName('')
+    setNewTypeDescription('')
+    setNewIsHotelType(false)
+    setNewCoverImage(null)
+  }
 
   const handleAddType = async () => {
     if (!newTypeName.trim() || !newTypeDescription.trim()) return
@@ -132,26 +137,19 @@ export default function TypeRentPage() {
         newIsHotelType,
         newCoverImage || undefined
       )
-
       if (newType) {
-        setTypeRents([...typeRents, newType])
-        setNewTypeName('')
-        setNewTypeDescription('')
-        setNewIsHotelType(false)
-        setNewCoverImage(null)
+        setTypeRents(prev => [...prev, newType as TypeRentWithCount])
+        resetNewForm()
         setIsAddDialogOpen(false)
-      } else {
-        setError('Erreur lors de la création du type de logement')
       }
-    } catch (err) {
-      console.error('Erreur lors de la création:', err)
-      setError('Erreur lors de la création du type de logement')
+    } catch (error) {
+      console.error('Erreur lors de la création:', error)
     } finally {
       setIsSubmitting(false)
     }
   }
 
-  const handleEditType = (type: TypeRentInterface) => {
+  const handleEditType = (type: TypeRentWithCount) => {
     setEditingType(type)
     setEditTypeName(type.name || '')
     setEditTypeDescription(type.description || '')
@@ -165,418 +163,447 @@ export default function TypeRentPage() {
 
     setIsSubmitting(true)
     try {
-      const updatedType = await updateTypeRent(
+      const updated = await updateTypeRent(
         editingType.id,
         editTypeName,
         editTypeDescription,
         editIsHotelType,
         editCoverImage
       )
-
-      if (updatedType) {
-        setTypeRents(typeRents.map(type => (type.id === editingType.id ? updatedType : type)))
-        setEditTypeName('')
-        setEditTypeDescription('')
-        setEditIsHotelType(false)
-        setEditCoverImage(null)
+      if (updated) {
+        setTypeRents(prev =>
+          prev.map(t =>
+            t.id === editingType.id ? ({ ...updated, _count: t._count } as TypeRentWithCount) : t
+          )
+        )
         setEditingType(null)
         setIsEditDialogOpen(false)
-      } else {
-        setError('Erreur lors de la modification du type de logement')
       }
-    } catch (err) {
-      console.error('Erreur lors de la modification:', err)
-      setError('Erreur lors de la modification du type de logement')
+    } catch (error) {
+      console.error('Erreur lors de la modification:', error)
     } finally {
       setIsSubmitting(false)
     }
   }
 
-  const handleDeleteType = (type: TypeRentInterface) => {
+  const handleDeleteType = (type: TypeRentWithCount) => {
     setDeletingType(type)
     setIsDeleteModalOpen(true)
   }
 
   const handleDeleteSuccess = (typeId: string) => {
-    setTypeRents(typeRents.filter(type => type.id !== typeId))
+    setTypeRents(prev => prev.filter(t => t.id !== typeId))
     setDeletingType(null)
     setIsDeleteModalOpen(false)
   }
 
-  const handleDeleteError = (message: string) => {
-    setError(message)
-    setTimeout(() => setError(null), 5000)
-  }
+  const columns: Array<DataTableColumn<TypeRentWithCount>> = [
+    {
+      key: 'name',
+      header: 'Type de logement',
+      sortable: true,
+      sortAccessor: item => (item.name ?? '').toLowerCase(),
+      render: item => (
+        <div className='flex items-center gap-3 min-w-0'>
+          <div className='relative flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-gradient-to-br from-purple-500 to-indigo-500 text-white shadow-sm'>
+            {item.coverImage ? (
+              <Image
+                src={item.coverImage}
+                alt={item.name || 'Type'}
+                fill
+                className='object-cover'
+                sizes='44px'
+                unoptimized
+              />
+            ) : (
+              <Home className='h-5 w-5' />
+            )}
+          </div>
+          <div className='min-w-0'>
+            <p className='truncate text-sm font-semibold text-slate-900'>
+              {item.name || 'Type sans nom'}
+            </p>
+            <p className='truncate text-xs text-slate-500'>
+              {item.description || 'Aucune description'}
+            </p>
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: 'flags',
+      header: 'Caractéristiques',
+      render: item => (
+        <div className='flex flex-wrap items-center gap-1.5'>
+          {item.isHotelType && (
+            <span className='inline-flex items-center gap-1 rounded-full bg-purple-50 px-2 py-0.5 text-xs font-semibold text-purple-700 ring-1 ring-purple-200'>
+              <Hotel className='h-3 w-3' />
+              Hôtel
+            </span>
+          )}
+          {item.coverImage ? (
+            <span className='inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-700 ring-1 ring-emerald-200'>
+              <ImageIcon className='h-3 w-3' />
+              Image
+            </span>
+          ) : (
+            <span className='inline-flex items-center rounded-full bg-slate-50 px-2 py-0.5 text-xs font-semibold text-slate-500 ring-1 ring-slate-200'>
+              Sans image
+            </span>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'count',
+      header: 'Produits',
+      sortable: true,
+      sortAccessor: item => item._count?.products ?? 0,
+      align: 'right',
+      render: item => {
+        const count = item._count?.products ?? 0
+        return (
+          <span
+            className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${
+              count > 0
+                ? 'bg-blue-50 text-blue-700 ring-blue-200'
+                : 'bg-slate-50 text-slate-600 ring-slate-200'
+            }`}
+          >
+            {count} produit{count > 1 ? 's' : ''}
+          </span>
+        )
+      },
+      cellClassName: 'whitespace-nowrap',
+    },
+  ]
 
   if (isAuthLoading || loading) {
     return (
-      <div className='min-h-screen flex items-center justify-center'>
-        <div className='flex flex-col items-center gap-4'>
-          <div className='w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin'></div>
-          <p className='text-slate-600 text-lg'>Chargement...</p>
+      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+        <div className='mx-auto max-w-7xl space-y-8 p-6'>
+          <div className='space-y-3'>
+            <div className='h-4 w-40 animate-pulse rounded bg-slate-200' />
+            <div className='h-10 w-80 animate-pulse rounded bg-slate-200' />
+            <div className='h-4 w-96 animate-pulse rounded bg-slate-200' />
+          </div>
+          <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+            {[0, 1, 2, 3].map(i => (
+              <div
+                key={i}
+                className='h-32 animate-pulse rounded-2xl border border-slate-200/80 bg-white'
+              />
+            ))}
+          </div>
+          <div className='h-96 animate-pulse rounded-2xl border border-slate-200/80 bg-white' />
         </div>
       </div>
     )
   }
 
-  if (!session) {
-    return null
-  }
-
-  if (error) {
-    return (
-      <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 p-8'>
-        <div className='max-w-7xl mx-auto'>
-          <Alert variant='destructive'>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        </div>
-      </div>
-    )
-  }
+  if (!session) return null
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50'>
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
       <motion.div
-        className='max-w-7xl mx-auto p-6 space-y-8'
-        variants={containerVariants}
-        initial='hidden'
-        animate='visible'
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
       >
-        {/* Header with breadcrumb */}
-        <motion.div className='flex items-center gap-4' variants={itemVariants}>
-          <Button variant='ghost' size='sm' asChild className='text-slate-600 hover:text-slate-800'>
-            <Link href='/admin' className='flex items-center gap-2'>
-              <ArrowLeft className='h-4 w-4' />
-              Retour au panel admin
-            </Link>
-          </Button>
-        </motion.div>
+        <PageHeader
+          backHref='/admin'
+          backLabel='Retour au panel admin'
+          eyebrow='Espace administrateur'
+          eyebrowIcon={Shield}
+          title='Types de logements'
+          subtitle='Gérez les catégories d’hébergements disponibles sur la plateforme (villa, appartement, hôtel, etc.).'
+          actions={
+            <Button onClick={() => setIsAddDialogOpen(true)} className='gap-2'>
+              <Plus className='h-4 w-4' />
+              Ajouter un type
+            </Button>
+          }
+        />
 
-        {/* Page Header */}
-        <motion.div className='text-center space-y-4' variants={itemVariants}>
-          <div className='inline-flex items-center gap-2 px-4 py-2 bg-purple-100 text-purple-700 rounded-full text-sm font-medium'>
-            <Home className='h-4 w-4' />
-            Types de Logements
-          </div>
-          <h1 className='text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-slate-800 via-purple-700 to-indigo-700'>
-            Gestion des types de logements
-          </h1>
-          <p className='text-slate-600 max-w-2xl mx-auto text-lg'>
-            {typeRents.length} type{typeRents.length > 1 ? 's' : ''} de logement
-            {typeRents.length > 1 ? 's' : ''} enregistré{typeRents.length > 1 ? 's' : ''}
-          </p>
-        </motion.div>
+        {/* KPI row */}
+        <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <KpiCard
+            label='Types enregistrés'
+            value={stats.total}
+            hint='dans le catalogue'
+            icon={Home}
+            tone='purple'
+          />
+          <KpiCard
+            label='Types hôteliers'
+            value={stats.hotelCount}
+            hint='gestion multi-chambres'
+            icon={Hotel}
+            tone='indigo'
+          />
+          <KpiCard
+            label='Avec image'
+            value={stats.withImage}
+            hint={`sur ${stats.total} au total`}
+            icon={ImageIcon}
+            tone='emerald'
+          />
+          <KpiCard
+            label='Produits catégorisés'
+            value={stats.totalUsages}
+            hint='hébergements concernés'
+            icon={CheckCircle2}
+            tone='blue'
+          />
+        </div>
 
-        {/* Search and Add */}
-        <motion.div variants={itemVariants}>
-          <div className='flex flex-col sm:flex-row gap-4 items-center justify-between bg-white/70 backdrop-blur-sm rounded-2xl p-6 border-0 shadow-lg'>
-            <div className='relative flex-1 max-w-md'>
-              <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4' />
-              <Input
-                placeholder='Rechercher un type de logement...'
-                value={searchTerm}
-                onChange={e => setSearchTerm(e.target.value)}
-                className='pl-10 border-slate-200 focus:border-purple-300 focus:ring-purple-200'
-              />
-            </div>
-            <div className='flex gap-3'>
-              <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-                <DialogTrigger asChild>
-                  <Button className='bg-purple-600 hover:bg-purple-700 text-white shadow-lg'>
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter un type
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Home className='h-5 w-5 text-purple-600' />
-                      Ajouter un type de logement
-                    </DialogTitle>
-                    <DialogDescription>
-                      Créez un nouveau type de logement pour votre plateforme.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='typeName'>Nom du type</Label>
-                      <Input
-                        id='typeName'
-                        placeholder='Ex: Villa, Appartement, Maison...'
-                        value={newTypeName}
-                        onChange={e => setNewTypeName(e.target.value)}
-                      />
-                    </div>
-                    <div className='space-y-2'>
-                      <Label htmlFor='typeDescription'>Description</Label>
-                      <Input
-                        id='typeDescription'
-                        placeholder='Description du type de logement...'
-                        value={newTypeDescription}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                          setNewTypeDescription(e.target.value)
-                        }
-                      />
-                    </div>
-                    <ImageUpload
-                      currentImage={newCoverImage}
-                      onImageChange={setNewCoverImage}
-                      entityType='type-rent'
-                    />
-                    <div className='flex items-center space-x-2 pt-2'>
-                      <Checkbox
-                        id='isHotelType'
-                        checked={newIsHotelType}
-                        onCheckedChange={checked => setNewIsHotelType(checked as boolean)}
-                      />
-                      <Label
-                        htmlFor='isHotelType'
-                        className='text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer'
-                      >
-                        <div className='flex items-center gap-2'>
-                          <Hotel className='h-4 w-4 text-purple-600' />
-                          <span>Fonctionne comme un hôtel (gestion multi-chambres)</span>
-                        </div>
-                      </Label>
-                    </div>
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsAddDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleAddType}
-                      disabled={!newTypeName.trim() || !newTypeDescription.trim() || isSubmitting}
-                      className='bg-purple-600 hover:bg-purple-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Création...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Créer
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
+        {/* Search */}
+        <FilterBar
+          searchValue={searchTerm}
+          onSearchChange={setSearchTerm}
+          searchPlaceholder='Rechercher un type de logement…'
+        />
 
-              {/* Dialog d'édition */}
-              <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-                <DialogContent className='sm:max-w-[425px]'>
-                  <DialogHeader>
-                    <DialogTitle className='flex items-center gap-2'>
-                      <Edit3 className='h-5 w-5 text-orange-600' />
-                      Modifier le type de logement
-                    </DialogTitle>
-                    <DialogDescription>
-                      Modifiez les informations de ce type de logement.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <div className='space-y-4 py-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='editTypeName'>Nom du type</Label>
-                      <Input
-                        id='editTypeName'
-                        placeholder='Ex: Villa, Appartement, Maison...'
-                        value={editTypeName}
-                        onChange={e => setEditTypeName(e.target.value)}
-                      />
-                    </div>
-                    <div className='space-y-2'>
-                      <Label htmlFor='editTypeDescription'>Description</Label>
-                      <Input
-                        id='editTypeDescription'
-                        placeholder='Description du type de logement...'
-                        value={editTypeDescription}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                          setEditTypeDescription(e.target.value)
-                        }
-                      />
-                    </div>
-                    <ImageUpload
-                      currentImage={editCoverImage}
-                      onImageChange={setEditCoverImage}
-                      entityType='type-rent'
-                      entityId={editingType?.id}
-                    />
-                    <div className='flex items-center space-x-2 pt-2'>
-                      <Checkbox
-                        id='editIsHotelType'
-                        checked={editIsHotelType}
-                        onCheckedChange={checked => setEditIsHotelType(checked as boolean)}
-                      />
-                      <Label
-                        htmlFor='editIsHotelType'
-                        className='text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer'
-                      >
-                        <div className='flex items-center gap-2'>
-                          <Hotel className='h-4 w-4 text-orange-600' />
-                          <span>Fonctionne comme un hôtel (gestion multi-chambres)</span>
-                        </div>
-                      </Label>
-                    </div>
-                  </div>
-                  <DialogFooter>
-                    <Button
-                      variant='outline'
-                      onClick={() => setIsEditDialogOpen(false)}
-                      disabled={isSubmitting}
-                    >
-                      Annuler
-                    </Button>
-                    <Button
-                      onClick={handleUpdateType}
-                      disabled={!editTypeName.trim() || !editTypeDescription.trim() || isSubmitting}
-                      className='bg-orange-600 hover:bg-orange-700'
-                    >
-                      {isSubmitting ? (
-                        <>
-                          <Loader2 className='h-4 w-4 mr-2 animate-spin' />
-                          Modification...
-                        </>
-                      ) : (
-                        <>
-                          <CheckCircle className='h-4 w-4 mr-2' />
-                          Modifier
-                        </>
-                      )}
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              {/* Modal de suppression améliorée */}
-              <DeleteTypeModal
-                isOpen={isDeleteModalOpen}
-                onClose={() => {
-                  setIsDeleteModalOpen(false)
-                  setDeletingType(null)
-                }}
-                typeToDelete={deletingType}
-                onDeleteSuccess={handleDeleteSuccess}
-                onError={handleDeleteError}
-              />
-            </div>
-          </div>
-        </motion.div>
-
-        {/* Content */}
-        <motion.div variants={itemVariants}>
-          {filteredTypes.length === 0 ? (
-            <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm'>
-              <CardContent className='text-center py-12'>
-                <Home className='h-16 w-16 text-slate-300 mx-auto mb-4' />
-                <h3 className='text-xl font-semibold text-slate-600 mb-2'>
-                  {searchTerm ? 'Aucun résultat' : 'Aucun type de logement'}
-                </h3>
-                <p className='text-slate-500 mb-6'>
-                  {searchTerm
-                    ? 'Aucun type ne correspond à votre recherche.'
-                    : 'Commencez par ajouter votre premier type de logement.'}
-                </p>
-                {!searchTerm && (
-                  <Button
-                    onClick={() => setIsAddDialogOpen(true)}
-                    className='bg-purple-600 hover:bg-purple-700'
-                  >
-                    <Plus className='h-4 w-4 mr-2' />
-                    Ajouter un type
-                  </Button>
-                )}
-              </CardContent>
-            </Card>
-          ) : (
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-3 items-stretch'>
-              {filteredTypes.map((type, index) => (
-                <motion.div
-                  key={type.id}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: index * 0.05 }}
+        {/* Table */}
+        <DataTable<TypeRentWithCount>
+          columns={columns}
+          rows={filteredTypes}
+          getRowId={item => item.id}
+          loading={loading}
+          rowActions={item => (
+            <div className='flex items-center justify-end gap-1'>
+              <Button variant='ghost' size='sm' asChild>
+                <Link
+                  href={`/admin/typeRent/${item.id}`}
+                  className='gap-1 text-slate-600 hover:text-slate-900'
                 >
-                  <Card className='border-0 shadow-lg bg-white/70 backdrop-blur-sm hover:shadow-xl transition-all duration-300 group h-full'>
-                    <CardHeader className='pb-3'>
-                      <div className='flex items-start justify-between'>
-                        <div className='flex items-center gap-3'>
-                          <div className='p-2 bg-purple-50 rounded-lg group-hover:bg-purple-100 transition-colors'>
-                            <Home className='h-5 w-5 text-purple-600' />
-                          </div>
-                          <div>
-                            <CardTitle className='text-lg font-semibold text-slate-800'>
-                              {type.name || 'Type sans nom'}
-                            </CardTitle>
-                          </div>
-                        </div>
-                        <div className='flex gap-1'>
-                          {type.isHotelType && (
-                            <Badge
-                              variant='secondary'
-                              className='bg-purple-50 text-purple-700 border-purple-200 flex items-center gap-1'
-                            >
-                              <Hotel className='h-3 w-3' />
-                              Hôtel
-                            </Badge>
-                          )}
-                          <Badge
-                            variant='secondary'
-                            className='bg-green-50 text-green-700 border-green-200'
-                          >
-                            Actif
-                          </Badge>
-                        </div>
-                      </div>
-                    </CardHeader>
-                    <CardContent className='pt-0'>
-                      <p className='text-slate-600 text-sm mb-4 line-clamp-2'>
-                        {type.description || 'Aucune description'}
-                      </p>
-                      <div className='flex items-center gap-2'>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          asChild
-                          className='flex-1 hover:bg-purple-50 hover:text-purple-600'
-                        >
-                          <Link href={`/admin/typeRent/${type.id}`}>
-                            <Eye className='h-4 w-4 mr-2' />
-                            Voir logements
-                          </Link>
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-orange-50 hover:text-orange-600'
-                          onClick={() => handleEditType(type)}
-                        >
-                          <Edit3 className='h-4 w-4' />
-                        </Button>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='hover:bg-red-50 hover:text-red-600'
-                          onClick={() => handleDeleteType(type)}
-                        >
-                          <Trash2 className='h-4 w-4' />
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </motion.div>
-              ))}
+                  <Eye className='h-4 w-4' />
+                  Voir
+                </Link>
+              </Button>
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={() => handleEditType(item)}
+                className='text-slate-600 hover:text-slate-900'
+              >
+                <Edit className='h-4 w-4' />
+              </Button>
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={() => handleDeleteType(item)}
+                className='text-red-600 hover:bg-red-50 hover:text-red-700'
+              >
+                <Trash2 className='h-4 w-4' />
+              </Button>
             </div>
           )}
-        </motion.div>
+          emptyState={{
+            icon: Home,
+            title: searchTerm ? 'Aucun résultat' : 'Aucun type de logement',
+            subtitle: searchTerm
+              ? 'Essayez d’ajuster votre recherche.'
+              : 'Commencez par ajouter votre premier type de logement.',
+          }}
+        />
       </motion.div>
+
+      {/* Add dialog */}
+      <Dialog
+        open={isAddDialogOpen}
+        onOpenChange={open => {
+          setIsAddDialogOpen(open)
+          if (!open) resetNewForm()
+        }}
+      >
+        <DialogContent className='sm:max-w-[520px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-purple-50 text-purple-600 ring-1 ring-purple-100'>
+                <Home className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>Ajouter un type de logement</DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  Créez un nouveau type de logement pour votre plateforme.
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <div className='space-y-4 py-2'>
+            <div className='space-y-1.5'>
+              <Label htmlFor='typeName'>
+                Nom <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='typeName'
+                placeholder='Ex: Villa, Appartement, Hôtel'
+                value={newTypeName}
+                onChange={e => setNewTypeName(e.target.value)}
+              />
+            </div>
+            <div className='space-y-1.5'>
+              <Label htmlFor='typeDescription'>
+                Description <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='typeDescription'
+                placeholder='Description du type de logement…'
+                value={newTypeDescription}
+                onChange={e => setNewTypeDescription(e.target.value)}
+              />
+            </div>
+            <ImageUpload
+              currentImage={newCoverImage}
+              onImageChange={setNewCoverImage}
+              entityType='type-rent'
+            />
+            <div className='flex items-start gap-3 rounded-xl border border-slate-200 bg-slate-50/60 p-3'>
+              <Checkbox
+                id='isHotelType'
+                checked={newIsHotelType}
+                onCheckedChange={checked => setNewIsHotelType(checked === true)}
+              />
+              <Label htmlFor='isHotelType' className='cursor-pointer space-y-0.5'>
+                <span className='flex items-center gap-1.5 text-sm font-medium text-slate-900'>
+                  <Hotel className='h-4 w-4 text-purple-600' />
+                  Fonctionne comme un hôtel
+                </span>
+                <span className='text-xs text-slate-500'>
+                  Active la gestion multi-chambres pour ce type.
+                </span>
+              </Label>
+            </div>
+          </div>
+
+          <DialogFooter className='gap-2'>
+            <Button
+              variant='outline'
+              onClick={() => setIsAddDialogOpen(false)}
+              disabled={isSubmitting}
+            >
+              Annuler
+            </Button>
+            <Button
+              onClick={handleAddType}
+              disabled={!newTypeName.trim() || !newTypeDescription.trim() || isSubmitting}
+              className='gap-2'
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Création…
+                </>
+              ) : (
+                'Créer'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit dialog */}
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent className='sm:max-w-[520px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 ring-1 ring-blue-100'>
+                <Edit className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>Modifier le type de logement</DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  Mettez à jour les informations de ce type.
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <div className='space-y-4 py-2'>
+            <div className='space-y-1.5'>
+              <Label htmlFor='editTypeName'>
+                Nom <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='editTypeName'
+                value={editTypeName}
+                onChange={e => setEditTypeName(e.target.value)}
+              />
+            </div>
+            <div className='space-y-1.5'>
+              <Label htmlFor='editTypeDescription'>
+                Description <span className='text-red-500'>*</span>
+              </Label>
+              <Input
+                id='editTypeDescription'
+                value={editTypeDescription}
+                onChange={e => setEditTypeDescription(e.target.value)}
+              />
+            </div>
+            <ImageUpload
+              currentImage={editCoverImage}
+              onImageChange={setEditCoverImage}
+              entityType='type-rent'
+              entityId={editingType?.id}
+            />
+            <div className='flex items-start gap-3 rounded-xl border border-slate-200 bg-slate-50/60 p-3'>
+              <Checkbox
+                id='editIsHotelType'
+                checked={editIsHotelType}
+                onCheckedChange={checked => setEditIsHotelType(checked === true)}
+              />
+              <Label htmlFor='editIsHotelType' className='cursor-pointer space-y-0.5'>
+                <span className='flex items-center gap-1.5 text-sm font-medium text-slate-900'>
+                  <Hotel className='h-4 w-4 text-purple-600' />
+                  Fonctionne comme un hôtel
+                </span>
+                <span className='text-xs text-slate-500'>
+                  Active la gestion multi-chambres pour ce type.
+                </span>
+              </Label>
+            </div>
+          </div>
+
+          <DialogFooter className='gap-2'>
+            <Button
+              variant='outline'
+              onClick={() => setIsEditDialogOpen(false)}
+              disabled={isSubmitting}
+            >
+              Annuler
+            </Button>
+            <Button
+              onClick={handleUpdateType}
+              disabled={!editTypeName.trim() || !editTypeDescription.trim() || isSubmitting}
+              className='gap-2'
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Mise à jour…
+                </>
+              ) : (
+                'Mettre à jour'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete modal (specialised — checks for associated products) */}
+      <DeleteTypeModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => {
+          setIsDeleteModalOpen(false)
+          setDeletingType(null)
+        }}
+        typeToDelete={deletingType}
+        onDeleteSuccess={handleDeleteSuccess}
+        onError={message => console.error(message)}
+      />
     </div>
   )
 }

--- a/src/components/admin/ui/TaxonomyManager.tsx
+++ b/src/components/admin/ui/TaxonomyManager.tsx
@@ -1,0 +1,627 @@
+'use client'
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { motion } from 'framer-motion'
+import { LucideIcon, Plus, Edit, Trash2, Loader2, AlertTriangle } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { PageHeader } from './PageHeader'
+import { KpiCard, type KpiTone } from './KpiCard'
+import { FilterBar } from './FilterBar'
+import { DataTable, type DataTableColumn } from './DataTable'
+import { Button } from '@/components/ui/shadcnui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/shadcnui/dialog'
+import { Input } from '@/components/ui/shadcnui/input'
+import { Label } from '@/components/ui/shadcnui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+/**
+ * Data adapter for a taxonomy entity. Provides the four CRUD operations.
+ * Implementations may wrap REST fetch calls or direct service function calls.
+ */
+export interface TaxonomyAdapter<T, FormData> {
+  fetchAll: () => Promise<T[]>
+  create: (data: FormData) => Promise<T | null>
+  update: (id: string, data: FormData) => Promise<T | null>
+  /** Delete the item. Return true on success. Throw an Error with a readable message on failure. */
+  delete: (id: string) => Promise<boolean>
+}
+
+type FieldType = 'text' | 'textarea' | 'number' | 'select'
+
+/**
+ * Describes a single form field in the add/edit dialog.
+ */
+export interface TaxonomyField<FormData> {
+  name: keyof FormData & string
+  label: string
+  type: FieldType
+  required?: boolean
+  placeholder?: string
+  help?: string
+  /** Required when `type === 'select'`. */
+  options?: Array<{ value: string; label: string }>
+  /** Applied to <input type="number">. */
+  step?: string
+  min?: string
+}
+
+export interface TaxonomyManagerProps<T, FormData extends object> {
+  /** PageHeader eyebrow pill (e.g. "Espace administrateur"). */
+  eyebrow?: string
+  eyebrowIcon?: LucideIcon
+  /** Main page title. */
+  title: string
+  subtitle?: string
+  backHref?: string
+  backLabel?: string
+
+  /** Lucide icon representing this taxonomy. Used in KPIs and empty state. */
+  icon: LucideIcon
+  /** Optional color tone for the primary KPI. */
+  kpiTone?: KpiTone
+
+  /** Singular French label used in labels/toasts (e.g. "un point fort"). */
+  itemLabelSingular: string
+  /** Plural French label used in KPI hints (e.g. "points forts"). */
+  itemLabelPlural: string
+
+  /** Placeholder for the search input. */
+  searchPlaceholder?: string
+  /** Extracts a stable id from an item (used by DataTable). */
+  getItemId: (item: T) => string
+  /** Returns the display name (used in dialogs and delete confirmation). */
+  getItemName: (item: T) => string
+  /** Returns the "number of products using this" count. Return `undefined` if not applicable. */
+  getItemCount?: (item: T) => number
+  /** Returns true if the item matches the given lowercased query. */
+  searchMatches: (item: T, queryLower: string) => boolean
+
+  /** Columns to render in addition to the mandatory "Nom" column (which is auto-rendered). */
+  extraColumns?: Array<DataTableColumn<T>>
+
+  /** Form field definitions — determine what appears in the add/edit dialog. */
+  fields: Array<TaxonomyField<FormData>>
+  /** Empty form data used when opening "add" dialog and after reset. */
+  emptyFormData: FormData
+  /** Converts an item to form data when opening the "edit" dialog. */
+  toFormData: (item: T) => FormData
+  /** Custom client-side validation. Return an error message to block submit, or null to pass. */
+  validate?: (formData: FormData) => string | null
+
+  /** Data adapter backing this taxonomy. */
+  adapter: TaxonomyAdapter<T, FormData>
+}
+
+/**
+ * Generic, reusable CRUD manager for admin taxonomy pages.
+ *
+ * Provides PageHeader, KPI summary, search + DataTable, add/edit dialog, and a
+ * delete confirmation dialog. Specialises per-page via the `fields`, `adapter`,
+ * and `extraColumns` props.
+ */
+export function TaxonomyManager<T, FormData extends object>(
+  props: TaxonomyManagerProps<T, FormData>
+) {
+  const {
+    eyebrow,
+    eyebrowIcon,
+    title,
+    subtitle,
+    backHref,
+    backLabel,
+    icon: Icon,
+    kpiTone = 'blue',
+    itemLabelSingular,
+    itemLabelPlural,
+    searchPlaceholder,
+    getItemId,
+    getItemName,
+    getItemCount,
+    searchMatches,
+    extraColumns = [],
+    fields,
+    emptyFormData,
+    toFormData,
+    validate,
+    adapter,
+  } = props
+
+  const [items, setItems] = useState<T[]>([])
+  const [loading, setLoading] = useState(true)
+  const [searchValue, setSearchValue] = useState('')
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingItem, setEditingItem] = useState<T | null>(null)
+  const [formData, setFormData] = useState<FormData>(emptyFormData)
+  const [submitting, setSubmitting] = useState(false)
+
+  const [deleteTarget, setDeleteTarget] = useState<T | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  const fetchItems = useCallback(async () => {
+    try {
+      setLoading(true)
+      const result = await adapter.fetchAll()
+      setItems(result ?? [])
+    } catch (error) {
+      console.error(`Erreur lors du chargement des ${itemLabelPlural}:`, error)
+      toast.error(`Erreur lors du chargement des ${itemLabelPlural}`)
+    } finally {
+      setLoading(false)
+    }
+    // adapter is expected to be stable; itemLabelPlural is a primitive string
+  }, [adapter, itemLabelPlural])
+
+  useEffect(() => {
+    fetchItems()
+  }, [fetchItems])
+
+  const filteredItems = useMemo(() => {
+    const query = searchValue.trim().toLowerCase()
+    if (!query) return items
+    return items.filter(item => searchMatches(item, query))
+  }, [items, searchValue, searchMatches])
+
+  const stats = useMemo(() => {
+    const total = items.length
+    if (!getItemCount) return { total, inUse: 0, unused: 0, totalUsages: 0 }
+    let inUse = 0
+    let totalUsages = 0
+    for (const item of items) {
+      const count = getItemCount(item) ?? 0
+      totalUsages += count
+      if (count > 0) inUse += 1
+    }
+    return { total, inUse, unused: total - inUse, totalUsages }
+  }, [items, getItemCount])
+
+  const openAddDialog = () => {
+    setEditingItem(null)
+    setFormData(emptyFormData)
+    setDialogOpen(true)
+  }
+
+  const openEditDialog = (item: T) => {
+    setEditingItem(item)
+    setFormData(toFormData(item))
+    setDialogOpen(true)
+  }
+
+  const closeDialog = () => {
+    if (submitting) return
+    setDialogOpen(false)
+    setEditingItem(null)
+    setFormData(emptyFormData)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (validate) {
+      const error = validate(formData)
+      if (error) {
+        toast.error(error)
+        return
+      }
+    } else {
+      // Default: require every `required` field to be non-empty
+      for (const field of fields) {
+        if (field.required) {
+          const value = formData[field.name]
+          if (value === undefined || value === null || String(value).trim() === '') {
+            toast.error(`${field.label} est requis`)
+            return
+          }
+        }
+      }
+    }
+
+    try {
+      setSubmitting(true)
+      if (editingItem) {
+        const updated = await adapter.update(getItemId(editingItem), formData)
+        if (!updated) {
+          toast.error('Erreur lors de la mise à jour')
+          return
+        }
+        toast.success(`${capitalize(itemLabelSingular)} mis à jour`)
+      } else {
+        const created = await adapter.create(formData)
+        if (!created) {
+          toast.error('Erreur lors de la création')
+          return
+        }
+        toast.success(`${capitalize(itemLabelSingular)} créé`)
+      }
+      setDialogOpen(false)
+      setEditingItem(null)
+      setFormData(emptyFormData)
+      // Refetch to pick up derived fields such as `_count.products`.
+      await fetchItems()
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Erreur lors de la sauvegarde'
+      toast.error(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return
+    try {
+      setDeleting(true)
+      const success = await adapter.delete(getItemId(deleteTarget))
+      if (!success) {
+        toast.error('Erreur lors de la suppression')
+        return
+      }
+      toast.success(`${capitalize(itemLabelSingular)} supprimé`)
+      setDeleteTarget(null)
+      await fetchItems()
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Erreur lors de la suppression'
+      toast.error(message)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  const nameColumn: DataTableColumn<T> = {
+    key: 'name',
+    header: 'Nom',
+    sortable: true,
+    sortAccessor: item => getItemName(item).toLowerCase(),
+    render: item => (
+      <div className='flex items-center gap-3 min-w-0'>
+        <div className='flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-600'>
+          <Icon className='h-4 w-4' />
+        </div>
+        <p className='truncate text-sm font-semibold text-slate-900'>
+          {getItemName(item)}
+        </p>
+      </div>
+    ),
+  }
+
+  const countColumn: DataTableColumn<T> | null = getItemCount
+    ? {
+        key: 'count',
+        header: 'Utilisations',
+        sortable: true,
+        sortAccessor: item => getItemCount(item) ?? 0,
+        align: 'right',
+        render: item => {
+          const count = getItemCount(item) ?? 0
+          return (
+            <span
+              className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${
+                count > 0
+                  ? 'bg-blue-50 text-blue-700 ring-blue-200'
+                  : 'bg-slate-50 text-slate-600 ring-slate-200'
+              }`}
+            >
+              {count} produit{count > 1 ? 's' : ''}
+            </span>
+          )
+        },
+        cellClassName: 'whitespace-nowrap',
+      }
+    : null
+
+  const columns: Array<DataTableColumn<T>> = [
+    nameColumn,
+    ...extraColumns,
+    ...(countColumn ? [countColumn] : []),
+  ]
+
+  return (
+    <div className='min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40'>
+      <motion.div
+        className='mx-auto max-w-7xl space-y-8 p-6'
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <PageHeader
+          backHref={backHref}
+          backLabel={backLabel}
+          eyebrow={eyebrow}
+          eyebrowIcon={eyebrowIcon}
+          title={title}
+          subtitle={subtitle}
+          actions={
+            <Button onClick={openAddDialog} className='gap-2'>
+              <Plus className='h-4 w-4' />
+              Ajouter
+            </Button>
+          }
+        />
+
+        {/* KPI row */}
+        <div
+          className={`grid gap-4 ${
+            getItemCount ? 'md:grid-cols-2 lg:grid-cols-3' : 'md:grid-cols-2'
+          }`}
+        >
+          <KpiCard
+            label={`Total ${itemLabelPlural}`}
+            value={stats.total}
+            hint='enregistrés dans le catalogue'
+            icon={Icon}
+            tone={kpiTone}
+            loading={loading}
+          />
+          {getItemCount && (
+            <>
+              <KpiCard
+                label='Utilisés'
+                value={stats.inUse}
+                hint={`sur ${stats.total} au total`}
+                icon={Icon}
+                tone='emerald'
+                loading={loading}
+              />
+              <KpiCard
+                label='Associations totales'
+                value={stats.totalUsages}
+                hint={`produit${stats.totalUsages > 1 ? 's' : ''} concerné${stats.totalUsages > 1 ? 's' : ''}`}
+                icon={Icon}
+                tone='indigo'
+                loading={loading}
+              />
+            </>
+          )}
+          {!getItemCount && (
+            <KpiCard
+              label='Affichés'
+              value={filteredItems.length}
+              hint='après filtres'
+              icon={Icon}
+              tone='indigo'
+              loading={loading}
+            />
+          )}
+        </div>
+
+        {/* Search */}
+        <FilterBar
+          searchValue={searchValue}
+          onSearchChange={setSearchValue}
+          searchPlaceholder={searchPlaceholder ?? `Rechercher un ${itemLabelSingular}…`}
+        />
+
+        {/* Data table */}
+        <DataTable<T>
+          columns={columns}
+          rows={filteredItems}
+          getRowId={getItemId}
+          loading={loading}
+          rowActions={item => (
+            <div className='flex items-center justify-end gap-1'>
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={() => openEditDialog(item)}
+                className='text-slate-600 hover:text-slate-900'
+              >
+                <Edit className='h-4 w-4' />
+              </Button>
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={() => setDeleteTarget(item)}
+                className='text-red-600 hover:bg-red-50 hover:text-red-700'
+              >
+                <Trash2 className='h-4 w-4' />
+              </Button>
+            </div>
+          )}
+          emptyState={{
+            icon: Icon,
+            title: `Aucun ${itemLabelSingular}`,
+            subtitle:
+              searchValue.trim().length > 0
+                ? 'Essayez d’ajuster votre recherche.'
+                : `Commencez par ajouter votre premier ${itemLabelSingular}.`,
+          }}
+        />
+      </motion.div>
+
+      {/* Add / edit dialog */}
+      <Dialog open={dialogOpen} onOpenChange={open => !open && closeDialog()}>
+        <DialogContent className='sm:max-w-[520px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-600 ring-1 ring-blue-100'>
+                <Icon className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>
+                  {editingItem ? 'Modifier' : 'Ajouter'} {itemLabelSingular}
+                </DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  {editingItem
+                    ? `Mettez à jour les informations de ${itemLabelSingular}.`
+                    : `Créez ${itemLabelSingular} pour le catalogue.`}
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <form onSubmit={handleSubmit} className='space-y-4 py-2'>
+            {fields.map(field => (
+              <div key={field.name} className='space-y-1.5'>
+                <Label htmlFor={field.name}>
+                  {field.label}
+                  {field.required && <span className='ml-0.5 text-red-500'>*</span>}
+                </Label>
+                {field.type === 'textarea' ? (
+                  <textarea
+                    id={field.name}
+                    value={(formData[field.name] as string | undefined) ?? ''}
+                    onChange={e =>
+                      setFormData(prev => ({ ...prev, [field.name]: e.target.value }))
+                    }
+                    rows={3}
+                    placeholder={field.placeholder}
+                    className='w-full resize-none rounded-md border border-slate-200 bg-white p-3 text-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20'
+                  />
+                ) : field.type === 'select' ? (
+                  <Select
+                    value={(formData[field.name] as string | undefined) ?? ''}
+                    onValueChange={value =>
+                      setFormData(prev => ({ ...prev, [field.name]: value }))
+                    }
+                  >
+                    <SelectTrigger id={field.name}>
+                      <SelectValue placeholder={field.placeholder ?? 'Sélectionner…'} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {field.options?.map(opt => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <Input
+                    id={field.name}
+                    type={field.type === 'number' ? 'number' : 'text'}
+                    step={field.step}
+                    min={field.min}
+                    value={(formData[field.name] as string | number | undefined) ?? ''}
+                    onChange={e =>
+                      setFormData(prev => ({
+                        ...prev,
+                        [field.name]:
+                          field.type === 'number' ? e.target.value : e.target.value,
+                      }))
+                    }
+                    placeholder={field.placeholder}
+                  />
+                )}
+                {field.help && <p className='text-xs text-slate-500'>{field.help}</p>}
+              </div>
+            ))}
+
+            <DialogFooter className='gap-2 pt-2'>
+              <Button
+                type='button'
+                variant='outline'
+                onClick={closeDialog}
+                disabled={submitting}
+              >
+                Annuler
+              </Button>
+              <Button type='submit' disabled={submitting} className='gap-2'>
+                {submitting ? (
+                  <>
+                    <Loader2 className='h-4 w-4 animate-spin' />
+                    {editingItem ? 'Mise à jour…' : 'Création…'}
+                  </>
+                ) : editingItem ? (
+                  'Mettre à jour'
+                ) : (
+                  'Créer'
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <Dialog
+        open={Boolean(deleteTarget)}
+        onOpenChange={open => !open && !deleting && setDeleteTarget(null)}
+      >
+        <DialogContent className='sm:max-w-[480px]'>
+          <DialogHeader>
+            <div className='flex items-start gap-3'>
+              <div className='flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-red-50 text-red-600 ring-1 ring-red-100'>
+                <AlertTriangle className='h-5 w-5' />
+              </div>
+              <div className='min-w-0 flex-1 space-y-1'>
+                <DialogTitle className='text-lg'>
+                  Supprimer {itemLabelSingular}
+                </DialogTitle>
+                <DialogDescription className='text-sm text-slate-600'>
+                  {deleteTarget ? (
+                    <>
+                      Cette action supprimera définitivement{' '}
+                      <span className='font-semibold text-slate-900'>
+                        {getItemName(deleteTarget)}
+                      </span>
+                      . Elle est <strong>irréversible</strong>.
+                    </>
+                  ) : null}
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          {deleteTarget && getItemCount && (getItemCount(deleteTarget) ?? 0) > 0 && (
+            <div className='flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50/60 p-3 text-sm'>
+              <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0 text-amber-600' />
+              <p className='text-amber-800'>
+                Cet élément est actuellement utilisé par{' '}
+                <strong>{getItemCount(deleteTarget)}</strong> produit
+                {(getItemCount(deleteTarget) ?? 0) > 1 ? 's' : ''}. La suppression
+                pourrait affecter ces hébergements.
+              </p>
+            </div>
+          )}
+
+          <DialogFooter className='gap-2'>
+            <Button
+              variant='outline'
+              onClick={() => setDeleteTarget(null)}
+              disabled={deleting}
+            >
+              Annuler
+            </Button>
+            <Button
+              variant='destructive'
+              onClick={handleDelete}
+              disabled={deleting}
+              className='gap-2'
+            >
+              {deleting ? (
+                <>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Suppression…
+                </>
+              ) : (
+                <>
+                  <Trash2 className='h-4 w-4' />
+                  Supprimer
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}


### PR DESCRIPTION
## Summary

Phase 4 of the admin redesign — modernise all 7 taxonomy/catalog pages under `/admin`.

- Introduce a new generic **`TaxonomyManager`** component in `src/components/admin/ui/TaxonomyManager.tsx` that wraps the existing admin design system (`PageHeader`, `KpiCard`, `FilterBar`, `DataTable`) and drives add/edit/delete flows via a field config + adapter.
- Rewrite 6 pages on top of the manager: `highlights`, `included-services`, `extras`, `meals`, `equipments`, `security`. Together they shed ~1150 net lines while gaining KPI summaries, proper typed DataTable rows, and a shadcn `Dialog`-based delete confirmation (replacing `window.confirm()`).
- Redesign `typeRent` separately (it has an image upload, `isHotelType` toggle, a sub-page route, and a specialised `DeleteTypeModal` that checks for associated products). It reuses the same admin primitives (`PageHeader` + KPI row + `DataTable`) for visual consistency.

## Changes

- **New** `src/components/admin/ui/TaxonomyManager.tsx` — generic CRUD manager with field-driven dialogs, refetch after mutations (to refresh `_count.products`), and a shadcn delete confirmation dialog.
- **Rewritten** `highlights`, `included-services` — simplest REST cases, two-field forms.
- **Rewritten** `extras` — REST case with extra fields (priceEUR, priceMGA, `ExtraPriceType` enum, custom `validate`).
- **Rewritten** `meals`, `security` — service-backed adapters wrapping `findAllMeals/createMeal/updateMeal/deleteMeal` and the security equivalents.
- **Rewritten** `equipments` — service-backed with an additional `icon` field column.
- **Rewritten** `typeRent` — custom redesign using the admin primitives, preserves `DeleteTypeModal` and `ImageUpload`.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] Chrome DevTools visual check on `/admin/highlights` (empty), `/admin/meals` (6 items), `/admin/equipments` (17 items), `/admin/security` (7 items), `/admin/extras` (empty), `/admin/typeRent` (2 items)
- [x] Add dialog opens with proper form fields and icon chip header
- [x] Delete confirmation dialog matches `ConfirmDeleteUserDialog` style
- [ ] Manual create/edit/delete flow on staging
- [ ] `typeRent` specialised `DeleteTypeModal` still triggers the associated-products check